### PR TITLE
Fix broken generated controller documentation

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -491,6 +491,17 @@ workflows:
     jobs:
       - publish-aperture-docs
 
+  build-aperture-docs:
+    when:
+      and:
+        - not:
+            equal: [main, << pipeline.git.branch >>]
+        - << pipeline.parameters.updated-aperture-docs >>
+    jobs:
+      - publish-aperture-docs:
+          name: build-aperture-docs
+          dry-run: true
+
   push-deployment-changes:
     when:
       and:

--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -356,6 +356,10 @@ jobs:
         type: boolean
         default: false
         description: Whether to push changes to the deployment repository
+      task-name:
+        type: string
+        default: Publish documentation updates
+        description: The name of the actual task
     steps:
       - checkout
       - add_ssh_keys:
@@ -371,7 +375,7 @@ jobs:
           name: Install yarn
           command: npm install --global yarn
       - run:
-          name: Publish documentation updates
+          name: << parameters.task-name >>
           command: |
             export LOGURU_LEVEL=TRACE
             export GIT_SSH_COMMAND="fn circleci ssh -o IdentitiesOnly=yes"
@@ -500,6 +504,7 @@ workflows:
     jobs:
       - publish-aperture-docs:
           name: build-aperture-docs
+          task-name: Build aperture documentation and verify changes
           dry-run: true
 
   push-deployment-changes:

--- a/docs/gen/config/aperture-agent/swagger.md
+++ b/docs/gen/config/aperture-agent/swagger.md
@@ -87,6 +87,7 @@ Key: `agent_info`
 Type: [AgentInfoConfig](#agent-info-config)
 
 </dd>
+
 </dl>
 
 ### <span id="client"></span> _Client_
@@ -106,6 +107,7 @@ Env-Var Prefix: `APERTURE_AGENT_CLIENT_PROXY_`
 Type: [ProxyConfig](#proxy-config)
 
 </dd>
+
 </dl>
 
 ### <span id="dist-cache"></span> _DistCache_
@@ -125,6 +127,7 @@ Env-Var Prefix: `APERTURE_AGENT_DIST_CACHE_`
 Type: [DistCacheConfig](#dist-cache-config)
 
 </dd>
+
 </dl>
 
 ### <span id="etcd"></span> _Etcd_
@@ -144,6 +147,7 @@ Env-Var Prefix: `APERTURE_AGENT_ETCD_`
 Type: [EtcdConfig](#etcd-config)
 
 </dd>
+
 </dl>
 
 ### <span id="flux-ninja-plugin"></span> _FluxNinjaPlugin_
@@ -163,6 +167,7 @@ Env-Var Prefix: `APERTURE_AGENT_FLUXNINJA_PLUGIN_`
 Type: [FluxNinjaPluginConfig](#flux-ninja-plugin-config)
 
 </dd>
+
 </dl>
 
 ### <span id="kubernetes-client"></span> _KubernetesClient_
@@ -182,6 +187,7 @@ Env-Var Prefix: `APERTURE_AGENT_KUBERNETES_CLIENT_HTTP_CLIENT_`
 Type: [HTTPClientConfig](#http-client-config)
 
 </dd>
+
 </dl>
 
 ### <span id="liveness"></span> _Liveness_
@@ -209,6 +215,7 @@ Env-Var Prefix: `APERTURE_AGENT_LIVENESS_SERVICE_`
 Type: [JobConfig](#job-config)
 
 </dd>
+
 </dl>
 
 ### <span id="log"></span> _Log_
@@ -228,6 +235,7 @@ Env-Var Prefix: `APERTURE_AGENT_LOG_`
 Type: [LogConfig](#log-config)
 
 </dd>
+
 </dl>
 
 ### <span id="metrics"></span> _Metrics_
@@ -247,6 +255,7 @@ Env-Var Prefix: `APERTURE_AGENT_METRICS_`
 Type: [MetricsConfig](#metrics-config)
 
 </dd>
+
 </dl>
 
 ### <span id="otel"></span> _Otel_
@@ -266,6 +275,7 @@ Env-Var Prefix: `APERTURE_AGENT_OTEL_PROXY_`
 Type: [OtelConfig](#otel-config)
 
 </dd>
+
 </dl>
 
 ### <span id="peer-discovery"></span> _PeerDiscovery_
@@ -282,6 +292,7 @@ Key: `peer_discovery`
 Type: [PeerDiscoveryConfig](#peer-discovery-config)
 
 </dd>
+
 </dl>
 
 ### <span id="plugins"></span> _Plugins_
@@ -301,6 +312,7 @@ Env-Var Prefix: `APERTURE_AGENT_PLUGINS_`
 Type: [PluginsConfig](#plugins-config)
 
 </dd>
+
 </dl>
 
 ### <span id="profilers"></span> _Profilers_
@@ -320,6 +332,7 @@ Env-Var Prefix: `APERTURE_AGENT_PROFILERS_`
 Type: [ProfilersConfig](#profilers-config)
 
 </dd>
+
 </dl>
 
 ### <span id="prometheus"></span> _Prometheus_
@@ -347,6 +360,7 @@ Env-Var Prefix: `APERTURE_AGENT_PROMETHEUS_HTTP_CLIENT_`
 Type: [HTTPClientConfig](#http-client-config)
 
 </dd>
+
 </dl>
 
 ### <span id="readiness"></span> _Readiness_
@@ -374,6 +388,7 @@ Env-Var Prefix: `APERTURE_AGENT_READINESS_SERVICE_`
 Type: [JobConfig](#job-config)
 
 </dd>
+
 </dl>
 
 ### <span id="sentry-plugin"></span> _SentryPlugin_
@@ -393,6 +408,7 @@ Env-Var Prefix: `APERTURE_AGENT_SENTRY_PLUGIN_SENTRY_`
 Type: [SentryConfig](#sentry-config)
 
 </dd>
+
 </dl>
 
 ### <span id="server"></span> _Server_
@@ -444,6 +460,7 @@ Env-Var Prefix: `APERTURE_AGENT_SERVER_TLS_`
 Type: [ServerTLSConfig](#server-tls-config)
 
 </dd>
+
 </dl>
 
 ### <span id="service-discovery"></span> _ServiceDiscovery_
@@ -471,6 +488,7 @@ Env-Var Prefix: `APERTURE_AGENT_SERVICE_DISCOVERY_STATIC_`
 Type: [StaticDiscoveryConfig](#static-discovery-config)
 
 </dd>
+
 </dl>
 
 ### <span id="watchdog"></span> _Watchdog_
@@ -490,6 +508,7 @@ Env-Var Prefix: `APERTURE_AGENT_WATCHDOG_MEMORY_`
 Type: [WatchdogConfig](#watchdog-config)
 
 </dd>
+
 </dl>
 
 ## Objects
@@ -507,8 +526,6 @@ AdaptivePolicy creates a policy that forces GC when the usage surpasses the conf
 (bool, default: `false`) Flag to enable the policy
 
 </dd>
-</dl>
-<dl>
 <dt>factor</dt>
 <dd>
 
@@ -545,24 +562,18 @@ BackoffConfig holds configuration for GRPC Client Backoff.
 (string, `gte=0`, default: `1s`) Base Delay
 
 </dd>
-</dl>
-<dl>
 <dt>jitter</dt>
 <dd>
 
 (float64, `gte=0`, default: `0.2`) Jitter
 
 </dd>
-</dl>
-<dl>
 <dt>max_delay</dt>
 <dd>
 
 (string, `gte=0`, default: `120s`) Max Delay
 
 </dd>
-</dl>
-<dl>
 <dt>multiplier</dt>
 <dd>
 
@@ -584,8 +595,6 @@ BatchConfig defines configuration for OTEL batch processor.
 (uint32, `gt=0`, default: `10000`) SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 
 </dd>
-</dl>
-<dl>
 <dt>timeout</dt>
 <dd>
 
@@ -607,8 +616,6 @@ ClientConfig is the client configuration.
 ([GRPCClientConfig](#g-rpc-client-config))
 
 </dd>
-</dl>
-<dl>
 <dt>http</dt>
 <dd>
 
@@ -630,32 +637,24 @@ ClientTLSConfig is the config for client TLS.
 (string, `omitempty,file`)
 
 </dd>
-</dl>
-<dl>
 <dt>cert_file</dt>
 <dd>
 
 (string, `omitempty,file`)
 
 </dd>
-</dl>
-<dl>
 <dt>insecure_skip_verify</dt>
 <dd>
 
 (bool)
 
 </dd>
-</dl>
-<dl>
 <dt>key_file</dt>
 <dd>
 
 (string, `omitempty,file`)
 
 </dd>
-</dl>
-<dl>
 <dt>key_log_file</dt>
 <dd>
 
@@ -677,24 +676,18 @@ DistCacheConfig configures distributed cache that holds per-label counters in di
 (string, `hostname_port`, default: `:3320`) BindAddr denotes the address that DistCache will bind to for communication with other peer nodes.
 
 </dd>
-</dl>
-<dl>
 <dt>memberlist_advertise_addr</dt>
 <dd>
 
 (string, `omitempty,hostname_port`) Address of memberlist to advertise to other cluster members. Used for nat traversal if provided.
 
 </dd>
-</dl>
-<dl>
 <dt>memberlist_bind_addr</dt>
 <dd>
 
 (string, `hostname_port`, default: `:3322`) Address to bind mememberlist server to.
 
 </dd>
-</dl>
-<dl>
 <dt>replica_count</dt>
 <dd>
 
@@ -716,16 +709,12 @@ EntityConfig describes a single entity.
 (string, `required,ip`) IP address of the entity.
 
 </dd>
-</dl>
-<dl>
 <dt>name</dt>
 <dd>
 
 (string) Name of the entity.
 
 </dd>
-</dl>
-<dl>
 <dt>uid</dt>
 <dd>
 
@@ -747,8 +736,6 @@ EtcdConfig holds configuration for etcd client.
 ([]string, `gt=0,dive,hostname_port|url|fqdn`) List of Etcd server endpoints
 
 </dd>
-</dl>
-<dl>
 <dt>lease_ttl</dt>
 <dd>
 
@@ -770,24 +757,18 @@ FluxNinjaPluginConfig is the configuration for FluxNinja cloud integration plugi
 (string) API Key for this agent.
 
 </dd>
-</dl>
-<dl>
 <dt>fluxninja_endpoint</dt>
 <dd>
 
 (string, `omitempty,hostname_port|url|fqdn`) Address to grpc or http(s) server listening in agent service. To use http protocol, the address must start with http(s)://.
 
 </dd>
-</dl>
-<dl>
 <dt>heartbeat_interval</dt>
 <dd>
 
 (string, `gte=0s`, default: `5s`) Interval between each heartbeat.
 
 </dd>
-</dl>
-<dl>
 <dt>client</dt>
 <dd>
 
@@ -809,32 +790,24 @@ GRPCClientConfig holds configuration for GRPC Client.
 (bool, default: `false`) Disable ClientTLS
 
 </dd>
-</dl>
-<dl>
 <dt>min_connection_timeout</dt>
 <dd>
 
 (string, `gte=0`, default: `20s`) Minimum connection timeout
 
 </dd>
-</dl>
-<dl>
 <dt>use_proxy</dt>
 <dd>
 
 (bool, default: `false`) Use HTTP CONNECT Proxy
 
 </dd>
-</dl>
-<dl>
 <dt>backoff</dt>
 <dd>
 
 ([BackoffConfig](#backoff-config))
 
 </dd>
-</dl>
-<dl>
 <dt>tls</dt>
 <dd>
 
@@ -871,8 +844,6 @@ GRPCServerConfig holds configuration for GRPC Server.
 (string, `gte=0s`, default: `120s`) Connection timeout
 
 </dd>
-</dl>
-<dl>
 <dt>enable_reflection</dt>
 <dd>
 
@@ -894,144 +865,108 @@ HTTPClientConfig holds configuration for HTTP Client.
 (bool, default: `false`) Disable Compression
 
 </dd>
-</dl>
-<dl>
 <dt>disable_keep_alives</dt>
 <dd>
 
 (bool, default: `false`) Disable HTTP Keep Alives
 
 </dd>
-</dl>
-<dl>
 <dt>expect_continue_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `1s`) Expect Continue Timeout. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>idle_connection_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `90s`) Idle Connection Timeout. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>key_log_file</dt>
 <dd>
 
 (string, `omitempty,file`) SSL key log file (useful for debugging with wireshark)
 
 </dd>
-</dl>
-<dl>
 <dt>max_conns_per_host</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Max Connections Per Host. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>max_idle_connections</dt>
 <dd>
 
 (int64, `gte=0`, default: `100`) Max Idle Connections. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>max_idle_connections_per_host</dt>
 <dd>
 
 (int64, `gte=0`, default: `5`) Max Idle Connections per host. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>max_response_header_bytes</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Max Response Header Bytes. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>network_keep_alive</dt>
 <dd>
 
 (string, `gte=0s`, default: `30s`) Network level keep-alive duration
 
 </dd>
-</dl>
-<dl>
 <dt>network_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `30s`) Timeout for making network connection
 
 </dd>
-</dl>
-<dl>
 <dt>read_buffer_size</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Read Buffer Size. 0 = 4KB
 
 </dd>
-</dl>
-<dl>
 <dt>response_header_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `0s`) Response Header Timeout. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>tls_handshake_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `10s`) TLS Handshake Timeout. 0 = no timeout
 
 </dd>
-</dl>
-<dl>
 <dt>timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `60s`) HTTP client timeout - Timeouts includes connection time, redirects, reading the response etc. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>use_proxy</dt>
 <dd>
 
 (bool, default: `false`) Use Proxy
 
 </dd>
-</dl>
-<dl>
 <dt>write_buffer_size</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Write Buffer Size. 0 = 4KB.
 
 </dd>
-</dl>
-<dl>
 <dt>proxy_connect_header</dt>
 <dd>
 
 ([Header](#header))
 
 </dd>
-</dl>
-<dl>
 <dt>tls</dt>
 <dd>
 
@@ -1053,64 +988,48 @@ HTTPServerConfig holds configuration for HTTP Server.
 (bool, default: `false`) Disable HTTP Keep Alives
 
 </dd>
-</dl>
-<dl>
 <dt>idle_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `30s`) Idle timeout
 
 </dd>
-</dl>
-<dl>
 <dt>latency_bucket_count</dt>
 <dd>
 
 (int64, `gte=0`, default: `100`) The number of buckets in latency histogram
 
 </dd>
-</dl>
-<dl>
 <dt>latency_bucket_start_ms</dt>
 <dd>
 
 (float64, `gte=0`, default: `20`) The lowest bucket in latency histogram
 
 </dd>
-</dl>
-<dl>
 <dt>latency_bucket_width_ms</dt>
 <dd>
 
 (float64, `gte=0`, default: `20`) The bucket width in latency histogram
 
 </dd>
-</dl>
-<dl>
 <dt>max_header_bytes</dt>
 <dd>
 
 (int64, `gte=0`, default: `1048576`) Max header size in bytes
 
 </dd>
-</dl>
-<dl>
 <dt>read_header_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `10s`) Read header timeout
 
 </dd>
-</dl>
-<dl>
 <dt>read_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `10s`) Read timeout
 
 </dd>
-</dl>
-<dl>
 <dt>write_timeout</dt>
 <dd>
 
@@ -1141,24 +1060,18 @@ HeapConfig holds configuration for heap Watchdog.
 (uint64, `gt=0`, default: `268435456`) Maximum memory (in bytes) sets limit of process usage. Default = 256MB.
 
 </dd>
-</dl>
-<dl>
 <dt>min_gogc</dt>
 <dd>
 
 (int64, `gt=0,lte=100`, default: `25`) Minimum GoGC sets the minimum garbage collection target percentage for heap driven Watchdogs. This setting helps avoid overscheduling.
 
 </dd>
-</dl>
-<dl>
 <dt>adaptive_policy</dt>
 <dd>
 
 ([AdaptivePolicy](#adaptive-policy))
 
 </dd>
-</dl>
-<dl>
 <dt>watermarks_policy</dt>
 <dd>
 
@@ -1180,24 +1093,18 @@ JobConfig is config for Job
 (string, default: `10s`) Time period between job executions. Zero or negative value means that the job will never execute periodically.
 
 </dd>
-</dl>
-<dl>
 <dt>execution_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `5s`) Execution timeout
 
 </dd>
-</dl>
-<dl>
 <dt>initial_delay</dt>
 <dd>
 
 (string, default: `0s`) Initial delay to start the job. Zero value will schedule the job immediately. Negative value will wait for next scheduled interval.
 
 </dd>
-</dl>
-<dl>
 <dt>initially_healthy</dt>
 <dd>
 
@@ -1234,16 +1141,12 @@ KubernetesDiscoveryConfig for Kubernetes service discovery.
 (bool, default: `true`)
 
 </dd>
-</dl>
-<dl>
 <dt>node_name</dt>
 <dd>
 
 (string) NodeName is the name of the k8s node the agent should be monitoring
 
 </dd>
-</dl>
-<dl>
 <dt>pod_name</dt>
 <dd>
 
@@ -1265,16 +1168,12 @@ ListenerConfig holds configuration for socket listeners.
 (string, `hostname_port`, default: `:8080`) Address to bind to in the form of [host%zone]:port
 
 </dd>
-</dl>
-<dl>
 <dt>keep_alive</dt>
 <dd>
 
 (string, `gte=0s`, default: `180s`) Keep-alive period - 0 = enabled if supported by protocol or OS. If negative then keep-alives are disabled.
 
 </dd>
-</dl>
-<dl>
 <dt>network</dt>
 <dd>
 
@@ -1296,64 +1195,48 @@ LogConfig holds configuration for a logger and log writers.
 (bool, default: `false`) Compress
 
 </dd>
-</dl>
-<dl>
 <dt>file</dt>
 <dd>
 
 (string, default: `stderr`) Output file for logs. Keywords allowed - ["stderr", "default"]. "default" maps to `/var/log/fluxninja/<service>.log`
 
 </dd>
-</dl>
-<dl>
 <dt>level</dt>
 <dd>
 
 (string, `oneof=debug DEBUG info INFO warn WARN error ERROR fatal FATAL panic PANIC trace TRACE disabled DISABLED`, default: `info`) Log level
 
 </dd>
-</dl>
-<dl>
 <dt>max_age</dt>
 <dd>
 
 (int64, `gte=0`, default: `7`) Max age in days for log files
 
 </dd>
-</dl>
-<dl>
 <dt>max_backups</dt>
 <dd>
 
 (int64, `gte=0`, default: `3`) Max log file backups
 
 </dd>
-</dl>
-<dl>
 <dt>max_size</dt>
 <dd>
 
 (int64, `gte=0`, default: `50`) Log file max size in MB
 
 </dd>
-</dl>
-<dl>
 <dt>non_blocking</dt>
 <dd>
 
 (bool, default: `true`) Use non-blocking log writer (can lose logs at high throughput)
 
 </dd>
-</dl>
-<dl>
 <dt>pretty_console</dt>
 <dd>
 
 (bool, default: `false`) Additional log writer: pretty console (stdout) logging (not recommended for prod environments)
 
 </dd>
-</dl>
-<dl>
 <dt>writers</dt>
 <dd>
 
@@ -1375,32 +1258,24 @@ LogWriterConfig holds configuration for a log writer.
 (bool, default: `false`) Compress
 
 </dd>
-</dl>
-<dl>
 <dt>file</dt>
 <dd>
 
 (string, default: `stderr`) Output file for logs. Keywords allowed - ["stderr", "default"]. "default" maps to `/var/log/fluxninja/<service>.log`
 
 </dd>
-</dl>
-<dl>
 <dt>max_age</dt>
 <dd>
 
 (int64, `gte=0`, default: `7`) Max age in days for log files
 
 </dd>
-</dl>
-<dl>
 <dt>max_backups</dt>
 <dd>
 
 (int64, `gte=0`, default: `3`) Max log file backups
 
 </dd>
-</dl>
-<dl>
 <dt>max_size</dt>
 <dd>
 
@@ -1422,16 +1297,12 @@ MetricsConfig holds configuration for service metrics.
 (bool, default: `false`) EnableGoCollector controls whether the go collector is registered on startup. See <https://godoc.org/github.com/prometheus/client_golang/prometheus#NewGoCollector>
 
 </dd>
-</dl>
-<dl>
 <dt>enable_process_collector</dt>
 <dd>
 
 (bool, default: `false`) EnableProcessCollector controls whether the process collector is registered on startup. See <https://godoc.org/github.com/prometheus/client_golang/prometheus#NewProcessCollector>
 
 </dd>
-</dl>
-<dl>
 <dt>pedantic</dt>
 <dd>
 
@@ -1453,24 +1324,18 @@ OtelConfig is the configuration for the OTEL collector.
 (string, `hostname_port`, default: `:4317`) GRPC listener addr for OTEL Collector.
 
 </dd>
-</dl>
-<dl>
 <dt>http_addr</dt>
 <dd>
 
 (string, `hostname_port`, default: `:4318`) HTTP listener addr for OTEL Collector.
 
 </dd>
-</dl>
-<dl>
 <dt>batch_postrollup</dt>
 <dd>
 
 ([BatchConfig](#batch-config))
 
 </dd>
-</dl>
-<dl>
 <dt>batch_prerollup</dt>
 <dd>
 
@@ -1507,24 +1372,18 @@ PluginsConfig holds configuration for plugins.
 (bool, default: `false`) Disables all plugins
 
 </dd>
-</dl>
-<dl>
 <dt>disabled_plugins</dt>
 <dd>
 
 ([]string) Specific plugins to disable
 
 </dd>
-</dl>
-<dl>
 <dt>disabled_symbols</dt>
 <dd>
 
 ([]string) Specific plugin types to disable
 
 </dd>
-</dl>
-<dl>
 <dt>plugins_path</dt>
 <dd>
 
@@ -1546,16 +1405,12 @@ ProfilersConfig holds configuration for profilers.
 (bool, default: `false`) Flag to enable cpu profiling on process start and save it to a file. HTTP interface will not work if this is enabled as CPU profile will always be running.
 
 </dd>
-</dl>
-<dl>
 <dt>profiles_path</dt>
 <dd>
 
 (string) Path to save performance profiles. This can be set via command line arguments as well. E.g. default path for aperture-agent is /var/log/aperture/aperture-agent/profiles.
 
 </dd>
-</dl>
-<dl>
 <dt>register_http_routes</dt>
 <dd>
 
@@ -1594,16 +1449,12 @@ This configuration has preference over environment variables HTTP_PROXY, HTTPS_P
 (string, `omitempty,url|hostname_port`)
 
 </dd>
-</dl>
-<dl>
 <dt>https</dt>
 <dd>
 
 (string, `omitempty,url|hostname_port`)
 
 </dd>
-</dl>
-<dl>
 <dt>no_proxy</dt>
 <dd>
 
@@ -1625,24 +1476,18 @@ SentryConfig holds configuration for Sentry.
 (bool, default: `true`) Configure to generate and attach stacktraces to capturing message calls
 
 </dd>
-</dl>
-<dl>
 <dt>debug</dt>
 <dd>
 
 (bool, default: `true`) Debug enables printing of Sentry SDK debug messages
 
 </dd>
-</dl>
-<dl>
 <dt>disabled</dt>
 <dd>
 
 (bool, default: `false`) Sentry crash report disabled
 
 </dd>
-</dl>
-<dl>
 <dt>dsn</dt>
 <dd>
 
@@ -1651,24 +1496,18 @@ You can set test project's dsn to send log events.
 oss-aperture project dsn is set as default.
 
 </dd>
-</dl>
-<dl>
 <dt>environment</dt>
 <dd>
 
 (string, default: `production`) Environment
 
 </dd>
-</dl>
-<dl>
 <dt>sample_rate</dt>
 <dd>
 
 (float64, default: `1.0`) Sample rate for event submission i.e. 0.0 to 1.0
 
 </dd>
-</dl>
-<dl>
 <dt>traces_sample_rate</dt>
 <dd>
 
@@ -1690,40 +1529,30 @@ ServerTLSConfig holds configuration for setting up server TLS support.
 (string, `omitempty,fqdn`) Allowed CN
 
 </dd>
-</dl>
-<dl>
 <dt>certs_path</dt>
 <dd>
 
 (string) Path to credentials. This can be set via command line arguments as well.
 
 </dd>
-</dl>
-<dl>
 <dt>client_ca</dt>
 <dd>
 
 (string, `omitempty`) Client CA file
 
 </dd>
-</dl>
-<dl>
 <dt>enabled</dt>
 <dd>
 
 (bool, default: `false`) Enabled TLS
 
 </dd>
-</dl>
-<dl>
 <dt>server_cert</dt>
 <dd>
 
 (string, default: `ca.crt`) Server Cert file
 
 </dd>
-</dl>
-<dl>
 <dt>server_key</dt>
 <dd>
 
@@ -1745,8 +1574,6 @@ ServiceConfig describes a service and its entities.
 ([[]EntityConfig](#entity-config)) Entities of the service.
 
 </dd>
-</dl>
-<dl>
 <dt>name</dt>
 <dd>
 
@@ -1783,24 +1610,18 @@ WatchdogConfig holds configuration for Watchdog Policy. For each policy, either 
 ([WatchdogPolicyType](#watchdog-policy-type))
 
 </dd>
-</dl>
-<dl>
 <dt>heap</dt>
 <dd>
 
 ([HeapConfig](#heap-config))
 
 </dd>
-</dl>
-<dl>
 <dt>job</dt>
 <dd>
 
 ([JobConfig](#job-config))
 
 </dd>
-</dl>
-<dl>
 <dt>system</dt>
 <dd>
 
@@ -1822,8 +1643,6 @@ WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algor
 ([AdaptivePolicy](#adaptive-policy))
 
 </dd>
-</dl>
-<dl>
 <dt>watermarks_policy</dt>
 <dd>
 
@@ -1845,8 +1664,6 @@ WatermarksPolicy creates a Watchdog policy that schedules GC at concrete waterma
 (bool, default: `false`) Flag to enable the policy
 
 </dd>
-</dl>
-<dl>
 <dt>watermarks</dt>
 <dd>
 

--- a/docs/gen/config/aperture-controller/swagger.md
+++ b/docs/gen/config/aperture-controller/swagger.md
@@ -78,6 +78,7 @@ Key: `agent_info`
 Type: [AgentInfoConfig](#agent-info-config)
 
 </dd>
+
 </dl>
 
 ### <span id="client"></span> _Client_
@@ -97,6 +98,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_CLIENT_PROXY_`
 Type: [ProxyConfig](#proxy-config)
 
 </dd>
+
 </dl>
 
 ### <span id="etcd"></span> _Etcd_
@@ -116,6 +118,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_ETCD_`
 Type: [EtcdConfig](#etcd-config)
 
 </dd>
+
 </dl>
 
 ### <span id="flux-ninja-plugin"></span> _FluxNinjaPlugin_
@@ -135,6 +138,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_FLUXNINJA_PLUGIN_`
 Type: [FluxNinjaPluginConfig](#flux-ninja-plugin-config)
 
 </dd>
+
 </dl>
 
 ### <span id="liveness"></span> _Liveness_
@@ -162,6 +166,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_LIVENESS_SERVICE_`
 Type: [JobConfig](#job-config)
 
 </dd>
+
 </dl>
 
 ### <span id="log"></span> _Log_
@@ -181,6 +186,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_LOG_`
 Type: [LogConfig](#log-config)
 
 </dd>
+
 </dl>
 
 ### <span id="metrics"></span> _Metrics_
@@ -200,6 +206,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_METRICS_`
 Type: [MetricsConfig](#metrics-config)
 
 </dd>
+
 </dl>
 
 ### <span id="otel"></span> _Otel_
@@ -219,6 +226,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_OTEL_PROXY_`
 Type: [OtelConfig](#otel-config)
 
 </dd>
+
 </dl>
 
 ### <span id="plugins"></span> _Plugins_
@@ -238,6 +246,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_PLUGINS_`
 Type: [PluginsConfig](#plugins-config)
 
 </dd>
+
 </dl>
 
 ### <span id="policies-config"></span> _PoliciesConfig_
@@ -255,10 +264,6 @@ Env-Var Prefix: `APERTURE_CONTROLLER_POLICIES_`
 (string, default: `/etc/aperture/aperture-controller/policies`, env-var: `APERTURE_CONTROLLER_POLICIES_POLICIES_PATH`) Directory containing policies rules
 
 </dd>
-</dl>
-
-<dl>
-</dd>
 
 <dt>promql_jobs_scheduler</dt>
 <dd>
@@ -267,6 +272,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_POLICIES_PROMQL_JOBS_SCHEDULER_`
 Type: [JobGroupConfig](#job-group-config)
 
 </dd>
+
 </dl>
 
 ### <span id="profilers"></span> _Profilers_
@@ -286,6 +292,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_PROFILERS_`
 Type: [ProfilersConfig](#profilers-config)
 
 </dd>
+
 </dl>
 
 ### <span id="prometheus"></span> _Prometheus_
@@ -313,6 +320,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_PROMETHEUS_HTTP_CLIENT_`
 Type: [HTTPClientConfig](#http-client-config)
 
 </dd>
+
 </dl>
 
 ### <span id="readiness"></span> _Readiness_
@@ -340,6 +348,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_READINESS_SERVICE_`
 Type: [JobConfig](#job-config)
 
 </dd>
+
 </dl>
 
 ### <span id="sentry-plugin"></span> _SentryPlugin_
@@ -359,6 +368,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_SENTRY_PLUGIN_SENTRY_`
 Type: [SentryConfig](#sentry-config)
 
 </dd>
+
 </dl>
 
 ### <span id="server"></span> _Server_
@@ -410,6 +420,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_SERVER_TLS_`
 Type: [ServerTLSConfig](#server-tls-config)
 
 </dd>
+
 </dl>
 
 ### <span id="watchdog"></span> _Watchdog_
@@ -429,6 +440,7 @@ Env-Var Prefix: `APERTURE_CONTROLLER_WATCHDOG_MEMORY_`
 Type: [WatchdogConfig](#watchdog-config)
 
 </dd>
+
 </dl>
 
 ## Objects
@@ -446,8 +458,6 @@ AdaptivePolicy creates a policy that forces GC when the usage surpasses the conf
 (bool, default: `false`) Flag to enable the policy
 
 </dd>
-</dl>
-<dl>
 <dt>factor</dt>
 <dd>
 
@@ -484,24 +494,18 @@ BackoffConfig holds configuration for GRPC Client Backoff.
 (string, `gte=0`, default: `1s`) Base Delay
 
 </dd>
-</dl>
-<dl>
 <dt>jitter</dt>
 <dd>
 
 (float64, `gte=0`, default: `0.2`) Jitter
 
 </dd>
-</dl>
-<dl>
 <dt>max_delay</dt>
 <dd>
 
 (string, `gte=0`, default: `120s`) Max Delay
 
 </dd>
-</dl>
-<dl>
 <dt>multiplier</dt>
 <dd>
 
@@ -523,8 +527,6 @@ BatchConfig defines configuration for OTEL batch processor.
 (uint32, `gt=0`, default: `10000`) SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 
 </dd>
-</dl>
-<dl>
 <dt>timeout</dt>
 <dd>
 
@@ -546,8 +548,6 @@ ClientConfig is the client configuration.
 ([GRPCClientConfig](#g-rpc-client-config))
 
 </dd>
-</dl>
-<dl>
 <dt>http</dt>
 <dd>
 
@@ -569,32 +569,24 @@ ClientTLSConfig is the config for client TLS.
 (string, `omitempty,file`)
 
 </dd>
-</dl>
-<dl>
 <dt>cert_file</dt>
 <dd>
 
 (string, `omitempty,file`)
 
 </dd>
-</dl>
-<dl>
 <dt>insecure_skip_verify</dt>
 <dd>
 
 (bool)
 
 </dd>
-</dl>
-<dl>
 <dt>key_file</dt>
 <dd>
 
 (string, `omitempty,file`)
 
 </dd>
-</dl>
-<dl>
 <dt>key_log_file</dt>
 <dd>
 
@@ -616,8 +608,6 @@ EtcdConfig holds configuration for etcd client.
 ([]string, `gt=0,dive,hostname_port|url|fqdn`) List of Etcd server endpoints
 
 </dd>
-</dl>
-<dl>
 <dt>lease_ttl</dt>
 <dd>
 
@@ -639,24 +629,18 @@ FluxNinjaPluginConfig is the configuration for FluxNinja cloud integration plugi
 (string) API Key for this agent.
 
 </dd>
-</dl>
-<dl>
 <dt>fluxninja_endpoint</dt>
 <dd>
 
 (string, `omitempty,hostname_port|url|fqdn`) Address to grpc or http(s) server listening in agent service. To use http protocol, the address must start with http(s)://.
 
 </dd>
-</dl>
-<dl>
 <dt>heartbeat_interval</dt>
 <dd>
 
 (string, `gte=0s`, default: `5s`) Interval between each heartbeat.
 
 </dd>
-</dl>
-<dl>
 <dt>client</dt>
 <dd>
 
@@ -678,32 +662,24 @@ GRPCClientConfig holds configuration for GRPC Client.
 (bool, default: `false`) Disable ClientTLS
 
 </dd>
-</dl>
-<dl>
 <dt>min_connection_timeout</dt>
 <dd>
 
 (string, `gte=0`, default: `20s`) Minimum connection timeout
 
 </dd>
-</dl>
-<dl>
 <dt>use_proxy</dt>
 <dd>
 
 (bool, default: `false`) Use HTTP CONNECT Proxy
 
 </dd>
-</dl>
-<dl>
 <dt>backoff</dt>
 <dd>
 
 ([BackoffConfig](#backoff-config))
 
 </dd>
-</dl>
-<dl>
 <dt>tls</dt>
 <dd>
 
@@ -740,8 +716,6 @@ GRPCServerConfig holds configuration for GRPC Server.
 (string, `gte=0s`, default: `120s`) Connection timeout
 
 </dd>
-</dl>
-<dl>
 <dt>enable_reflection</dt>
 <dd>
 
@@ -763,144 +737,108 @@ HTTPClientConfig holds configuration for HTTP Client.
 (bool, default: `false`) Disable Compression
 
 </dd>
-</dl>
-<dl>
 <dt>disable_keep_alives</dt>
 <dd>
 
 (bool, default: `false`) Disable HTTP Keep Alives
 
 </dd>
-</dl>
-<dl>
 <dt>expect_continue_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `1s`) Expect Continue Timeout. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>idle_connection_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `90s`) Idle Connection Timeout. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>key_log_file</dt>
 <dd>
 
 (string, `omitempty,file`) SSL key log file (useful for debugging with wireshark)
 
 </dd>
-</dl>
-<dl>
 <dt>max_conns_per_host</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Max Connections Per Host. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>max_idle_connections</dt>
 <dd>
 
 (int64, `gte=0`, default: `100`) Max Idle Connections. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>max_idle_connections_per_host</dt>
 <dd>
 
 (int64, `gte=0`, default: `5`) Max Idle Connections per host. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>max_response_header_bytes</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Max Response Header Bytes. 0 = no limit.
 
 </dd>
-</dl>
-<dl>
 <dt>network_keep_alive</dt>
 <dd>
 
 (string, `gte=0s`, default: `30s`) Network level keep-alive duration
 
 </dd>
-</dl>
-<dl>
 <dt>network_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `30s`) Timeout for making network connection
 
 </dd>
-</dl>
-<dl>
 <dt>read_buffer_size</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Read Buffer Size. 0 = 4KB
 
 </dd>
-</dl>
-<dl>
 <dt>response_header_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `0s`) Response Header Timeout. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>tls_handshake_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `10s`) TLS Handshake Timeout. 0 = no timeout
 
 </dd>
-</dl>
-<dl>
 <dt>timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `60s`) HTTP client timeout - Timeouts includes connection time, redirects, reading the response etc. 0 = no timeout.
 
 </dd>
-</dl>
-<dl>
 <dt>use_proxy</dt>
 <dd>
 
 (bool, default: `false`) Use Proxy
 
 </dd>
-</dl>
-<dl>
 <dt>write_buffer_size</dt>
 <dd>
 
 (int64, `gte=0`, default: `0`) Write Buffer Size. 0 = 4KB.
 
 </dd>
-</dl>
-<dl>
 <dt>proxy_connect_header</dt>
 <dd>
 
 ([Header](#header))
 
 </dd>
-</dl>
-<dl>
 <dt>tls</dt>
 <dd>
 
@@ -922,64 +860,48 @@ HTTPServerConfig holds configuration for HTTP Server.
 (bool, default: `false`) Disable HTTP Keep Alives
 
 </dd>
-</dl>
-<dl>
 <dt>idle_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `30s`) Idle timeout
 
 </dd>
-</dl>
-<dl>
 <dt>latency_bucket_count</dt>
 <dd>
 
 (int64, `gte=0`, default: `100`) The number of buckets in latency histogram
 
 </dd>
-</dl>
-<dl>
 <dt>latency_bucket_start_ms</dt>
 <dd>
 
 (float64, `gte=0`, default: `20`) The lowest bucket in latency histogram
 
 </dd>
-</dl>
-<dl>
 <dt>latency_bucket_width_ms</dt>
 <dd>
 
 (float64, `gte=0`, default: `20`) The bucket width in latency histogram
 
 </dd>
-</dl>
-<dl>
 <dt>max_header_bytes</dt>
 <dd>
 
 (int64, `gte=0`, default: `1048576`) Max header size in bytes
 
 </dd>
-</dl>
-<dl>
 <dt>read_header_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `10s`) Read header timeout
 
 </dd>
-</dl>
-<dl>
 <dt>read_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `10s`) Read timeout
 
 </dd>
-</dl>
-<dl>
 <dt>write_timeout</dt>
 <dd>
 
@@ -1010,24 +932,18 @@ HeapConfig holds configuration for heap Watchdog.
 (uint64, `gt=0`, default: `268435456`) Maximum memory (in bytes) sets limit of process usage. Default = 256MB.
 
 </dd>
-</dl>
-<dl>
 <dt>min_gogc</dt>
 <dd>
 
 (int64, `gt=0,lte=100`, default: `25`) Minimum GoGC sets the minimum garbage collection target percentage for heap driven Watchdogs. This setting helps avoid overscheduling.
 
 </dd>
-</dl>
-<dl>
 <dt>adaptive_policy</dt>
 <dd>
 
 ([AdaptivePolicy](#adaptive-policy))
 
 </dd>
-</dl>
-<dl>
 <dt>watermarks_policy</dt>
 <dd>
 
@@ -1049,24 +965,18 @@ JobConfig is config for Job
 (string, default: `10s`) Time period between job executions. Zero or negative value means that the job will never execute periodically.
 
 </dd>
-</dl>
-<dl>
 <dt>execution_timeout</dt>
 <dd>
 
 (string, `gte=0s`, default: `5s`) Execution timeout
 
 </dd>
-</dl>
-<dl>
 <dt>initial_delay</dt>
 <dd>
 
 (string, default: `0s`) Initial delay to start the job. Zero value will schedule the job immediately. Negative value will wait for next scheduled interval.
 
 </dd>
-</dl>
-<dl>
 <dt>initially_healthy</dt>
 <dd>
 
@@ -1103,16 +1013,12 @@ ListenerConfig holds configuration for socket listeners.
 (string, `hostname_port`, default: `:8080`) Address to bind to in the form of [host%zone]:port
 
 </dd>
-</dl>
-<dl>
 <dt>keep_alive</dt>
 <dd>
 
 (string, `gte=0s`, default: `180s`) Keep-alive period - 0 = enabled if supported by protocol or OS. If negative then keep-alives are disabled.
 
 </dd>
-</dl>
-<dl>
 <dt>network</dt>
 <dd>
 
@@ -1134,64 +1040,48 @@ LogConfig holds configuration for a logger and log writers.
 (bool, default: `false`) Compress
 
 </dd>
-</dl>
-<dl>
 <dt>file</dt>
 <dd>
 
 (string, default: `stderr`) Output file for logs. Keywords allowed - ["stderr", "default"]. "default" maps to `/var/log/fluxninja/<service>.log`
 
 </dd>
-</dl>
-<dl>
 <dt>level</dt>
 <dd>
 
 (string, `oneof=debug DEBUG info INFO warn WARN error ERROR fatal FATAL panic PANIC trace TRACE disabled DISABLED`, default: `info`) Log level
 
 </dd>
-</dl>
-<dl>
 <dt>max_age</dt>
 <dd>
 
 (int64, `gte=0`, default: `7`) Max age in days for log files
 
 </dd>
-</dl>
-<dl>
 <dt>max_backups</dt>
 <dd>
 
 (int64, `gte=0`, default: `3`) Max log file backups
 
 </dd>
-</dl>
-<dl>
 <dt>max_size</dt>
 <dd>
 
 (int64, `gte=0`, default: `50`) Log file max size in MB
 
 </dd>
-</dl>
-<dl>
 <dt>non_blocking</dt>
 <dd>
 
 (bool, default: `true`) Use non-blocking log writer (can lose logs at high throughput)
 
 </dd>
-</dl>
-<dl>
 <dt>pretty_console</dt>
 <dd>
 
 (bool, default: `false`) Additional log writer: pretty console (stdout) logging (not recommended for prod environments)
 
 </dd>
-</dl>
-<dl>
 <dt>writers</dt>
 <dd>
 
@@ -1213,32 +1103,24 @@ LogWriterConfig holds configuration for a log writer.
 (bool, default: `false`) Compress
 
 </dd>
-</dl>
-<dl>
 <dt>file</dt>
 <dd>
 
 (string, default: `stderr`) Output file for logs. Keywords allowed - ["stderr", "default"]. "default" maps to `/var/log/fluxninja/<service>.log`
 
 </dd>
-</dl>
-<dl>
 <dt>max_age</dt>
 <dd>
 
 (int64, `gte=0`, default: `7`) Max age in days for log files
 
 </dd>
-</dl>
-<dl>
 <dt>max_backups</dt>
 <dd>
 
 (int64, `gte=0`, default: `3`) Max log file backups
 
 </dd>
-</dl>
-<dl>
 <dt>max_size</dt>
 <dd>
 
@@ -1260,16 +1142,12 @@ MetricsConfig holds configuration for service metrics.
 (bool, default: `false`) EnableGoCollector controls whether the go collector is registered on startup. See <https://godoc.org/github.com/prometheus/client_golang/prometheus#NewGoCollector>
 
 </dd>
-</dl>
-<dl>
 <dt>enable_process_collector</dt>
 <dd>
 
 (bool, default: `false`) EnableProcessCollector controls whether the process collector is registered on startup. See <https://godoc.org/github.com/prometheus/client_golang/prometheus#NewProcessCollector>
 
 </dd>
-</dl>
-<dl>
 <dt>pedantic</dt>
 <dd>
 
@@ -1291,24 +1169,18 @@ OtelConfig is the configuration for the OTEL collector.
 (string, `hostname_port`, default: `:4317`) GRPC listener addr for OTEL Collector.
 
 </dd>
-</dl>
-<dl>
 <dt>http_addr</dt>
 <dd>
 
 (string, `hostname_port`, default: `:4318`) HTTP listener addr for OTEL Collector.
 
 </dd>
-</dl>
-<dl>
 <dt>batch_postrollup</dt>
 <dd>
 
 ([BatchConfig](#batch-config))
 
 </dd>
-</dl>
-<dl>
 <dt>batch_prerollup</dt>
 <dd>
 
@@ -1330,24 +1202,18 @@ PluginsConfig holds configuration for plugins.
 (bool, default: `false`) Disables all plugins
 
 </dd>
-</dl>
-<dl>
 <dt>disabled_plugins</dt>
 <dd>
 
 ([]string) Specific plugins to disable
 
 </dd>
-</dl>
-<dl>
 <dt>disabled_symbols</dt>
 <dd>
 
 ([]string) Specific plugin types to disable
 
 </dd>
-</dl>
-<dl>
 <dt>plugins_path</dt>
 <dd>
 
@@ -1369,16 +1235,12 @@ ProfilersConfig holds configuration for profilers.
 (bool, default: `false`) Flag to enable cpu profiling on process start and save it to a file. HTTP interface will not work if this is enabled as CPU profile will always be running.
 
 </dd>
-</dl>
-<dl>
 <dt>profiles_path</dt>
 <dd>
 
 (string) Path to save performance profiles. This can be set via command line arguments as well. E.g. default path for aperture-agent is /var/log/aperture/aperture-agent/profiles.
 
 </dd>
-</dl>
-<dl>
 <dt>register_http_routes</dt>
 <dd>
 
@@ -1417,16 +1279,12 @@ This configuration has preference over environment variables HTTP_PROXY, HTTPS_P
 (string, `omitempty,url|hostname_port`)
 
 </dd>
-</dl>
-<dl>
 <dt>https</dt>
 <dd>
 
 (string, `omitempty,url|hostname_port`)
 
 </dd>
-</dl>
-<dl>
 <dt>no_proxy</dt>
 <dd>
 
@@ -1448,24 +1306,18 @@ SentryConfig holds configuration for Sentry.
 (bool, default: `true`) Configure to generate and attach stacktraces to capturing message calls
 
 </dd>
-</dl>
-<dl>
 <dt>debug</dt>
 <dd>
 
 (bool, default: `true`) Debug enables printing of Sentry SDK debug messages
 
 </dd>
-</dl>
-<dl>
 <dt>disabled</dt>
 <dd>
 
 (bool, default: `false`) Sentry crash report disabled
 
 </dd>
-</dl>
-<dl>
 <dt>dsn</dt>
 <dd>
 
@@ -1474,24 +1326,18 @@ You can set test project's dsn to send log events.
 oss-aperture project dsn is set as default.
 
 </dd>
-</dl>
-<dl>
 <dt>environment</dt>
 <dd>
 
 (string, default: `production`) Environment
 
 </dd>
-</dl>
-<dl>
 <dt>sample_rate</dt>
 <dd>
 
 (float64, default: `1.0`) Sample rate for event submission i.e. 0.0 to 1.0
 
 </dd>
-</dl>
-<dl>
 <dt>traces_sample_rate</dt>
 <dd>
 
@@ -1513,40 +1359,30 @@ ServerTLSConfig holds configuration for setting up server TLS support.
 (string, `omitempty,fqdn`) Allowed CN
 
 </dd>
-</dl>
-<dl>
 <dt>certs_path</dt>
 <dd>
 
 (string) Path to credentials. This can be set via command line arguments as well.
 
 </dd>
-</dl>
-<dl>
 <dt>client_ca</dt>
 <dd>
 
 (string, `omitempty`) Client CA file
 
 </dd>
-</dl>
-<dl>
 <dt>enabled</dt>
 <dd>
 
 (bool, default: `false`) Enabled TLS
 
 </dd>
-</dl>
-<dl>
 <dt>server_cert</dt>
 <dd>
 
 (string, default: `ca.crt`) Server Cert file
 
 </dd>
-</dl>
-<dl>
 <dt>server_key</dt>
 <dd>
 
@@ -1568,24 +1404,18 @@ WatchdogConfig holds configuration for Watchdog Policy. For each policy, either 
 ([WatchdogPolicyType](#watchdog-policy-type))
 
 </dd>
-</dl>
-<dl>
 <dt>heap</dt>
 <dd>
 
 ([HeapConfig](#heap-config))
 
 </dd>
-</dl>
-<dl>
 <dt>job</dt>
 <dd>
 
 ([JobConfig](#job-config))
 
 </dd>
-</dl>
-<dl>
 <dt>system</dt>
 <dd>
 
@@ -1607,8 +1437,6 @@ WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algor
 ([AdaptivePolicy](#adaptive-policy))
 
 </dd>
-</dl>
-<dl>
 <dt>watermarks_policy</dt>
 <dd>
 
@@ -1630,8 +1458,6 @@ WatermarksPolicy creates a Watchdog policy that schedules GC at concrete waterma
 (bool, default: `false`) Flag to enable the policy
 
 </dd>
-</dl>
-<dl>
 <dt>watermarks</dt>
 <dd>
 

--- a/docs/gen/policies/policy.md
+++ b/docs/gen/policies/policy.md
@@ -94,6 +94,7 @@ Example of…
 Type: [V1Policy](#v1-policy)
 
 </dd>
+
 </dl>
 
 ## Objects
@@ -128,8 +129,6 @@ eg. {any: {of: [expr1, expr2]}}.
 TODO document what happens when lazy sync is disabled
 
 </dd>
-</dl>
-<dl>
 <dt>num_sync</dt>
 <dd>
 
@@ -149,8 +148,6 @@ TODO document what happens when lazy sync is disabled
 (string, `required`) Value of the label for which the override should be applied.
 
 </dd>
-</dl>
-<dl>
 <dt>limit_scale_factor</dt>
 <dd>
 
@@ -176,8 +173,6 @@ High-level extractor-based rules are compiled into a single rego query.
 Note: The module name must match the package name from the "source".
 
 </dd>
-</dl>
-<dl>
 <dt>source</dt>
 <dd>
 
@@ -204,8 +199,6 @@ you have a classifier that sets `user` flow label, you might want to set
 `fairness_key = "user"`.
 
 </dd>
-</dl>
-<dl>
 <dt>priority</dt>
 <dd>
 
@@ -214,8 +207,6 @@ Priority level ranges from 0 to 255.
 Higher numbers means higher priority level.
 
 </dd>
-</dl>
-<dl>
 <dt>tokens</dt>
 <dd>
 
@@ -237,8 +228,6 @@ This override is applicable only if `auto_tokens` is set to false.
 [flow labels](/concepts/flow-control/label/label.md).
 
 </dd>
-</dl>
-<dl>
 <dt>workload</dt>
 <dd>
 
@@ -272,8 +261,6 @@ strategy and a scheduler. Right now, only `load_shed_actuator` strategy is avail
 Actuation strategy defines the input signal that will drive the scheduler.
 
 </dd>
-</dl>
-<dl>
 <dt>scheduler</dt>
 <dd>
 
@@ -305,8 +292,6 @@ to select which label should be used as key.
 ([V1RateLimiterIns](#v1-rate-limiter-ins), `required`)
 
 </dd>
-</dl>
-<dl>
 <dt>label_key</dt>
 <dd>
 
@@ -320,32 +305,24 @@ label set up, set `label_key: "user"`.
 TODO make it possible for this field to be optional – to achieve global ratelimit.
 
 </dd>
-</dl>
-<dl>
 <dt>lazy_sync</dt>
 <dd>
 
 ([RateLimiterLazySync](#rate-limiter-lazy-sync)) Configuration of lazy-syncing behaviour of ratelimiter
 
 </dd>
-</dl>
-<dl>
 <dt>limit_reset_interval</dt>
 <dd>
 
 (string, default: `60s`) Time after which the limit for a given label value will be reset.
 
 </dd>
-</dl>
-<dl>
 <dt>overrides</dt>
 <dd>
 
 ([[]RateLimiterOverride](#rate-limiter-override)) Allows to specify different limits for particular label values.
 
 </dd>
-</dl>
-<dl>
 <dt>selector</dt>
 <dd>
 
@@ -377,8 +354,6 @@ selector:
 ([]float64, default: `[5.0,10.0,25.0,50.0,100.0,250.0,500.0,1000.0,2500.0,5000.0,10000.0]`) Latency histogram buckets (in ms) for this FluxMeter.
 
 </dd>
-</dl>
-<dl>
 <dt>selector</dt>
 <dd>
 
@@ -435,8 +410,6 @@ Type of combinator that computes the arithmetic operation on the operand signals
 ([V1ArithmeticCombinatorIns](#v1-arithmetic-combinator-ins)) Input ports for the Arithmetic Combinator component.
 
 </dd>
-</dl>
-<dl>
 <dt>operator</dt>
 <dd>
 
@@ -446,8 +419,6 @@ The arithmetic operation can be addition, subtraction, multiplication, division,
 In case of XOR and bitshifts, value of signals is cast to integers before performing the operation.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
@@ -469,8 +440,6 @@ Inputs for the Arithmetic Combinator component.
 ([V1Port](#v1-port)) Left hand side of the arithmetic operation.
 
 </dd>
-</dl>
-<dl>
 <dt>rhs</dt>
 <dd>
 
@@ -527,8 +496,6 @@ docs on how exactly it handles invalid inputs.
 ([[]V1Component](#v1-component)) Defines a signal processing graph as a list of components.
 
 </dd>
-</dl>
-<dl>
 <dt>evaluation_interval</dt>
 <dd>
 
@@ -570,8 +537,6 @@ rules:
 how to extract and propagate flow labels with that key.
 
 </dd>
-</dl>
-<dl>
 <dt>selector</dt>
 <dd>
 
@@ -626,48 +591,36 @@ See also [Policy](#-v1policy) for a higher-level explanation of circuits.
 ([V1ArithmeticCombinator](#v1-arithmetic-combinator)) Applies the given operator on input operands (signals) and emits the result.
 
 </dd>
-</dl>
-<dl>
 <dt>concurrency_limiter</dt>
 <dd>
 
 ([Languagev1ConcurrencyLimiter](#languagev1-concurrency-limiter)) Concurrency Limiter provides service protection by applying prioritized load shedding of flows using a network scheduler (e.g. Weighted Fair Queuing).
 
 </dd>
-</dl>
-<dl>
 <dt>constant</dt>
 <dd>
 
 ([V1Constant](#v1-constant)) Emits a constant signal.
 
 </dd>
-</dl>
-<dl>
 <dt>decider</dt>
 <dd>
 
 ([V1Decider](#v1-decider)) Decider acts as a switch that emits one of the two signals based on the binary result of comparison operator on two operands.
 
 </dd>
-</dl>
-<dl>
 <dt>ema</dt>
 <dd>
 
 ([V1EMA](#v1-e-m-a)) Exponential Moving Average filter.
 
 </dd>
-</dl>
-<dl>
 <dt>extrapolator</dt>
 <dd>
 
 ([V1Extrapolator](#v1-extrapolator)) Takes an input signal and emits the extrapolated value; either mirroring the input value or repeating the last known value up to the maximum extrapolation interval.
 
 </dd>
-</dl>
-<dl>
 <dt>gradient_controller</dt>
 <dd>
 
@@ -675,40 +628,30 @@ See also [Policy](#-v1policy) for a higher-level explanation of circuits.
 This controller can be used to build AIMD (Additive Increase, Multiplicative Decrease) or MIMD style response.
 
 </dd>
-</dl>
-<dl>
 <dt>max</dt>
 <dd>
 
 ([V1Max](#v1-max)) Emits the maximum of the input siganls.
 
 </dd>
-</dl>
-<dl>
 <dt>min</dt>
 <dd>
 
 ([V1Min](#v1-min)) Emits the minimum of the input signals.
 
 </dd>
-</dl>
-<dl>
 <dt>promql</dt>
 <dd>
 
 ([V1PromQL](#v1-prom-q-l)) Periodically runs a Prometheus query in the background and emits the result.
 
 </dd>
-</dl>
-<dl>
 <dt>rate_limiter</dt>
 <dd>
 
 ([Languagev1RateLimiter](#languagev1-rate-limiter)) Rate Limiter provides service protection by applying rate limiter.
 
 </dd>
-</dl>
-<dl>
 <dt>sqrt</dt>
 <dd>
 
@@ -730,8 +673,6 @@ Component that emits a constant value as an output signal
 ([V1ConstantOuts](#v1-constant-outs)) Output ports for the Constant component.
 
 </dd>
-</dl>
-<dl>
 <dt>value</dt>
 <dd>
 
@@ -772,8 +713,6 @@ Feature corresponds to a block of code that can be "switched off" which usually 
 Note: Flowcontrol only.
 
 </dd>
-</dl>
-<dl>
 <dt>traffic</dt>
 <dd>
 
@@ -809,32 +748,24 @@ instantaneous.
 If the duration is zero, the transition will happen instantaneously.
 
 </dd>
-</dl>
-<dl>
 <dt>in_ports</dt>
 <dd>
 
 ([V1DeciderIns](#v1-decider-ins)) Input ports for the Decider component.
 
 </dd>
-</dl>
-<dl>
 <dt>operator</dt>
 <dd>
 
 (string, `oneof=gt lt gte lte eq neq`) Comparison operator that computes operation on lhs and rhs input signals.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
 ([V1DeciderOuts](#v1-decider-outs)) Output ports for the Decider component.
 
 </dd>
-</dl>
-<dl>
 <dt>true_for</dt>
 <dd>
 
@@ -857,24 +788,18 @@ Inputs for the Decider component.
 ([V1Port](#v1-port)) Left hand side input signal for the comparison operation.
 
 </dd>
-</dl>
-<dl>
 <dt>on_false</dt>
 <dd>
 
 ([V1Port](#v1-port)) Output signal when the result of the operation is false.
 
 </dd>
-</dl>
-<dl>
 <dt>on_true</dt>
 <dd>
 
 ([V1Port](#v1-port)) Output signal when the result of the operation is true.
 
 </dd>
-</dl>
-<dl>
 <dt>rhs</dt>
 <dd>
 
@@ -937,40 +862,30 @@ The EMA filter also employs a min-max-envolope logic during warm up stage, expla
 (float64, `gte=0,lte=1.0`, default: `1`) Correction factor to apply on the output value if its in violation of the max envelope.
 
 </dd>
-</dl>
-<dl>
 <dt>correction_factor_on_min_envelope_violation</dt>
 <dd>
 
 (float64, `gte=1.0`, default: `1`) Correction factor to apply on the output value if its in violation of the min envelope.
 
 </dd>
-</dl>
-<dl>
 <dt>ema_window</dt>
 <dd>
 
 (string, default: `5s`) Duration of EMA sampling window.
 
 </dd>
-</dl>
-<dl>
 <dt>in_ports</dt>
 <dd>
 
 ([V1EMAIns](#v1-e-m-a-ins)) Input ports for the EMA component.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
 ([V1EMAOuts](#v1-e-m-a-outs)) Output ports for the EMA component.
 
 </dd>
-</dl>
-<dl>
 <dt>warm_up_window</dt>
 <dd>
 
@@ -994,8 +909,6 @@ Inputs for the EMA component.
 ([V1Port](#v1-port)) Input signal to be used for the EMA computation.
 
 </dd>
-</dl>
-<dl>
 <dt>max_envelope</dt>
 <dd>
 
@@ -1014,8 +927,6 @@ The envelope logic is **not** used outside the warm-up stage!
 :::
 
 </dd>
-</dl>
-<dl>
 <dt>min_envelope</dt>
 <dd>
 
@@ -1054,8 +965,6 @@ Label selector expression of the equal form "label == value".
 (string, `required`) Name of the label to equal match the value.
 
 </dd>
-</dl>
-<dl>
 <dt>value</dt>
 <dd>
 
@@ -1079,8 +988,6 @@ There are multiple variants of extractor, specify exactly one.
 ([V1AddressExtractor](#v1-address-extractor)) Display an address as a single string - `<ip>:<port>`.
 
 </dd>
-</dl>
-<dl>
 <dt>from</dt>
 <dd>
 
@@ -1106,24 +1013,18 @@ from: request.http.headers.user-agent
 [attribute-context]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto"
 
 </dd>
-</dl>
-<dl>
 <dt>json</dt>
 <dd>
 
 ([V1JSONExtractor](#v1-json-extractor)) Deserialize a json, and extract one of the fields.
 
 </dd>
-</dl>
-<dl>
 <dt>jwt</dt>
 <dd>
 
 ([V1JWTExtractor](#v1-j-w-t-extractor)) Parse the attribute as JWT and read the payload.
 
 </dd>
-</dl>
-<dl>
 <dt>path_templates</dt>
 <dd>
 
@@ -1147,16 +1048,12 @@ It does so until `maximum_extrapolation_interval` is reached, beyond which it em
 ([V1ExtrapolatorIns](#v1-extrapolator-ins)) Input ports for the Extrapolator component.
 
 </dd>
-</dl>
-<dl>
 <dt>max_extrapolation_interval</dt>
 <dd>
 
 (string, default: `10s`) Maximum time interval to repeat the last valid value of input signal.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
@@ -1236,32 +1133,24 @@ Some changes are expected in the near future:
 ([V1GradientControllerIns](#v1-gradient-controller-ins)) Input ports of the Gradient Controller.
 
 </dd>
-</dl>
-<dl>
 <dt>max_gradient</dt>
 <dd>
 
 (float64, default: `1.7976931348623157e+308`) Maximum gradient which clamps the computed gradient value to the range, [min_gradient, max_gradient].
 
 </dd>
-</dl>
-<dl>
 <dt>min_gradient</dt>
 <dd>
 
 (float64, default: `-1.7976931348623157e+308`) Minimum gradient which clamps the computed gradient value to the range, [min_gradient, max_gradient].
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
 ([V1GradientControllerOuts](#v1-gradient-controller-outs)) Output ports of the Gradient Controller.
 
 </dd>
-</dl>
-<dl>
 <dt>tolerance</dt>
 <dd>
 
@@ -1291,40 +1180,30 @@ Inputs for the Gradient Controller component.
 This signal is multiplied by the gradient to produce the output.
 
 </dd>
-</dl>
-<dl>
 <dt>max</dt>
 <dd>
 
 ([V1Port](#v1-port)) Maximum value to limit the output signal.
 
 </dd>
-</dl>
-<dl>
 <dt>min</dt>
 <dd>
 
 ([V1Port](#v1-port)) Minimum value to limit the output signal.
 
 </dd>
-</dl>
-<dl>
 <dt>optimize</dt>
 <dd>
 
 ([V1Port](#v1-port)) Optimize signal is added to the output of the gradient calculation.
 
 </dd>
-</dl>
-<dl>
 <dt>setpoint</dt>
 <dd>
 
 ([V1Port](#v1-port)) Setpoint to be used for the gradient computation.
 
 </dd>
-</dl>
-<dl>
 <dt>signal</dt>
 <dd>
 
@@ -1368,8 +1247,6 @@ pointer: /user/name
 (string, `required`) Attribute path pointing to some strings - eg. "request.http.body".
 
 </dd>
-</dl>
-<dl>
 <dt>pointer</dt>
 <dd>
 
@@ -1406,8 +1283,6 @@ json_pointer: /user/email
 (string, `required`) Jwt token can be pulled from any input attribute, but most likely you'd want to use "request.http.bearer".
 
 </dd>
-</dl>
-<dl>
 <dt>json_pointer</dt>
 <dd>
 
@@ -1432,8 +1307,6 @@ Label selector requirement which is a selector that contains values, a key, and 
 (string, `required`) Label key that the selector applies to.
 
 </dd>
-</dl>
-<dl>
 <dt>operator</dt>
 <dd>
 
@@ -1441,8 +1314,6 @@ Label selector requirement which is a selector that contains values, a key, and 
 Valid operators are In, NotIn, Exists and DoesNotExist.
 
 </dd>
-</dl>
-<dl>
 <dt>values</dt>
 <dd>
 
@@ -1477,8 +1348,6 @@ An empty label matcher always matches.
 ([V1MatchExpression](#v1-match-expression)) An arbitrary expression to be evaluated on the labels.
 
 </dd>
-</dl>
-<dl>
 <dt>match_expressions</dt>
 <dd>
 
@@ -1487,8 +1356,6 @@ An empty label matcher always matches.
 Note: The requirements are ANDed.
 
 </dd>
-</dl>
-<dl>
 <dt>match_labels</dt>
 <dd>
 
@@ -1555,40 +1422,30 @@ all:
 ([MatchExpressionList](#match-expression-list)) The expression is true when all subexpressions are true.
 
 </dd>
-</dl>
-<dl>
 <dt>any</dt>
 <dd>
 
 ([MatchExpressionList](#match-expression-list)) The expression is true when any subexpression is true.
 
 </dd>
-</dl>
-<dl>
 <dt>label_equals</dt>
 <dd>
 
 ([V1EqualsMatchExpression](#v1-equals-match-expression)) The expression is true when label value equals given value.
 
 </dd>
-</dl>
-<dl>
 <dt>label_exists</dt>
 <dd>
 
 (string, `required`) The expression is true when label with given name exists.
 
 </dd>
-</dl>
-<dl>
 <dt>label_matches</dt>
 <dd>
 
 ([V1MatchesMatchExpression](#v1-matches-match-expression)) The expression is true when label matches given regex.
 
 </dd>
-</dl>
-<dl>
 <dt>not</dt>
 <dd>
 
@@ -1610,8 +1467,6 @@ Label selector expression of the matches form "label matches regex".
 (string, `required`) Name of the label to match the regular expression.
 
 </dd>
-</dl>
-<dl>
 <dt>regex</dt>
 <dd>
 
@@ -1636,8 +1491,6 @@ Max: output = max([]inputs).
 ([V1MaxIns](#v1-max-ins)) Input ports for the Max component.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
@@ -1690,8 +1543,6 @@ Min: output = min([]inputs).
 ([V1MinIns](#v1-min-ins)) Input ports for the Min component.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
@@ -1785,8 +1636,6 @@ Policy specification contains a circuit that defines the controller logic and re
 ([V1Circuit](#v1-circuit)) Defines the control-loop logic of the policy.
 
 </dd>
-</dl>
-<dl>
 <dt>resources</dt>
 <dd>
 
@@ -1823,16 +1672,12 @@ Component that runs a Prometheus query periodically and returns the result as an
 (string, default: `10s`) Describes the interval between successive evaluations of the Prometheus query.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
 ([V1PromQLOuts](#v1-prom-q-l-outs)) Output ports for the PromQL component.
 
 </dd>
-</dl>
-<dl>
 <dt>query_string</dt>
 <dd>
 
@@ -1899,8 +1744,6 @@ Resources are typically FluxMeters, Classifiers, etc. that can be used to create
 The flow labels created by Classifiers can be matched by FluxMeters to create metrics for control purposes.
 
 </dd>
-</dl>
-<dl>
 <dt>flux_meters</dt>
 <dd>
 
@@ -1961,8 +1804,6 @@ propagate: false
 ([V1Extractor](#v1-extractor)) High-level declarative extractor.
 
 </dd>
-</dl>
-<dl>
 <dt>hidden</dt>
 <dd>
 
@@ -1979,8 +1820,6 @@ sensitive labels.
 :::
 
 </dd>
-</dl>
-<dl>
 <dt>propagate</dt>
 <dd>
 
@@ -1989,8 +1828,6 @@ sensitive labels.
 (default=true).
 
 </dd>
-</dl>
-<dl>
 <dt>rego</dt>
 <dd>
 
@@ -2022,16 +1859,12 @@ latency of flows in that workload during last few seconds (exact duration
 of this average can change).
 
 </dd>
-</dl>
-<dl>
 <dt>default_workload</dt>
 <dd>
 
 ([SchedulerWorkload](#scheduler-workload)) Workload to be used if none of workloads specified in `workloads` match.
 
 </dd>
-</dl>
-<dl>
 <dt>max_timeout</dt>
 <dd>
 
@@ -2055,24 +1888,18 @@ tweaking this timeout, make sure to adjust the GRPC timeout accordingly.
 :::
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
 ([V1SchedulerOuts](#v1-scheduler-outs)) Output ports for the Scheduler component.
 
 </dd>
-</dl>
-<dl>
 <dt>selector</dt>
 <dd>
 
 ([V1Selector](#v1-selector)) Selector decides for which service or flows the scheduler will be applied.
 
 </dd>
-</dl>
-<dl>
 <dt>timeout_factor</dt>
 <dd>
 
@@ -2084,8 +1911,6 @@ it will be rejected.
 This value impacts the prioritization and fairness because the larger the timeout the higher the chance a request has to get scheduled.
 
 </dd>
-</dl>
-<dl>
 <dt>workloads</dt>
 <dd>
 
@@ -2137,8 +1962,6 @@ via `auto_tokens` or explicitly by `Workload.tokens`).
 Value of this signal is the sum across all the relevant schedulers.
 
 </dd>
-</dl>
-<dl>
 <dt>incoming_concurrency</dt>
 <dd>
 
@@ -2182,16 +2005,12 @@ selector:
 (string, default: `default`) Describes where this selector applies to.
 
 </dd>
-</dl>
-<dl>
 <dt>control_point</dt>
 <dd>
 
 ([V1ControlPoint](#v1-control-point), `required`) Describes control point within the entity where the policy should apply to.
 
 </dd>
-</dl>
-<dl>
 <dt>label_matcher</dt>
 <dd>
 
@@ -2211,8 +2030,6 @@ control point.
 :::
 
 </dd>
-</dl>
-<dl>
 <dt>service</dt>
 <dd>
 
@@ -2241,16 +2058,12 @@ $$
 ([V1SqrtIns](#v1-sqrt-ins)) Input ports for the Sqrt component.
 
 </dd>
-</dl>
-<dl>
 <dt>out_ports</dt>
 <dd>
 
 ([V1SqrtOuts](#v1-sqrt-outs)) Output ports for the Sqrt component.
 
 </dd>
-</dl>
-<dl>
 <dt>scale</dt>
 <dd>
 

--- a/docs/tools/swagger/swagger-templates/config.gotmpl
+++ b/docs/tools/swagger/swagger-templates/config.gotmpl
@@ -159,8 +159,8 @@ any
     {{- if .Properties }}
 #### {{ if .IsTuple }}Tuple members{{ else }}Properties{{ end }}
 
-      {{- range .Properties }}
 <dl>
+      {{- range .Properties }}
 <dt>{{ .OriginalName }}</dt>
 <dd>{{/* blank lines inside dd are important for correct markdown rendering, don't remove */}}
 
@@ -171,8 +171,8 @@ any
 {{- .Description }}
 
 </dd>
-</dl>
       {{- end }}
+</dl>
     {{- end }}
   {{- end -}}
 {{- end }}
@@ -229,8 +229,8 @@ any
 {{- $base := .BasePath }}
 {{- $path := .Path }}
 {{- $env := index .Extensions "x-fn-config-env" }}
-  {{- if .QueryParams }}
 <dl>
+  {{- if .QueryParams }}
 {{- range .QueryParams }}
 <dt>{{ .Name }}</dt>
 <dd>{{/* blank lines inside dd are important for correct markdown rendering, don't remove */}}
@@ -242,11 +242,9 @@ any
 
 </dd>
 {{- end }}
-</dl>
   {{- end }}
   {{- if .HasBodyParams }}
 
-<dl>
 {{- range .Params }}
 {{- if .IsBodyParam }}
 
@@ -254,12 +252,13 @@ any
 <dd>{{/* blank lines inside dd are important for correct markdown rendering, don't remove */}}
 
 {{ if $env  }} Env-Var Prefix: `{{ upper (snakize (slice $base 1)) }}_{{ if $path }}{{ (upper (snakize (slice $path 1))) }}_{{ end }}{{ if and .Name (ne .Name ".") }}{{ upper (snakize .Name) }}_{{ end }}`{{ end }}
-Type: {{ template "fnSchemaSimple" . -}}
-{{ end }}
+Type: {{ template "fnSchemaSimple" . }}
+
 </dd>
+{{ end }}
 {{- end }}
-</dl>
 {{- end }}{{/* end .HasBodyParams */}}
+</dl>
 {{- end }}{{/* end .Operations */}}
 
 ## Objects


### PR DESCRIPTION
Rendering of definition lists (dl/dt/dd) was producing invalid markdown/html, causing docusaurus to fail.

* fix closing dl tags,
* add missing spacing around dd tags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/354)
<!-- Reviewable:end -->
