### PR TITLE
Soft pod anti affinity for demo app

### DIFF
--- a/manifests/charts/demo-app/templates/deployment.yaml
+++ b/manifests/charts/demo-app/templates/deployment.yaml
@@ -29,11 +29,13 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app.kubernetes.io/instance: {{ .Release.Name }}
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: {{ .Release.Name }}
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: simplesrv
           securityContext:


### PR DESCRIPTION
# Why
* Demo app comes up successfully on one node cluster after this change.

# What
* Pod anti affinity constraint for demo app is now preferred instead of required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/286)
<!-- Reviewable:end -->
