### PR TITLE
Fix default CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/*                                           @FluxNinja/backend
+*                                            @FluxNinja/backend
 /.circleci/                                  @FluxNinja/devops
 /.github/                                    @FluxNinja/devops


### PR DESCRIPTION
`/*` matched files directly in the root dir, without subdirs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/16)
<!-- Reviewable:end -->
