### PR TITLE
Fix markdown glitches in generated classifiers documentation

### DIFF
--- a/api/aperture/classification/v1/extractor.proto
+++ b/api/aperture/classification/v1/extractor.proto
@@ -4,14 +4,16 @@ package aperture.classification.v1;
 
 import "protoc-gen-openapiv2/options/annotations.proto";
 
-// Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write regod code.
+// Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write rego code
+//
 // There are multiple variants of extractor, specify exactly one:
 // - JSON Extractor
 // - Address Extractor
 // - JWT Extractor
 message Extractor {
   oneof variant {
-    // Use an attribute with no convertion.
+    // Use an attribute with no convertion
+    //
     // Attribute path is a dot-separated path to attribute.
     //
     // Should be either:
@@ -43,7 +45,7 @@ message Extractor {
   }
 }
 
-// Deserialize a json, and extract one of the fields.
+// Deserialize a json, and extract one of the fields
 //
 // Example:
 // ```yaml
@@ -68,7 +70,8 @@ message JSONExtractor {
   string pointer = 2;
 }
 
-// Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`.
+// Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`
+//
 // IP addresses in attribute context are defined as objects with separate ip and port fields.
 // This is a helper to display an address as a single string.
 //
@@ -92,7 +95,8 @@ message AddressExtractor {
   }]; //@gotags: validate:"required"
 }
 
-// Parse the attribute as JWT and read the payload.
+// Parse the attribute as JWT and read the payload
+//
 // Specify a field to be extracted from payload using "json_pointer".
 //
 // Note: The signature is not verified against the secret (we're assuming there's some
@@ -121,7 +125,8 @@ message JWTExtractor {
   string json_pointer = 2;
 }
 
-// Matches HTTP Path to given path templates.
+// Matches HTTP Path to given path templates
+//
 // HTTP path will be matched against given path templates.
 // If a match occurs, the value associated with the path template will be treated as a result.
 // In case of multiple path templates matching, the most specific one will be chosen.

--- a/api/aperture/classification/v1/ruleset.proto
+++ b/api/aperture/classification/v1/ruleset.proto
@@ -26,7 +26,7 @@ message AllRules {
   map<string, Classifier> all_rules = 1;
 }
 
-// Set of classification rules sharing a common selector.
+// Set of classification rules sharing a common selector
 //
 // Example:
 // ```yaml
@@ -47,7 +47,8 @@ message Classifier {
   map<string, Rule> rules = 2;
 }
 
-// Rule describes a single Flow Classification Rule.
+// Rule describes a single Flow Classification Rule
+//
 // Flow classification rule extracts a value from request metadata.
 // More specifically, from `input`, which has the same spec as [Envoy's External Authorization Attribute Context][attribute-context].
 // See <https://play.openpolicyagent.org/p/gU7vcLkc70> for an example input.
@@ -85,7 +86,8 @@ message Classifier {
 //     hidden: true
 // ```
 message Rule {
-  // Raw rego rules are compiled 1:1 to rego queries.
+  // Raw rego rules are compiled 1:1 to rego queries
+  //
   // High-level extractor-based rules are compiled into a single rego query.
   message Rego {
     // Source code of the rego module.

--- a/api/aperture/common/labelmatcher/v1/labelmatcher.proto
+++ b/api/aperture/common/labelmatcher/v1/labelmatcher.proto
@@ -58,7 +58,8 @@ message K8sLabelMatcherRequirement {
   repeated string values = 3;
 }
 
-// Defines a [map<string, string> → bool] expression to be evaluated on labels.
+// Defines a [map<string, string> → bool] expression to be evaluated on labels
+//
 // MatchExpression has multiple variants, exactly one should be set.
 //
 // Example:
@@ -69,7 +70,8 @@ message K8sLabelMatcherRequirement {
 //     - label_equals: { label = app, value = frobnicator }
 // ```
 message MatchExpression {
-  // List of MatchExpressions that is used for all/any matching.
+  // List of MatchExpressions that is used for all/any matching
+  //
   // eg. {any: {of: [expr1, expr2]}}.
   message List {
     // List of subexpressions of the match expression.

--- a/api/gen/openapiv2/aperture.swagger.yaml
+++ b/api/gen/openapiv2/aperture.swagger.yaml
@@ -191,9 +191,8 @@ definitions:
         items:
           $ref: '#/definitions/v1MatchExpression'
         description: List of subexpressions of the match expression.
-    description: |-
-      List of MatchExpressions that is used for all/any matching.
-      eg. {any: {of: [expr1, expr2]}}.
+    description: 'eg. {any: {of: [expr1, expr2]}}.'
+    title: List of MatchExpressions that is used for all/any matching
   RateLimiterLazySyncConfig:
     type: object
     properties:
@@ -231,9 +230,8 @@ definitions:
           Source code of the rego module.
 
           Note: Must include a "package" declaration.
-    description: |-
-      Raw rego rules are compiled 1:1 to rego queries.
-      High-level extractor-based rules are compiled into a single rego query.
+    description: High-level extractor-based rules are compiled into a single rego query.
+    title: Raw rego rules are compiled 1:1 to rego queries
   SchedulerWorkload:
     type: object
     properties:
@@ -497,7 +495,6 @@ definitions:
         description: Attribute path pointing to some string - eg. "source.address".
         x-go-validate: required
     description: |-
-      Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`.
       IP addresses in attribute context are defined as objects with separate ip and port fields.
       This is a helper to display an address as a single string.
 
@@ -509,6 +506,7 @@ definitions:
       ```yaml
       from: "source.address # or dstination.address"
       ```
+    title: Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`
   v1AllPolicies:
     type: object
     properties:
@@ -617,8 +615,6 @@ definitions:
         $ref: '#/definitions/v1Selector'
         description: Defines where to apply the flow classification rule.
     description: |-
-      Set of classification rules sharing a common selector.
-
       Example:
       ```yaml
       selector:
@@ -630,6 +626,7 @@ definitions:
           extractor:
             from: request.http.headers.user
       ```
+    title: Set of classification rules sharing a common selector
   v1Component:
     type: object
     properties:
@@ -943,7 +940,6 @@ definitions:
       from:
         type: string
         description: |-
-          Use an attribute with no convertion.
           Attribute path is a dot-separated path to attribute.
 
           Should be either:
@@ -959,6 +955,7 @@ definitions:
           from: request.http.headers.user-agent
           ```
           [attribute-context]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto"
+        title: Use an attribute with no convertion
       json:
         $ref: '#/definitions/v1JSONExtractor'
         description: Deserialize a json, and extract one of the fields.
@@ -968,12 +965,12 @@ definitions:
       path_templates:
         $ref: '#/definitions/v1PathTemplateMatcher'
         description: Match HTTP Path to given path templates.
-    title: |-
-      Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write regod code.
+    description: |-
       There are multiple variants of extractor, specify exactly one:
       - JSON Extractor
       - Address Extractor
       - JWT Extractor
+    title: Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write rego code
   v1Extrapolator:
     type: object
     properties:
@@ -1135,13 +1132,12 @@ definitions:
           Note: Uses [json pointer](https://datatracker.ietf.org/doc/html/rfc6901) syntax,
           eg. `/foo/bar`. If the pointer points into an object, it'd be stringified.
     description: |-
-      Deserialize a json, and extract one of the fields.
-
       Example:
       ```yaml
       from: request.http.body
       pointer: /user/name
       ```
+    title: Deserialize a json, and extract one of the fields
   v1JWTExtractor:
     type: object
     properties:
@@ -1157,7 +1153,6 @@ definitions:
           Note: Uses [json pointer](https://datatracker.ietf.org/doc/html/rfc6901) syntax,
           eg. `/foo/bar`. If the pointer points into an object, it'd be stringified.
     description: |-
-      Parse the attribute as JWT and read the payload.
       Specify a field to be extracted from payload using "json_pointer".
 
       Note: The signature is not verified against the secret (we're assuming there's some
@@ -1168,6 +1163,7 @@ definitions:
       from: request.http.bearer
       json_pointer: /user/email
       ```
+    title: Parse the attribute as JWT and read the payload
   v1K8sLabelMatcherRequirement:
     type: object
     properties:
@@ -1294,7 +1290,6 @@ definitions:
         $ref: '#/definitions/v1MatchExpression'
         description: The expression negates the result of subexpression.
     description: |-
-      Defines a [map<string, string> → bool] expression to be evaluated on labels.
       MatchExpression has multiple variants, exactly one should be set.
 
       Example:
@@ -1304,6 +1299,7 @@ definitions:
           - label_exists: foo
           - label_equals: { label = app, value = frobnicator }
       ```
+    title: Defines a [map<string, string> → bool] expression to be evaluated on labels
   v1MatchesMatchExpression:
     type: object
     properties:
@@ -1404,10 +1400,10 @@ definitions:
           /static/*: other
           ```
     description: |-
-      Matches HTTP Path to given path templates.
       HTTP path will be matched against given path templates.
       If a match occurs, the value associated with the path template will be treated as a result.
       In case of multiple path templates matching, the most specific one will be chosen.
+    title: Matches HTTP Path to given path templates
   v1PeerInfo:
     type: object
     properties:
@@ -1555,7 +1551,6 @@ definitions:
         $ref: '#/definitions/RuleRego'
         description: Rego module to extract a value from the rego module.
     description: |-
-      Rule describes a single Flow Classification Rule.
       Flow classification rule extracts a value from request metadata.
       More specifically, from `input`, which has the same spec as [Envoy's External Authorization Attribute Context][attribute-context].
       See <https://play.openpolicyagent.org/p/gU7vcLkc70> for an example input.
@@ -1592,6 +1587,7 @@ definitions:
           propagate: false
           hidden: true
       ```
+    title: Rule describes a single Flow Classification Rule
   v1Scheduler:
     type: object
     properties:

--- a/api/gen/proto/go/aperture/classification/v1/extractor.pb.go
+++ b/api/gen/proto/go/aperture/classification/v1/extractor.pb.go
@@ -21,7 +21,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write regod code.
+// Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write rego code
+//
 // There are multiple variants of extractor, specify exactly one:
 // - JSON Extractor
 // - Address Extractor
@@ -119,7 +120,8 @@ type isExtractor_Variant interface {
 }
 
 type Extractor_From struct {
-	// Use an attribute with no convertion.
+	// Use an attribute with no convertion
+	//
 	// Attribute path is a dot-separated path to attribute.
 	//
 	// Should be either:
@@ -168,7 +170,7 @@ func (*Extractor_Jwt) isExtractor_Variant() {}
 
 func (*Extractor_PathTemplates) isExtractor_Variant() {}
 
-// Deserialize a json, and extract one of the fields.
+// Deserialize a json, and extract one of the fields
 //
 // Example:
 // ```yaml
@@ -235,7 +237,8 @@ func (x *JSONExtractor) GetPointer() string {
 	return ""
 }
 
-// Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`.
+// Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`
+//
 // IP addresses in attribute context are defined as objects with separate ip and port fields.
 // This is a helper to display an address as a single string.
 //
@@ -295,7 +298,8 @@ func (x *AddressExtractor) GetFrom() string {
 	return ""
 }
 
-// Parse the attribute as JWT and read the payload.
+// Parse the attribute as JWT and read the payload
+//
 // Specify a field to be extracted from payload using "json_pointer".
 //
 // Note: The signature is not verified against the secret (we're assuming there's some
@@ -366,7 +370,8 @@ func (x *JWTExtractor) GetJsonPointer() string {
 	return ""
 }
 
-// Matches HTTP Path to given path templates.
+// Matches HTTP Path to given path templates
+//
 // HTTP path will be matched against given path templates.
 // If a match occurs, the value associated with the path template will be treated as a result.
 // In case of multiple path templates matching, the most specific one will be chosen.

--- a/api/gen/proto/go/aperture/classification/v1/ruleset.pb.go
+++ b/api/gen/proto/go/aperture/classification/v1/ruleset.pb.go
@@ -120,7 +120,7 @@ func (x *AllRules) GetAllRules() map[string]*Classifier {
 	return nil
 }
 
-// Set of classification rules sharing a common selector.
+// Set of classification rules sharing a common selector
 //
 // Example:
 // ```yaml
@@ -190,7 +190,8 @@ func (x *Classifier) GetRules() map[string]*Rule {
 	return nil
 }
 
-// Rule describes a single Flow Classification Rule.
+// Rule describes a single Flow Classification Rule
+//
 // Flow classification rule extracts a value from request metadata.
 // More specifically, from `input`, which has the same spec as [Envoy's External Authorization Attribute Context][attribute-context].
 // See <https://play.openpolicyagent.org/p/gU7vcLkc70> for an example input.
@@ -328,7 +329,8 @@ func (*Rule_Extractor) isRule_Source() {}
 
 func (*Rule_Rego_) isRule_Source() {}
 
-// Raw rego rules are compiled 1:1 to rego queries.
+// Raw rego rules are compiled 1:1 to rego queries
+//
 // High-level extractor-based rules are compiled into a single rego query.
 type Rule_Rego struct {
 	state         protoimpl.MessageState

--- a/api/gen/proto/go/aperture/common/labelmatcher/v1/labelmatcher.pb.go
+++ b/api/gen/proto/go/aperture/common/labelmatcher/v1/labelmatcher.pb.go
@@ -171,7 +171,8 @@ func (x *K8SLabelMatcherRequirement) GetValues() []string {
 	return nil
 }
 
-// Defines a [map<string, string> → bool] expression to be evaluated on labels.
+// Defines a [map<string, string> → bool] expression to be evaluated on labels
+//
 // MatchExpression has multiple variants, exactly one should be set.
 //
 // Example:
@@ -442,7 +443,8 @@ func (x *MatchesMatchExpression) GetRegex() string {
 	return ""
 }
 
-// List of MatchExpressions that is used for all/any matching.
+// List of MatchExpressions that is used for all/any matching
+//
 // eg. {any: {of: [expr1, expr2]}}.
 type MatchExpression_List struct {
 	state         protoimpl.MessageState

--- a/docs/gen/classification/swagger.md
+++ b/docs/gen/classification/swagger.md
@@ -10,53 +10,26 @@
 
 ### Object Index
 
-- [MatchExpressionList](#match-expression-list) – List of MatchExpressions that is used for all/any matching.
-  eg. {any: {of: [expr…
-- [RuleRego](#rule-rego) – Raw rego rules are compiled 1:1 to rego queries.
-  High-level extractor-based rule…
-- [v1AddressExtractor](#v1-address-extractor) – Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`.
-  I…
-- [v1Classifier](#v1-classifier) – Set of classification rules sharing a common selector.
-
-Example:
-
-````yaml
-selecto…
-* [v1ControlPoint](#v1-control-point) – Identifies control point within a service that the rule or policy should apply t…
-* [v1EqualsMatchExpression](#v1-equals-match-expression) – Label selector expression of the equal form "label == value".
-* [v1Extractor](#v1-extractor) – Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write regod code.
-There are multiple variants of extractor, specify exactly one:
-- JSON Extractor
-- Address Extractor
-- JWT Extractor
-* [v1JSONExtractor](#v1-json-extractor) – Deserialize a json, and extract one of the fields.
-
-Example:
-```yaml
-from: reque…
-* [v1JWTExtractor](#v1-j-w-t-extractor) – Parse the attribute as JWT and read the payload.
-Specify a field to be extracted…
-* [v1K8sLabelMatcherRequirement](#v1-k8s-label-matcher-requirement) – Label selector requirement which is a selector that contains values, a key, and …
-* [v1LabelMatcher](#v1-label-matcher) – Allows to define rules whether a map of labels should be considered a match or not
-* [v1MatchExpression](#v1-match-expression) – Defines a [map<string, string> → bool] expression to be evaluated on labels.
-…
-* [v1MatchesMatchExpression](#v1-matches-match-expression) – Label selector expression of the matches form "label matches regex".
-* [v1PathTemplateMatcher](#v1-path-template-matcher) – Matches HTTP Path to given path templates.
-HTTP path will be matched against giv…
-* [v1Rule](#v1-rule) – Rule describes a single Flow Classification Rule.
-Flow classification rule extra…
-* [v1Selector](#v1-selector) – Describes where a rule or actuation component should apply to
-
+- [MatchExpressionList](#match-expression-list) – List of MatchExpressions that is used for all/any matching
+- [RuleRego](#rule-rego) – Raw rego rules are compiled 1:1 to rego queries
+- [v1AddressExtractor](#v1-address-extractor) – Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`
+- [v1Classifier](#v1-classifier) – Set of classification rules sharing a common selector
+- [v1ControlPoint](#v1-control-point) – Identifies control point within a service that the rule or policy should apply t…
+- [v1EqualsMatchExpression](#v1-equals-match-expression) – Label selector expression of the equal form "label == value".
+- [v1Extractor](#v1-extractor) – Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write rego code
+- [v1JSONExtractor](#v1-json-extractor) – Deserialize a json, and extract one of the fields
+- [v1JWTExtractor](#v1-j-w-t-extractor) – Parse the attribute as JWT and read the payload
+- [v1K8sLabelMatcherRequirement](#v1-k8s-label-matcher-requirement) – Label selector requirement which is a selector that contains values, a key, and …
+- [v1LabelMatcher](#v1-label-matcher) – Allows to define rules whether a map of labels should be considered a match or not
+- [v1MatchExpression](#v1-match-expression) – Defines a [map<string, string> → bool] expression to be evaluated on labels
+- [v1MatchesMatchExpression](#v1-matches-match-expression) – Label selector expression of the matches form "label matches regex".
+- [v1PathTemplateMatcher](#v1-path-template-matcher) – Matches HTTP Path to given path templates
+- [v1Rule](#v1-rule) – Rule describes a single Flow Classification Rule
+- [v1Selector](#v1-selector) – Describes where a rule or actuation component should apply to
 
 ## Reference
 
-### <span id="classification-rule"></span> *ClassificationRule*
-
-
-
-
-
-
+### <span id="classification-rule"></span> _ClassificationRule_
 
 #### Members
 
@@ -65,8 +38,8 @@ Flow classification rule extra…
 <dt></dt>
 <dd>
 
-
 Type: [V1Classifier](#v1-classifier)
+
 </dd>
 </dl>
 
@@ -74,13 +47,12 @@ Type: [V1Classifier](#v1-classifier)
 
 ### <span id="match-expression-list"></span> MatchExpressionList
 
+List of MatchExpressions that is used for all/any matching
 
-List of MatchExpressions that is used for all/any matching.
 eg. {any: {of: [expr1, expr2]}}.
 
-
-
 #### Properties
+
 <dl>
 <dt>of</dt>
 <dd>
@@ -92,13 +64,12 @@ eg. {any: {of: [expr1, expr2]}}.
 
 ### <span id="rule-rego"></span> RuleRego
 
+Raw rego rules are compiled 1:1 to rego queries
 
-Raw rego rules are compiled 1:1 to rego queries.
 High-level extractor-based rules are compiled into a single rego query.
 
-
-
 #### Properties
+
 <dl>
 <dt>query</dt>
 <dd>
@@ -122,8 +93,8 @@ Note: Must include a "package" declaration.
 
 ### <span id="v1-address-extractor"></span> v1AddressExtractor
 
+Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`
 
-Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`.
 IP addresses in attribute context are defined as objects with separate ip and port fields.
 This is a helper to display an address as a single string.
 
@@ -132,9 +103,10 @@ Note: Use with care, as it might accidentally introduce a high-cardinality flow 
 [ext-authz-address]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#config-core-v3-address
 
 Example:
+
 ```yaml
 from: "source.address # or dstination.address"
-````
+```
 
 #### Properties
 
@@ -149,7 +121,7 @@ from: "source.address # or dstination.address"
 
 ### <span id="v1-classifier"></span> v1Classifier
 
-Set of classification rules sharing a common selector.
+Set of classification rules sharing a common selector
 
 Example:
 
@@ -240,7 +212,8 @@ Label selector expression of the equal form "label == value".
 
 ### <span id="v1-extractor"></span> v1Extractor
 
-Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write regod code.
+Defines a high-level way to specify how to extract a flow label given http request metadata, without a need to write rego code
+
 There are multiple variants of extractor, specify exactly one:
 
 - JSON Extractor
@@ -261,7 +234,8 @@ There are multiple variants of extractor, specify exactly one:
 <dt>from</dt>
 <dd>
 
-(string) Use an attribute with no convertion.
+(string) Use an attribute with no convertion
+
 Attribute path is a dot-separated path to attribute.
 
 Should be either:
@@ -310,7 +284,7 @@ from: request.http.headers.user-agent
 
 ### <span id="v1-json-extractor"></span> v1JSONExtractor
 
-Deserialize a json, and extract one of the fields.
+Deserialize a json, and extract one of the fields
 
 Example:
 
@@ -343,7 +317,8 @@ eg. `/foo/bar`. If the pointer points into an object, it'd be stringified.
 
 ### <span id="v1-j-w-t-extractor"></span> v1JWTExtractor
 
-Parse the attribute as JWT and read the payload.
+Parse the attribute as JWT and read the payload
+
 Specify a field to be extracted from payload using "json_pointer".
 
 Note: The signature is not verified against the secret (we're assuming there's some
@@ -459,7 +434,8 @@ Note: The requirements are ANDed.
 
 ### <span id="v1-match-expression"></span> v1MatchExpression
 
-Defines a [map<string, string> → bool] expression to be evaluated on labels.
+Defines a [map<string, string> → bool] expression to be evaluated on labels
+
 MatchExpression has multiple variants, exactly one should be set.
 
 Example:
@@ -548,7 +524,8 @@ It uses [golang's regular expression syntax](https://github.com/google/re2/wiki/
 
 ### <span id="v1-path-template-matcher"></span> v1PathTemplateMatcher
 
-Matches HTTP Path to given path templates.
+Matches HTTP Path to given path templates
+
 HTTP path will be matched against given path templates.
 If a match occurs, the value associated with the path template will be treated as a result.
 In case of multiple path templates matching, the most specific one will be chosen.
@@ -587,7 +564,8 @@ Example:
 
 ### <span id="v1-rule"></span> v1Rule
 
-Rule describes a single Flow Classification Rule.
+Rule describes a single Flow Classification Rule
+
 Flow classification rule extracts a value from request metadata.
 More specifically, from `input`, which has the same spec as [Envoy's External Authorization Attribute Context][attribute-context].
 See <https://play.openpolicyagent.org/p/gU7vcLkc70> for an example input.

--- a/docs/gen/policies/swagger.md
+++ b/docs/gen/policies/swagger.md
@@ -10,8 +10,7 @@
 
 ### Object Index
 
-- [MatchExpressionList](#match-expression-list) – List of MatchExpressions that is used for all/any matching.
-  eg. {any: {of: [expr…
+- [MatchExpressionList](#match-expression-list) – List of MatchExpressions that is used for all/any matching
 - [RateLimiterLazySyncConfig](#rate-limiter-lazy-sync-config)
 - [RateLimiterOverrideConfig](#rate-limiter-override-config)
 - [SchedulerWorkload](#scheduler-workload) – Workload defines a class of requests that preferably have similar properties suc…
@@ -47,8 +46,7 @@ Example of…
 - [v1LabelMatcher](#v1-label-matcher) – Allows to define rules whether a map of labels should be considered a match or not
 - [v1LoadShedActuator](#v1-load-shed-actuator) – Takes the load shed factor input signal and publishes it to the schedulers in th…
 - [v1LoadShedActuatorIns](#v1-load-shed-actuator-ins) – Input for the Load Shed Actuator component.
-- [v1MatchExpression](#v1-match-expression) – Defines a [map<string, string> → bool] expression to be evaluated on labels.
-  …
+- [v1MatchExpression](#v1-match-expression) – Defines a [map<string, string> → bool] expression to be evaluated on labels
 - [v1MatchesMatchExpression](#v1-matches-match-expression) – Label selector expression of the matches form "label matches regex".
 - [v1Max](#v1-max) – Takes a list of input signals and emits the signal with the maximum value.
   Max: …
@@ -93,7 +91,8 @@ Type: [V1Policy](#v1-policy)
 
 ### <span id="match-expression-list"></span> MatchExpressionList
 
-List of MatchExpressions that is used for all/any matching.
+List of MatchExpressions that is used for all/any matching
+
 eg. {any: {of: [expr1, expr2]}}.
 
 #### Properties
@@ -1212,7 +1211,8 @@ Input for the Load Shed Actuator component.
 
 ### <span id="v1-match-expression"></span> v1MatchExpression
 
-Defines a [map<string, string> → bool] expression to be evaluated on labels.
+Defines a [map<string, string> → bool] expression to be evaluated on labels
+
 MatchExpression has multiple variants, exactly one should be set.
 
 Example:


### PR DESCRIPTION
Glitches were caused by table-of-contents logic which in absence of
title was trying to take x first characters of description, resulting in
eg. yaml snippets cut in half.

This commits avoid glitches by **not** using dot on first sentence, so
that go-swagger knows that the first sentence is a title.

Resolves: https://github.com/fluxninja/aperture/issues/202

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/204)
<!-- Reviewable:end -->
