### PR TITLE
Fix themes in GH mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ facilitated by agents and a controller.
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./docs/content/assets/img/oaadark.png">
-    <img alt="Observe. Analyze. Actuate." src="./docs/content/assets/img/oaalight.png">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fluxninja/aperture/main/docs/content/assets/img/oaadark.png" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/fluxninja/aperture/main/docs/content/assets/img/oaalight.png" />
+    <img alt="Observe. Analyze. Actuate." src="https://raw.githubusercontent.com/fluxninja/aperture/main/docs/content/assets/img/oaalight.png">
   </picture>
 </p>
 


### PR DESCRIPTION
For some reason GH mobile app does not support relative paths to images in dual theme mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/340)
<!-- Reviewable:end -->
