### PR TITLE
Fixes around github and circleci post split

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -27,10 +27,10 @@ executors:
 parameters:
   updated-aperture:
     type: boolean
-    default: true
+    default: false
   updated-aperture-docs:
     type: boolean
-    default: true
+    default: false
   updated-circleci-config:
     type: boolean
     default: false
@@ -389,9 +389,7 @@ workflows:
         - equal: [main, << pipeline.git.branch >>]
         - << pipeline.parameters.updated-aperture-docs >>
     jobs:
-      - publish-aperture-docs:
-          dry-run: true
-
+      - publish-aperture-docs
 
 commands:
   asdf_install:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @aperture-control/aperture-approvers
+/*                                           @FluxNinja/backend
+/.circleci/                                  @FluxNinja/devops
+/.github/                                    @FluxNinja/devops


### PR DESCRIPTION
- Update CODEOWNERS to use FluxNinja/backend for everything
- Enable pushing documentation changes on the main branch
- Make workload filtering work by changing defaults

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1)
<!-- Reviewable:end -->
