### PR TITLE
Fix heading ids in generated docs

### DIFF
--- a/api/aperture/common/selector/v1/selector.proto
+++ b/api/aperture/common/selector/v1/selector.proto
@@ -57,7 +57,7 @@ message Selector {
   // must also be satisfied (in addition to service+control point matching)
   //
   // :::note
-  // [Classifiers](#-v1classifier) _can_ use flow labels created by some other
+  // [Classifiers](#v1-classifier) _can_ use flow labels created by some other
   // classifier, but only if they were created at some previous control point
   // (and propagated in baggage).
   //

--- a/api/aperture/policy/language/v1/policy.proto
+++ b/api/aperture/policy/language/v1/policy.proto
@@ -51,12 +51,12 @@ message Policy {
 //
 // A signal also have a special **Invalid** value. It's usually used to
 // communicate that signal doesn't have a meaningful value at the moment, eg.
-// [PromQL](#-v1promql) emits such a value if it cannot execute a query.
+// [PromQL](#v1-prom-q-l) emits such a value if it cannot execute a query.
 // Components know when their input signals are invalid and can act
 // accordingly. They can either propagate the invalidness, by making their
 // output itself invalid (like eg.
-// [ArithmeticCombinator](#-v1arithmeticcombinator)) or use some different
-// logic, like eg. [Extrapolator](#-v1extrapolator). Refer to a component's
+// [ArithmeticCombinator](#v1-arithmetic-combinator)) or use some different
+// logic, like eg. [Extrapolator](#v1-extrapolator). Refer to a component's
 // docs on how exactly it handles invalid inputs.
 // :::
 message Circuit {
@@ -101,16 +101,16 @@ message Resources {
 //
 // There are three categories of components:
 // * "source" components – they take some sort of input from "the real world" and output
-//   a signal based on this input. Example: [PromQL](#-v1promql). In the UI
+//   a signal based on this input. Example: [PromQL](#v1-prom-q-l). In the UI
 //   they're represented by green color.
 // * internal components – "pure" components that don't interact with the "real world".
-//   Examples: [GradientController](#-v1gradientcontroller), [Max](#-v1max).
+//   Examples: [GradientController](#v1-gradient-controller), [Max](#v1-max).
 //   :::note
 //   Internal components's output can depend on their internal state, in addition to the inputs.
-//   Eg. see the [Exponential Moving Average filter](#-v1ema).
+//   Eg. see the [Exponential Moving Average filter](#v1-e-m-a).
 //   :::
 // * "sink" components – they affect the real world.
-//   [ConcurrencyLimiter](#-languagev1concurrencylimiter) and [RateLimiter](#-languagev1ratelimiter).
+//   [ConcurrencyLimiter](#languagev1-concurrency-limiter) and [RateLimiter](#languagev1-rate-limiter).
 //   Also sometimes called [_actuators_](/concepts/flow-control/actuators/actuators.md).
 //   In the UI, represented by orange color.  Sink components are usually also
 //   "sources" too, they usually emit a feedback signal, like
@@ -118,10 +118,10 @@ message Resources {
 //
 // :::tip
 // Sometimes you may want to use a constant value as one of component's inputs.
-// You can use the [Constant](#-constant) component for this.
+// You can use the [Constant](#v1-constant) component for this.
 // :::
 //
-// See also [Policy](#-v1policy) for a higher-level explanation of circuits.
+// See also [Policy](#v1-policy) for a higher-level explanation of circuits.
 message Component {
   oneof component {
     // Gradient controller basically calculates the ratio between the signal and the setpoint to determine the magnitude of the correction that need to be applied.
@@ -295,7 +295,7 @@ message GradientController {
 // \alpha = \frac{2}{N + 1} \quad\text{where } N = \frac{\text{ema\_window}}{\text{evalutation\_period}}
 // $$
 //
-// The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#-v1emains).
+// The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#v1-e-m-a-ins).
 message EMA {
   // Inputs for the EMA component.
   message Ins {
@@ -565,7 +565,7 @@ message RateLimiter {
     //
     // :::tip
     // Negative limit can be useful to _conditionally_ enable the ratelimiter
-    // under certain circumstances. [Decider](#-v1decider) might be helpful.
+    // under certain circumstances. [Decider](#v1-decider) might be helpful.
     // :::
     Port limit = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       extensions: {
@@ -670,7 +670,7 @@ message ConcurrencyLimiter {
 // signal are aggregated across all agents.
 // :::
 //
-// See [ConcurrencyLimiter](#-languagev1concurrencylimiter) for more context.
+// See [ConcurrencyLimiter](#languagev1-concurrency-limiter) for more context.
 message Scheduler {
   // Workload defines a class of requests that preferably have similar properties such as response latency or desired priority.
   message Workload {
@@ -721,7 +721,7 @@ message Scheduler {
     // **Accepted tokens** are tokens associated with
     // [flows](/concepts/flow-control/flow-control.md#flow) that were accepted by
     // this scheduler. Number of tokens for a flow is determined by a
-    // [workload](#-schedulerworkload) that the flow was assigned to (either
+    // [workload](#scheduler-workload) that the flow was assigned to (either
     // via `auto_tokens` or explicitly by `Workload.tokens`).
     // :::
     //
@@ -831,7 +831,7 @@ message LoadShedActuator {
   // Input for the Load Shed Actuator component.
   message Ins {
     // Load shedding factor is a fraction of [incoming
-    // concurrency](#-v1schedulerouts) that needs to be dropped.
+    // concurrency](#v1-scheduler-outs) that needs to be dropped.
     Port load_shed_factor = 1;
   }
 

--- a/api/gen/openapiv2/aperture.swagger.yaml
+++ b/api/gen/openapiv2/aperture.swagger.yaml
@@ -641,12 +641,12 @@ definitions:
 
       A signal also have a special **Invalid** value. It's usually used to
       communicate that signal doesn't have a meaningful value at the moment, eg.
-      [PromQL](#-v1promql) emits such a value if it cannot execute a query.
+      [PromQL](#v1-prom-q-l) emits such a value if it cannot execute a query.
       Components know when their input signals are invalid and can act
       accordingly. They can either propagate the invalidness, by making their
       output itself invalid (like eg.
-      [ArithmeticCombinator](#-v1arithmeticcombinator)) or use some different
-      logic, like eg. [Extrapolator](#-v1extrapolator). Refer to a component's
+      [ArithmeticCombinator](#v1-arithmetic-combinator)) or use some different
+      logic, like eg. [Extrapolator](#v1-extrapolator). Refer to a component's
       docs on how exactly it handles invalid inputs.
       :::
     title: Circuit is defined as a dataflow graph of inter-connected components
@@ -733,16 +733,16 @@ definitions:
 
       There are three categories of components:
       * "source" components – they take some sort of input from "the real world" and output
-        a signal based on this input. Example: [PromQL](#-v1promql). In the UI
+        a signal based on this input. Example: [PromQL](#v1-prom-q-l). In the UI
         they're represented by green color.
       * internal components – "pure" components that don't interact with the "real world".
-        Examples: [GradientController](#-v1gradientcontroller), [Max](#-v1max).
+        Examples: [GradientController](#v1-gradient-controller), [Max](#v1-max).
         :::note
         Internal components's output can depend on their internal state, in addition to the inputs.
-        Eg. see the [Exponential Moving Average filter](#-v1ema).
+        Eg. see the [Exponential Moving Average filter](#v1-e-m-a).
         :::
       * "sink" components – they affect the real world.
-        [ConcurrencyLimiter](#-languagev1concurrencylimiter) and [RateLimiter](#-languagev1ratelimiter).
+        [ConcurrencyLimiter](#languagev1-concurrency-limiter) and [RateLimiter](#languagev1-rate-limiter).
         Also sometimes called [_actuators_](/concepts/flow-control/actuators/actuators.md).
         In the UI, represented by orange color.  Sink components are usually also
         "sources" too, they usually emit a feedback signal, like
@@ -750,10 +750,10 @@ definitions:
 
       :::tip
       Sometimes you may want to use a constant value as one of component's inputs.
-      You can use the [Constant](#-constant) component for this.
+      You can use the [Constant](#v1-constant) component for this.
       :::
 
-      See also [Policy](#-v1policy) for a higher-level explanation of circuits.
+      See also [Policy](#v1-policy) for a higher-level explanation of circuits.
     title: Computational block that form the circuit
   v1Constant:
     type: object
@@ -930,7 +930,7 @@ definitions:
       \alpha = \frac{2}{N + 1} \quad\text{where } N = \frac{\text{ema\_window}}{\text{evalutation\_period}}
       $$
 
-      The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#-v1emains).
+      The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#v1-e-m-a-ins).
     title: Exponential Moving Average (EMA) is a type of moving average that applies exponenially more weight to recent signal readings
   v1EMAIns:
     type: object
@@ -1314,7 +1314,7 @@ definitions:
         $ref: '#/definitions/v1Port'
         description: |-
           Load shedding factor is a fraction of [incoming
-          concurrency](#-v1schedulerouts) that needs to be dropped.
+          concurrency](#v1-scheduler-outs) that needs to be dropped.
     description: Input for the Load Shed Actuator component.
   v1MatchExpression:
     type: object
@@ -1545,7 +1545,7 @@ definitions:
 
           :::tip
           Negative limit can be useful to _conditionally_ enable the ratelimiter
-          under certain circumstances. [Decider](#-v1decider) might be helpful.
+          under certain circumstances. [Decider](#v1-decider) might be helpful.
           :::
         x-go-validate: required
     title: Inputs for the RateLimiter component
@@ -1738,7 +1738,7 @@ definitions:
       signal are aggregated across all agents.
       :::
 
-      See [ConcurrencyLimiter](#-languagev1concurrencylimiter) for more context.
+      See [ConcurrencyLimiter](#languagev1-concurrency-limiter) for more context.
     title: Weighted Fair Queuing-based workload scheduler
   v1SchedulerOuts:
     type: object
@@ -1752,7 +1752,7 @@ definitions:
           **Accepted tokens** are tokens associated with
           [flows](/concepts/flow-control/flow-control.md#flow) that were accepted by
           this scheduler. Number of tokens for a flow is determined by a
-          [workload](#-schedulerworkload) that the flow was assigned to (either
+          [workload](#scheduler-workload) that the flow was assigned to (either
           via `auto_tokens` or explicitly by `Workload.tokens`).
           :::
 
@@ -1779,7 +1779,7 @@ definitions:
         $ref: '#/definitions/v1LabelMatcher'
         description: |-
           :::note
-          [Classifiers](#-v1classifier) _can_ use flow labels created by some other
+          [Classifiers](#v1-classifier) _can_ use flow labels created by some other
           classifier, but only if they were created at some previous control point
           (and propagated in baggage).
 

--- a/api/gen/proto/go/aperture/common/selector/v1/selector.pb.go
+++ b/api/gen/proto/go/aperture/common/selector/v1/selector.pb.go
@@ -61,7 +61,7 @@ type Selector struct {
 	// must also be satisfied (in addition to service+control point matching)
 	//
 	// :::note
-	// [Classifiers](#-v1classifier) _can_ use flow labels created by some other
+	// [Classifiers](#v1-classifier) _can_ use flow labels created by some other
 	// classifier, but only if they were created at some previous control point
 	// (and propagated in baggage).
 	//

--- a/api/gen/proto/go/aperture/policy/language/v1/policy.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/policy.pb.go
@@ -193,12 +193,12 @@ func (x *Policy) GetResources() *Resources {
 //
 // A signal also have a special **Invalid** value. It's usually used to
 // communicate that signal doesn't have a meaningful value at the moment, eg.
-// [PromQL](#-v1promql) emits such a value if it cannot execute a query.
+// [PromQL](#v1-prom-q-l) emits such a value if it cannot execute a query.
 // Components know when their input signals are invalid and can act
 // accordingly. They can either propagate the invalidness, by making their
 // output itself invalid (like eg.
-// [ArithmeticCombinator](#-v1arithmeticcombinator)) or use some different
-// logic, like eg. [Extrapolator](#-v1extrapolator). Refer to a component's
+// [ArithmeticCombinator](#v1-arithmetic-combinator)) or use some different
+// logic, like eg. [Extrapolator](#v1-extrapolator). Refer to a component's
 // docs on how exactly it handles invalid inputs.
 // :::
 type Circuit struct {
@@ -335,16 +335,16 @@ func (x *Resources) GetClassifiers() []*Classifier {
 //
 // There are three categories of components:
 // * "source" components – they take some sort of input from "the real world" and output
-//   a signal based on this input. Example: [PromQL](#-v1promql). In the UI
+//   a signal based on this input. Example: [PromQL](#v1-prom-q-l). In the UI
 //   they're represented by green color.
 // * internal components – "pure" components that don't interact with the "real world".
-//   Examples: [GradientController](#-v1gradientcontroller), [Max](#-v1max).
+//   Examples: [GradientController](#v1-gradient-controller), [Max](#v1-max).
 //   :::note
 //   Internal components's output can depend on their internal state, in addition to the inputs.
-//   Eg. see the [Exponential Moving Average filter](#-v1ema).
+//   Eg. see the [Exponential Moving Average filter](#v1-e-m-a).
 //   :::
 // * "sink" components – they affect the real world.
-//   [ConcurrencyLimiter](#-languagev1concurrencylimiter) and [RateLimiter](#-languagev1ratelimiter).
+//   [ConcurrencyLimiter](#languagev1-concurrency-limiter) and [RateLimiter](#languagev1-rate-limiter).
 //   Also sometimes called [_actuators_](/concepts/flow-control/actuators/actuators.md).
 //   In the UI, represented by orange color.  Sink components are usually also
 //   "sources" too, they usually emit a feedback signal, like
@@ -352,10 +352,10 @@ func (x *Resources) GetClassifiers() []*Classifier {
 //
 // :::tip
 // Sometimes you may want to use a constant value as one of component's inputs.
-// You can use the [Constant](#-constant) component for this.
+// You can use the [Constant](#v1-constant) component for this.
 // :::
 //
-// See also [Policy](#-v1policy) for a higher-level explanation of circuits.
+// See also [Policy](#v1-policy) for a higher-level explanation of circuits.
 type Component struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -781,7 +781,7 @@ func (x *GradientController) GetMaxGradient() float64 {
 // \alpha = \frac{2}{N + 1} \quad\text{where } N = \frac{\text{ema\_window}}{\text{evalutation\_period}}
 // $$
 //
-// The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#-v1emains).
+// The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#v1-e-m-a-ins).
 type EMA struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1248,7 +1248,7 @@ func (*ConcurrencyLimiter_LoadShedActuator) isConcurrencyLimiter_ActuationStrate
 // signal are aggregated across all agents.
 // :::
 //
-// See [ConcurrencyLimiter](#-languagev1concurrencylimiter) for more context.
+// See [ConcurrencyLimiter](#languagev1-concurrency-limiter) for more context.
 type Scheduler struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2466,7 +2466,7 @@ type RateLimiter_Ins struct {
 	//
 	// :::tip
 	// Negative limit can be useful to _conditionally_ enable the ratelimiter
-	// under certain circumstances. [Decider](#-v1decider) might be helpful.
+	// under certain circumstances. [Decider](#v1-decider) might be helpful.
 	// :::
 	Limit *Port `protobuf:"bytes,1,opt,name=limit,proto3" json:"limit,omitempty" validate:"required"` // @gotags: validate:"required"
 }
@@ -2653,7 +2653,7 @@ type Scheduler_Outs struct {
 	// **Accepted tokens** are tokens associated with
 	// [flows](/concepts/flow-control/flow-control.md#flow) that were accepted by
 	// this scheduler. Number of tokens for a flow is determined by a
-	// [workload](#-schedulerworkload) that the flow was assigned to (either
+	// [workload](#scheduler-workload) that the flow was assigned to (either
 	// via `auto_tokens` or explicitly by `Workload.tokens`).
 	// :::
 	//
@@ -2718,7 +2718,7 @@ type LoadShedActuator_Ins struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Load shedding factor is a fraction of [incoming
-	// concurrency](#-v1schedulerouts) that needs to be dropped.
+	// concurrency](#v1-scheduler-outs) that needs to be dropped.
 	LoadShedFactor *Port `protobuf:"bytes,1,opt,name=load_shed_factor,json=loadShedFactor,proto3" json:"load_shed_factor,omitempty"`
 }
 

--- a/docs/content/concepts/flow-control/actuators/rate-limiter.md
+++ b/docs/content/concepts/flow-control/actuators/rate-limiter.md
@@ -18,7 +18,7 @@ See also what are [actuators](actuators.md) in general.
 :::info
 
 See also
-[Rate Limiter reference](/reference/configuration/policies.md#-languagev1ratelimiter).
+[Rate Limiter reference](/reference/configuration/policies.md#languagev1-rate-limiter).
 
 :::
 

--- a/docs/content/concepts/flow-control/actuators/scheduler.md
+++ b/docs/content/concepts/flow-control/actuators/scheduler.md
@@ -18,7 +18,7 @@ See also what are [actuators](actuators.md) in general.
 :::info
 
 See also
-[Concurrency Limiter reference](/reference/configuration/policies.md#-languagev1concurrencylimiter).
+[Concurrency Limiter reference](/reference/configuration/policies.md#languagev1-concurrency-limiter).
 
 :::
 

--- a/docs/content/concepts/flow-control/label/classifier.md
+++ b/docs/content/concepts/flow-control/label/classifier.md
@@ -111,9 +111,9 @@ See [full example in reference][reference]
   https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto
 [rego-playground]: https://play.openpolicyagent.org/p/mG0sXxCNdQ
 [baggage]: label.md#baggage
-[reference]: /reference/configuration/policies.md#-v1classifier
-[rule]: /reference/configuration/policies.md#-v1rule
-[extractor]: /reference/configuration/policies.md#-v1extractor
+[reference]: /reference/configuration/policies.md#v1-classifier
+[rule]: /reference/configuration/policies.md#v1-rule
+[extractor]: /reference/configuration/policies.md#v1-extractor
 [rego-rule]: /reference/configuration/policies.md#rule-rego
 [plugin]: /cloud/plugin.md
 [label-matcher]: ../selector.md#label-matcher

--- a/docs/content/concepts/flow-control/label/label.md
+++ b/docs/content/concepts/flow-control/label/label.md
@@ -76,7 +76,7 @@ allows:
 
 For classifier-created labels, you can disable this behaviour by setting
 `hidden: true` in
-[the classification rule](/reference/configuration/policies.md#-v1rule).
+[the classification rule](/reference/configuration/policies.md#v1-rule).
 
 :::
 

--- a/docs/content/concepts/flow-control/selector.md
+++ b/docs/content/concepts/flow-control/selector.md
@@ -10,7 +10,7 @@ keywords:
 
 :::info
 
-See also [Selector reference](/reference/configuration/policies#-v1selector)
+See also [Selector reference](/reference/configuration/policies.md#v1-selector)
 
 :::
 

--- a/docs/gen/config/aperture-agent/swagger.md
+++ b/docs/gen/config/aperture-agent/swagger.md
@@ -73,7 +73,7 @@
 
 ## Reference
 
-### <span id="agent-info"></span> _AgentInfo_
+### _AgentInfo_ {#agent-info}
 
 Key: `agent_info`
 
@@ -90,7 +90,7 @@ Type: [AgentInfoConfig](#agent-info-config)
 
 </dl>
 
-### <span id="client"></span> _Client_
+### _Client_ {#client}
 
 Key: `client`
 
@@ -110,7 +110,7 @@ Type: [ProxyConfig](#proxy-config)
 
 </dl>
 
-### <span id="dist-cache"></span> _DistCache_
+### _DistCache_ {#dist-cache}
 
 Key: `dist_cache`
 
@@ -130,7 +130,7 @@ Type: [DistCacheConfig](#dist-cache-config)
 
 </dl>
 
-### <span id="etcd"></span> _Etcd_
+### _Etcd_ {#etcd}
 
 Key: `etcd`
 
@@ -150,7 +150,7 @@ Type: [EtcdConfig](#etcd-config)
 
 </dl>
 
-### <span id="flux-ninja-plugin"></span> _FluxNinjaPlugin_
+### _FluxNinjaPlugin_ {#flux-ninja-plugin}
 
 Key: `fluxninja_plugin`
 
@@ -170,7 +170,7 @@ Type: [FluxNinjaPluginConfig](#flux-ninja-plugin-config)
 
 </dl>
 
-### <span id="kubernetes-client"></span> _KubernetesClient_
+### _KubernetesClient_ {#kubernetes-client}
 
 Key: `kubernetes_client`
 
@@ -190,7 +190,7 @@ Type: [HTTPClientConfig](#http-client-config)
 
 </dl>
 
-### <span id="liveness"></span> _Liveness_
+### _Liveness_ {#liveness}
 
 Key: `liveness`
 
@@ -218,7 +218,7 @@ Type: [JobConfig](#job-config)
 
 </dl>
 
-### <span id="log"></span> _Log_
+### _Log_ {#log}
 
 Key: `log`
 
@@ -238,7 +238,7 @@ Type: [LogConfig](#log-config)
 
 </dl>
 
-### <span id="metrics"></span> _Metrics_
+### _Metrics_ {#metrics}
 
 Key: `metrics`
 
@@ -258,7 +258,7 @@ Type: [MetricsConfig](#metrics-config)
 
 </dl>
 
-### <span id="otel"></span> _Otel_
+### _Otel_ {#otel}
 
 Key: `otel`
 
@@ -278,7 +278,7 @@ Type: [OtelConfig](#otel-config)
 
 </dl>
 
-### <span id="peer-discovery"></span> _PeerDiscovery_
+### _PeerDiscovery_ {#peer-discovery}
 
 Key: `peer_discovery`
 
@@ -295,7 +295,7 @@ Type: [PeerDiscoveryConfig](#peer-discovery-config)
 
 </dl>
 
-### <span id="plugins"></span> _Plugins_
+### _Plugins_ {#plugins}
 
 Key: `plugins`
 
@@ -315,7 +315,7 @@ Type: [PluginsConfig](#plugins-config)
 
 </dl>
 
-### <span id="profilers"></span> _Profilers_
+### _Profilers_ {#profilers}
 
 Key: `profilers`
 
@@ -335,7 +335,7 @@ Type: [ProfilersConfig](#profilers-config)
 
 </dl>
 
-### <span id="prometheus"></span> _Prometheus_
+### _Prometheus_ {#prometheus}
 
 Key: `prometheus`
 
@@ -363,7 +363,7 @@ Type: [HTTPClientConfig](#http-client-config)
 
 </dl>
 
-### <span id="readiness"></span> _Readiness_
+### _Readiness_ {#readiness}
 
 Key: `readiness`
 
@@ -391,7 +391,7 @@ Type: [JobConfig](#job-config)
 
 </dl>
 
-### <span id="sentry-plugin"></span> _SentryPlugin_
+### _SentryPlugin_ {#sentry-plugin}
 
 Key: `sentry_plugin`
 
@@ -411,7 +411,7 @@ Type: [SentryConfig](#sentry-config)
 
 </dl>
 
-### <span id="server"></span> _Server_
+### _Server_ {#server}
 
 Key: `server`
 
@@ -463,7 +463,7 @@ Type: [ServerTLSConfig](#server-tls-config)
 
 </dl>
 
-### <span id="service-discovery"></span> _ServiceDiscovery_
+### _ServiceDiscovery_ {#service-discovery}
 
 Key: `service_discovery`
 
@@ -491,7 +491,7 @@ Type: [StaticDiscoveryConfig](#static-discovery-config)
 
 </dl>
 
-### <span id="watchdog"></span> _Watchdog_
+### _Watchdog_ {#watchdog}
 
 Key: `watchdog`
 
@@ -513,7 +513,7 @@ Type: [WatchdogConfig](#watchdog-config)
 
 ## Objects
 
-### <span id="adaptive-policy"></span> AdaptivePolicy
+### AdaptivePolicy {#adaptive-policy}
 
 AdaptivePolicy creates a policy that forces GC when the usage surpasses the configured factor of the available memory. This policy calculates next target as usage+(limit-usage)\*factor.
 
@@ -534,7 +534,7 @@ AdaptivePolicy creates a policy that forces GC when the usage surpasses the conf
 </dd>
 </dl>
 
-### <span id="agent-info-config"></span> AgentInfoConfig
+### AgentInfoConfig {#agent-info-config}
 
 AgentInfoConfig is the configuration for the agent group etc.
 
@@ -549,7 +549,7 @@ AgentInfoConfig is the configuration for the agent group etc.
 </dd>
 </dl>
 
-### <span id="backoff-config"></span> BackoffConfig
+### BackoffConfig {#backoff-config}
 
 BackoffConfig holds configuration for GRPC Client Backoff.
 
@@ -582,7 +582,7 @@ BackoffConfig holds configuration for GRPC Client Backoff.
 </dd>
 </dl>
 
-### <span id="batch-config"></span> BatchConfig
+### BatchConfig {#batch-config}
 
 BatchConfig defines configuration for OTEL batch processor.
 
@@ -603,7 +603,7 @@ BatchConfig defines configuration for OTEL batch processor.
 </dd>
 </dl>
 
-### <span id="client-config"></span> ClientConfig
+### ClientConfig {#client-config}
 
 ClientConfig is the client configuration.
 
@@ -624,7 +624,7 @@ ClientConfig is the client configuration.
 </dd>
 </dl>
 
-### <span id="client-tls-config"></span> ClientTLSConfig
+### ClientTLSConfig {#client-tls-config}
 
 ClientTLSConfig is the config for client TLS.
 
@@ -663,7 +663,7 @@ ClientTLSConfig is the config for client TLS.
 </dd>
 </dl>
 
-### <span id="dist-cache-config"></span> DistCacheConfig
+### DistCacheConfig {#dist-cache-config}
 
 DistCacheConfig configures distributed cache that holds per-label counters in distributed rate limiters.
 
@@ -696,7 +696,7 @@ DistCacheConfig configures distributed cache that holds per-label counters in di
 </dd>
 </dl>
 
-### <span id="entity-config"></span> EntityConfig
+### EntityConfig {#entity-config}
 
 EntityConfig describes a single entity.
 
@@ -723,7 +723,7 @@ EntityConfig describes a single entity.
 </dd>
 </dl>
 
-### <span id="etcd-config"></span> EtcdConfig
+### EtcdConfig {#etcd-config}
 
 EtcdConfig holds configuration for etcd client.
 
@@ -744,7 +744,7 @@ EtcdConfig holds configuration for etcd client.
 </dd>
 </dl>
 
-### <span id="flux-ninja-plugin-config"></span> FluxNinjaPluginConfig
+### FluxNinjaPluginConfig {#flux-ninja-plugin-config}
 
 FluxNinjaPluginConfig is the configuration for FluxNinja cloud integration plugin.
 
@@ -777,7 +777,7 @@ FluxNinjaPluginConfig is the configuration for FluxNinja cloud integration plugi
 </dd>
 </dl>
 
-### <span id="g-rpc-client-config"></span> GRPCClientConfig
+### GRPCClientConfig {#g-rpc-client-config}
 
 GRPCClientConfig holds configuration for GRPC Client.
 
@@ -816,7 +816,7 @@ GRPCClientConfig holds configuration for GRPC Client.
 </dd>
 </dl>
 
-### <span id="g-rpc-gateway-config"></span> GRPCGatewayConfig
+### GRPCGatewayConfig {#g-rpc-gateway-config}
 
 GRPCGatewayConfig holds configuration for grpc-http gateway
 
@@ -831,7 +831,7 @@ GRPCGatewayConfig holds configuration for grpc-http gateway
 </dd>
 </dl>
 
-### <span id="g-rpc-server-config"></span> GRPCServerConfig
+### GRPCServerConfig {#g-rpc-server-config}
 
 GRPCServerConfig holds configuration for GRPC Server.
 
@@ -852,7 +852,7 @@ GRPCServerConfig holds configuration for GRPC Server.
 </dd>
 </dl>
 
-### <span id="http-client-config"></span> HTTPClientConfig
+### HTTPClientConfig {#http-client-config}
 
 HTTPClientConfig holds configuration for HTTP Client.
 
@@ -975,7 +975,7 @@ HTTPClientConfig holds configuration for HTTP Client.
 </dd>
 </dl>
 
-### <span id="http-server-config"></span> HTTPServerConfig
+### HTTPServerConfig {#http-server-config}
 
 HTTPServerConfig holds configuration for HTTP Server.
 
@@ -1038,7 +1038,7 @@ HTTPServerConfig holds configuration for HTTP Server.
 </dd>
 </dl>
 
-### <span id="header"></span> Header
+### Header {#header}
 
 A Header represents the key-value pairs in an HTTP header.
 
@@ -1047,7 +1047,7 @@ CanonicalHeaderKey.
 
 [Header](#header)
 
-### <span id="heap-config"></span> HeapConfig
+### HeapConfig {#heap-config}
 
 HeapConfig holds configuration for heap Watchdog.
 
@@ -1080,7 +1080,7 @@ HeapConfig holds configuration for heap Watchdog.
 </dd>
 </dl>
 
-### <span id="job-config"></span> JobConfig
+### JobConfig {#job-config}
 
 JobConfig is config for Job
 
@@ -1113,7 +1113,7 @@ JobConfig is config for Job
 </dd>
 </dl>
 
-### <span id="job-group-config"></span> JobGroupConfig
+### JobGroupConfig {#job-group-config}
 
 JobGroupConfig holds configuration for JobGroup.
 
@@ -1128,7 +1128,7 @@ JobGroupConfig holds configuration for JobGroup.
 </dd>
 </dl>
 
-### <span id="kubernetes-discovery-config"></span> KubernetesDiscoveryConfig
+### KubernetesDiscoveryConfig {#kubernetes-discovery-config}
 
 KubernetesDiscoveryConfig for Kubernetes service discovery.
 
@@ -1155,7 +1155,7 @@ KubernetesDiscoveryConfig for Kubernetes service discovery.
 </dd>
 </dl>
 
-### <span id="listener-config"></span> ListenerConfig
+### ListenerConfig {#listener-config}
 
 ListenerConfig holds configuration for socket listeners.
 
@@ -1182,7 +1182,7 @@ ListenerConfig holds configuration for socket listeners.
 </dd>
 </dl>
 
-### <span id="log-config"></span> LogConfig
+### LogConfig {#log-config}
 
 LogConfig holds configuration for a logger and log writers.
 
@@ -1245,7 +1245,7 @@ LogConfig holds configuration for a logger and log writers.
 </dd>
 </dl>
 
-### <span id="log-writer-config"></span> LogWriterConfig
+### LogWriterConfig {#log-writer-config}
 
 LogWriterConfig holds configuration for a log writer.
 
@@ -1284,7 +1284,7 @@ LogWriterConfig holds configuration for a log writer.
 </dd>
 </dl>
 
-### <span id="metrics-config"></span> MetricsConfig
+### MetricsConfig {#metrics-config}
 
 MetricsConfig holds configuration for service metrics.
 
@@ -1311,7 +1311,7 @@ MetricsConfig holds configuration for service metrics.
 </dd>
 </dl>
 
-### <span id="otel-config"></span> OtelConfig
+### OtelConfig {#otel-config}
 
 OtelConfig is the configuration for the OTEL collector.
 
@@ -1344,7 +1344,7 @@ OtelConfig is the configuration for the OTEL collector.
 </dd>
 </dl>
 
-### <span id="peer-discovery-config"></span> PeerDiscoveryConfig
+### PeerDiscoveryConfig {#peer-discovery-config}
 
 PeerDiscoveryConfig holds configuration for Agent Peer Discovery.
 
@@ -1359,7 +1359,7 @@ PeerDiscoveryConfig holds configuration for Agent Peer Discovery.
 </dd>
 </dl>
 
-### <span id="plugins-config"></span> PluginsConfig
+### PluginsConfig {#plugins-config}
 
 PluginsConfig holds configuration for plugins.
 
@@ -1392,7 +1392,7 @@ PluginsConfig holds configuration for plugins.
 </dd>
 </dl>
 
-### <span id="profilers-config"></span> ProfilersConfig
+### ProfilersConfig {#profilers-config}
 
 ProfilersConfig holds configuration for profilers.
 
@@ -1419,7 +1419,7 @@ ProfilersConfig holds configuration for profilers.
 </dd>
 </dl>
 
-### <span id="prometheus-config"></span> PrometheusConfig
+### PrometheusConfig {#prometheus-config}
 
 PrometheusConfig holds configuration for Prometheus Server.
 
@@ -1434,7 +1434,7 @@ PrometheusConfig holds configuration for Prometheus Server.
 </dd>
 </dl>
 
-### <span id="proxy-config"></span> ProxyConfig
+### ProxyConfig {#proxy-config}
 
 ProxyConfig holds proxy configuration.
 
@@ -1463,7 +1463,7 @@ This configuration has preference over environment variables HTTP_PROXY, HTTPS_P
 </dd>
 </dl>
 
-### <span id="sentry-config"></span> SentryConfig
+### SentryConfig {#sentry-config}
 
 SentryConfig holds configuration for Sentry.
 
@@ -1516,7 +1516,7 @@ oss-aperture project dsn is set as default.
 </dd>
 </dl>
 
-### <span id="server-tls-config"></span> ServerTLSConfig
+### ServerTLSConfig {#server-tls-config}
 
 ServerTLSConfig holds configuration for setting up server TLS support.
 
@@ -1561,7 +1561,7 @@ ServerTLSConfig holds configuration for setting up server TLS support.
 </dd>
 </dl>
 
-### <span id="service-config"></span> ServiceConfig
+### ServiceConfig {#service-config}
 
 ServiceConfig describes a service and its entities.
 
@@ -1582,7 +1582,7 @@ ServiceConfig describes a service and its entities.
 </dd>
 </dl>
 
-### <span id="static-discovery-config"></span> StaticDiscoveryConfig
+### StaticDiscoveryConfig {#static-discovery-config}
 
 StaticDiscoveryConfig for pre-determined list of services.
 
@@ -1597,7 +1597,7 @@ StaticDiscoveryConfig for pre-determined list of services.
 </dd>
 </dl>
 
-### <span id="watchdog-config"></span> WatchdogConfig
+### WatchdogConfig {#watchdog-config}
 
 WatchdogConfig holds configuration for Watchdog Policy. For each policy, either watermark or adaptive should be configured.
 
@@ -1630,7 +1630,7 @@ WatchdogConfig holds configuration for Watchdog Policy. For each policy, either 
 </dd>
 </dl>
 
-### <span id="watchdog-policy-type"></span> WatchdogPolicyType
+### WatchdogPolicyType {#watchdog-policy-type}
 
 WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algorithms are configured then only watermark algorithm is used.
 
@@ -1651,7 +1651,7 @@ WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algor
 </dd>
 </dl>
 
-### <span id="watermarks-policy"></span> WatermarksPolicy
+### WatermarksPolicy {#watermarks-policy}
 
 WatermarksPolicy creates a Watchdog policy that schedules GC at concrete watermarks.
 

--- a/docs/gen/config/aperture-controller/swagger.md
+++ b/docs/gen/config/aperture-controller/swagger.md
@@ -64,7 +64,7 @@
 
 ## Reference
 
-### <span id="agent-info"></span> _AgentInfo_
+### _AgentInfo_ {#agent-info}
 
 Key: `agent_info`
 
@@ -81,7 +81,7 @@ Type: [AgentInfoConfig](#agent-info-config)
 
 </dl>
 
-### <span id="client"></span> _Client_
+### _Client_ {#client}
 
 Key: `client`
 
@@ -101,7 +101,7 @@ Type: [ProxyConfig](#proxy-config)
 
 </dl>
 
-### <span id="etcd"></span> _Etcd_
+### _Etcd_ {#etcd}
 
 Key: `etcd`
 
@@ -121,7 +121,7 @@ Type: [EtcdConfig](#etcd-config)
 
 </dl>
 
-### <span id="flux-ninja-plugin"></span> _FluxNinjaPlugin_
+### _FluxNinjaPlugin_ {#flux-ninja-plugin}
 
 Key: `fluxninja_plugin`
 
@@ -141,7 +141,7 @@ Type: [FluxNinjaPluginConfig](#flux-ninja-plugin-config)
 
 </dl>
 
-### <span id="liveness"></span> _Liveness_
+### _Liveness_ {#liveness}
 
 Key: `liveness`
 
@@ -169,7 +169,7 @@ Type: [JobConfig](#job-config)
 
 </dl>
 
-### <span id="log"></span> _Log_
+### _Log_ {#log}
 
 Key: `log`
 
@@ -189,7 +189,7 @@ Type: [LogConfig](#log-config)
 
 </dl>
 
-### <span id="metrics"></span> _Metrics_
+### _Metrics_ {#metrics}
 
 Key: `metrics`
 
@@ -209,7 +209,7 @@ Type: [MetricsConfig](#metrics-config)
 
 </dl>
 
-### <span id="otel"></span> _Otel_
+### _Otel_ {#otel}
 
 Key: `otel`
 
@@ -229,7 +229,7 @@ Type: [OtelConfig](#otel-config)
 
 </dl>
 
-### <span id="plugins"></span> _Plugins_
+### _Plugins_ {#plugins}
 
 Key: `plugins`
 
@@ -249,7 +249,7 @@ Type: [PluginsConfig](#plugins-config)
 
 </dl>
 
-### <span id="policies-config"></span> _PoliciesConfig_
+### _PoliciesConfig_ {#policies-config}
 
 Key: `policies`
 
@@ -275,7 +275,7 @@ Type: [JobGroupConfig](#job-group-config)
 
 </dl>
 
-### <span id="profilers"></span> _Profilers_
+### _Profilers_ {#profilers}
 
 Key: `profilers`
 
@@ -295,7 +295,7 @@ Type: [ProfilersConfig](#profilers-config)
 
 </dl>
 
-### <span id="prometheus"></span> _Prometheus_
+### _Prometheus_ {#prometheus}
 
 Key: `prometheus`
 
@@ -323,7 +323,7 @@ Type: [HTTPClientConfig](#http-client-config)
 
 </dl>
 
-### <span id="readiness"></span> _Readiness_
+### _Readiness_ {#readiness}
 
 Key: `readiness`
 
@@ -351,7 +351,7 @@ Type: [JobConfig](#job-config)
 
 </dl>
 
-### <span id="sentry-plugin"></span> _SentryPlugin_
+### _SentryPlugin_ {#sentry-plugin}
 
 Key: `sentry_plugin`
 
@@ -371,7 +371,7 @@ Type: [SentryConfig](#sentry-config)
 
 </dl>
 
-### <span id="server"></span> _Server_
+### _Server_ {#server}
 
 Key: `server`
 
@@ -423,7 +423,7 @@ Type: [ServerTLSConfig](#server-tls-config)
 
 </dl>
 
-### <span id="watchdog"></span> _Watchdog_
+### _Watchdog_ {#watchdog}
 
 Key: `watchdog`
 
@@ -445,7 +445,7 @@ Type: [WatchdogConfig](#watchdog-config)
 
 ## Objects
 
-### <span id="adaptive-policy"></span> AdaptivePolicy
+### AdaptivePolicy {#adaptive-policy}
 
 AdaptivePolicy creates a policy that forces GC when the usage surpasses the configured factor of the available memory. This policy calculates next target as usage+(limit-usage)\*factor.
 
@@ -466,7 +466,7 @@ AdaptivePolicy creates a policy that forces GC when the usage surpasses the conf
 </dd>
 </dl>
 
-### <span id="agent-info-config"></span> AgentInfoConfig
+### AgentInfoConfig {#agent-info-config}
 
 AgentInfoConfig is the configuration for the agent group etc.
 
@@ -481,7 +481,7 @@ AgentInfoConfig is the configuration for the agent group etc.
 </dd>
 </dl>
 
-### <span id="backoff-config"></span> BackoffConfig
+### BackoffConfig {#backoff-config}
 
 BackoffConfig holds configuration for GRPC Client Backoff.
 
@@ -514,7 +514,7 @@ BackoffConfig holds configuration for GRPC Client Backoff.
 </dd>
 </dl>
 
-### <span id="batch-config"></span> BatchConfig
+### BatchConfig {#batch-config}
 
 BatchConfig defines configuration for OTEL batch processor.
 
@@ -535,7 +535,7 @@ BatchConfig defines configuration for OTEL batch processor.
 </dd>
 </dl>
 
-### <span id="client-config"></span> ClientConfig
+### ClientConfig {#client-config}
 
 ClientConfig is the client configuration.
 
@@ -556,7 +556,7 @@ ClientConfig is the client configuration.
 </dd>
 </dl>
 
-### <span id="client-tls-config"></span> ClientTLSConfig
+### ClientTLSConfig {#client-tls-config}
 
 ClientTLSConfig is the config for client TLS.
 
@@ -595,7 +595,7 @@ ClientTLSConfig is the config for client TLS.
 </dd>
 </dl>
 
-### <span id="etcd-config"></span> EtcdConfig
+### EtcdConfig {#etcd-config}
 
 EtcdConfig holds configuration for etcd client.
 
@@ -616,7 +616,7 @@ EtcdConfig holds configuration for etcd client.
 </dd>
 </dl>
 
-### <span id="flux-ninja-plugin-config"></span> FluxNinjaPluginConfig
+### FluxNinjaPluginConfig {#flux-ninja-plugin-config}
 
 FluxNinjaPluginConfig is the configuration for FluxNinja cloud integration plugin.
 
@@ -649,7 +649,7 @@ FluxNinjaPluginConfig is the configuration for FluxNinja cloud integration plugi
 </dd>
 </dl>
 
-### <span id="g-rpc-client-config"></span> GRPCClientConfig
+### GRPCClientConfig {#g-rpc-client-config}
 
 GRPCClientConfig holds configuration for GRPC Client.
 
@@ -688,7 +688,7 @@ GRPCClientConfig holds configuration for GRPC Client.
 </dd>
 </dl>
 
-### <span id="g-rpc-gateway-config"></span> GRPCGatewayConfig
+### GRPCGatewayConfig {#g-rpc-gateway-config}
 
 GRPCGatewayConfig holds configuration for grpc-http gateway
 
@@ -703,7 +703,7 @@ GRPCGatewayConfig holds configuration for grpc-http gateway
 </dd>
 </dl>
 
-### <span id="g-rpc-server-config"></span> GRPCServerConfig
+### GRPCServerConfig {#g-rpc-server-config}
 
 GRPCServerConfig holds configuration for GRPC Server.
 
@@ -724,7 +724,7 @@ GRPCServerConfig holds configuration for GRPC Server.
 </dd>
 </dl>
 
-### <span id="http-client-config"></span> HTTPClientConfig
+### HTTPClientConfig {#http-client-config}
 
 HTTPClientConfig holds configuration for HTTP Client.
 
@@ -847,7 +847,7 @@ HTTPClientConfig holds configuration for HTTP Client.
 </dd>
 </dl>
 
-### <span id="http-server-config"></span> HTTPServerConfig
+### HTTPServerConfig {#http-server-config}
 
 HTTPServerConfig holds configuration for HTTP Server.
 
@@ -910,7 +910,7 @@ HTTPServerConfig holds configuration for HTTP Server.
 </dd>
 </dl>
 
-### <span id="header"></span> Header
+### Header {#header}
 
 A Header represents the key-value pairs in an HTTP header.
 
@@ -919,7 +919,7 @@ CanonicalHeaderKey.
 
 [Header](#header)
 
-### <span id="heap-config"></span> HeapConfig
+### HeapConfig {#heap-config}
 
 HeapConfig holds configuration for heap Watchdog.
 
@@ -952,7 +952,7 @@ HeapConfig holds configuration for heap Watchdog.
 </dd>
 </dl>
 
-### <span id="job-config"></span> JobConfig
+### JobConfig {#job-config}
 
 JobConfig is config for Job
 
@@ -985,7 +985,7 @@ JobConfig is config for Job
 </dd>
 </dl>
 
-### <span id="job-group-config"></span> JobGroupConfig
+### JobGroupConfig {#job-group-config}
 
 JobGroupConfig holds configuration for JobGroup.
 
@@ -1000,7 +1000,7 @@ JobGroupConfig holds configuration for JobGroup.
 </dd>
 </dl>
 
-### <span id="listener-config"></span> ListenerConfig
+### ListenerConfig {#listener-config}
 
 ListenerConfig holds configuration for socket listeners.
 
@@ -1027,7 +1027,7 @@ ListenerConfig holds configuration for socket listeners.
 </dd>
 </dl>
 
-### <span id="log-config"></span> LogConfig
+### LogConfig {#log-config}
 
 LogConfig holds configuration for a logger and log writers.
 
@@ -1090,7 +1090,7 @@ LogConfig holds configuration for a logger and log writers.
 </dd>
 </dl>
 
-### <span id="log-writer-config"></span> LogWriterConfig
+### LogWriterConfig {#log-writer-config}
 
 LogWriterConfig holds configuration for a log writer.
 
@@ -1129,7 +1129,7 @@ LogWriterConfig holds configuration for a log writer.
 </dd>
 </dl>
 
-### <span id="metrics-config"></span> MetricsConfig
+### MetricsConfig {#metrics-config}
 
 MetricsConfig holds configuration for service metrics.
 
@@ -1156,7 +1156,7 @@ MetricsConfig holds configuration for service metrics.
 </dd>
 </dl>
 
-### <span id="otel-config"></span> OtelConfig
+### OtelConfig {#otel-config}
 
 OtelConfig is the configuration for the OTEL collector.
 
@@ -1189,7 +1189,7 @@ OtelConfig is the configuration for the OTEL collector.
 </dd>
 </dl>
 
-### <span id="plugins-config"></span> PluginsConfig
+### PluginsConfig {#plugins-config}
 
 PluginsConfig holds configuration for plugins.
 
@@ -1222,7 +1222,7 @@ PluginsConfig holds configuration for plugins.
 </dd>
 </dl>
 
-### <span id="profilers-config"></span> ProfilersConfig
+### ProfilersConfig {#profilers-config}
 
 ProfilersConfig holds configuration for profilers.
 
@@ -1249,7 +1249,7 @@ ProfilersConfig holds configuration for profilers.
 </dd>
 </dl>
 
-### <span id="prometheus-config"></span> PrometheusConfig
+### PrometheusConfig {#prometheus-config}
 
 PrometheusConfig holds configuration for Prometheus Server.
 
@@ -1264,7 +1264,7 @@ PrometheusConfig holds configuration for Prometheus Server.
 </dd>
 </dl>
 
-### <span id="proxy-config"></span> ProxyConfig
+### ProxyConfig {#proxy-config}
 
 ProxyConfig holds proxy configuration.
 
@@ -1293,7 +1293,7 @@ This configuration has preference over environment variables HTTP_PROXY, HTTPS_P
 </dd>
 </dl>
 
-### <span id="sentry-config"></span> SentryConfig
+### SentryConfig {#sentry-config}
 
 SentryConfig holds configuration for Sentry.
 
@@ -1346,7 +1346,7 @@ oss-aperture project dsn is set as default.
 </dd>
 </dl>
 
-### <span id="server-tls-config"></span> ServerTLSConfig
+### ServerTLSConfig {#server-tls-config}
 
 ServerTLSConfig holds configuration for setting up server TLS support.
 
@@ -1391,7 +1391,7 @@ ServerTLSConfig holds configuration for setting up server TLS support.
 </dd>
 </dl>
 
-### <span id="watchdog-config"></span> WatchdogConfig
+### WatchdogConfig {#watchdog-config}
 
 WatchdogConfig holds configuration for Watchdog Policy. For each policy, either watermark or adaptive should be configured.
 
@@ -1424,7 +1424,7 @@ WatchdogConfig holds configuration for Watchdog Policy. For each policy, either 
 </dd>
 </dl>
 
-### <span id="watchdog-policy-type"></span> WatchdogPolicyType
+### WatchdogPolicyType {#watchdog-policy-type}
 
 WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algorithms are configured then only watermark algorithm is used.
 
@@ -1445,7 +1445,7 @@ WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algor
 </dd>
 </dl>
 
-### <span id="watermarks-policy"></span> WatermarksPolicy
+### WatermarksPolicy {#watermarks-policy}
 
 WatermarksPolicy creates a Watchdog policy that schedules GC at concrete watermarks.
 

--- a/docs/gen/policies/gen.yaml
+++ b/docs/gen/policies/gen.yaml
@@ -317,12 +317,12 @@ definitions:
 
       A signal also have a special **Invalid** value. It's usually used to
       communicate that signal doesn't have a meaningful value at the moment, eg.
-      [PromQL](#-v1promql) emits such a value if it cannot execute a query.
+      [PromQL](#v1-prom-q-l) emits such a value if it cannot execute a query.
       Components know when their input signals are invalid and can act
       accordingly. They can either propagate the invalidness, by making their
       output itself invalid (like eg.
-      [ArithmeticCombinator](#-v1arithmeticcombinator)) or use some different
-      logic, like eg. [Extrapolator](#-v1extrapolator). Refer to a component's
+      [ArithmeticCombinator](#v1-arithmetic-combinator)) or use some different
+      logic, like eg. [Extrapolator](#v1-extrapolator). Refer to a component's
       docs on how exactly it handles invalid inputs.
       :::
     type: object
@@ -386,16 +386,16 @@ definitions:
 
       There are three categories of components:
       * "source" components – they take some sort of input from "the real world" and output
-        a signal based on this input. Example: [PromQL](#-v1promql). In the UI
+        a signal based on this input. Example: [PromQL](#v1-prom-q-l). In the UI
         they're represented by green color.
       * internal components – "pure" components that don't interact with the "real world".
-        Examples: [GradientController](#-v1gradientcontroller), [Max](#-v1max).
+        Examples: [GradientController](#v1-gradient-controller), [Max](#v1-max).
         :::note
         Internal components's output can depend on their internal state, in addition to the inputs.
-        Eg. see the [Exponential Moving Average filter](#-v1ema).
+        Eg. see the [Exponential Moving Average filter](#v1-e-m-a).
         :::
       * "sink" components – they affect the real world.
-        [ConcurrencyLimiter](#-languagev1concurrencylimiter) and [RateLimiter](#-languagev1ratelimiter).
+        [ConcurrencyLimiter](#languagev1-concurrency-limiter) and [RateLimiter](#languagev1-rate-limiter).
         Also sometimes called [_actuators_](/concepts/flow-control/actuators/actuators.md).
         In the UI, represented by orange color.  Sink components are usually also
         "sources" too, they usually emit a feedback signal, like
@@ -403,10 +403,10 @@ definitions:
 
       :::tip
       Sometimes you may want to use a constant value as one of component's inputs.
-      You can use the [Constant](#-constant) component for this.
+      You can use the [Constant](#v1-constant) component for this.
       :::
 
-      See also [Policy](#-v1policy) for a higher-level explanation of circuits.
+      See also [Policy](#v1-policy) for a higher-level explanation of circuits.
     type: object
     title: Computational block that form the circuit
     properties:
@@ -609,7 +609,7 @@ definitions:
       \alpha = \frac{2}{N + 1} \quad\text{where } N = \frac{\text{ema\_window}}{\text{evalutation\_period}}
       $$
 
-      The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#-v1emains).
+      The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#v1-e-m-a-ins).
     type: object
     title: Exponential Moving Average (EMA) is a type of moving average that applies
       exponenially more weight to recent signal readings
@@ -1022,7 +1022,7 @@ definitions:
       load_shed_factor:
         description: |-
           Load shedding factor is a fraction of [incoming
-          concurrency](#-v1schedulerouts) that needs to be dropped.
+          concurrency](#v1-scheduler-outs) that needs to be dropped.
         x-order: 0
         $ref: '#/definitions/v1Port'
   v1MatchExpression:
@@ -1245,7 +1245,7 @@ definitions:
 
           :::tip
           Negative limit can be useful to _conditionally_ enable the ratelimiter
-          under certain circumstances. [Decider](#-v1decider) might be helpful.
+          under certain circumstances. [Decider](#v1-decider) might be helpful.
           :::
         x-go-validate: required
         x-order: 0
@@ -1349,7 +1349,7 @@ definitions:
       signal are aggregated across all agents.
       :::
 
-      See [ConcurrencyLimiter](#-languagev1concurrencylimiter) for more context.
+      See [ConcurrencyLimiter](#languagev1-concurrency-limiter) for more context.
     type: object
     title: Weighted Fair Queuing-based workload scheduler
     properties:
@@ -1448,7 +1448,7 @@ definitions:
           **Accepted tokens** are tokens associated with
           [flows](/concepts/flow-control/flow-control.md#flow) that were accepted by
           this scheduler. Number of tokens for a flow is determined by a
-          [workload](#-schedulerworkload) that the flow was assigned to (either
+          [workload](#scheduler-workload) that the flow was assigned to (either
           via `auto_tokens` or explicitly by `Workload.tokens`).
           :::
 
@@ -1499,7 +1499,7 @@ definitions:
       label_matcher:
         description: |-
           :::note
-          [Classifiers](#-v1classifier) _can_ use flow labels created by some other
+          [Classifiers](#v1-classifier) _can_ use flow labels created by some other
           classifier, but only if they were created at some previous control point
           (and propagated in baggage).
 

--- a/docs/gen/policies/policy.md
+++ b/docs/gen/policies/policy.md
@@ -82,7 +82,7 @@ Example of…
 
 ## Reference
 
-### <span id="policy"></span> _Policy_
+### _Policy_ {#policy}
 
 #### Members
 
@@ -99,7 +99,7 @@ Type: [V1Policy](#v1-policy)
 
 ## Objects
 
-### <span id="match-expression-list"></span> MatchExpressionList
+### MatchExpressionList {#match-expression-list}
 
 List of MatchExpressions that is used for all/any matching
 
@@ -116,7 +116,7 @@ eg. {any: {of: [expr1, expr2]}}.
 </dd>
 </dl>
 
-### <span id="rate-limiter-lazy-sync"></span> RateLimiterLazySync
+### RateLimiterLazySync {#rate-limiter-lazy-sync}
 
 #### Properties
 
@@ -137,7 +137,7 @@ TODO document what happens when lazy sync is disabled
 </dd>
 </dl>
 
-### <span id="rate-limiter-override"></span> RateLimiterOverride
+### RateLimiterOverride {#rate-limiter-override}
 
 #### Properties
 
@@ -156,7 +156,7 @@ TODO document what happens when lazy sync is disabled
 </dd>
 </dl>
 
-### <span id="rule-rego"></span> RuleRego
+### RuleRego {#rule-rego}
 
 Raw rego rules are compiled 1:1 to rego queries
 
@@ -183,7 +183,7 @@ Note: Must include a "package" declaration.
 </dd>
 </dl>
 
-### <span id="scheduler-workload"></span> SchedulerWorkload
+### SchedulerWorkload {#scheduler-workload}
 
 Workload defines a class of requests that preferably have similar properties such as response latency or desired priority.
 
@@ -216,7 +216,7 @@ This override is applicable only if `auto_tokens` is set to false.
 </dd>
 </dl>
 
-### <span id="scheduler-workload-and-label-matcher"></span> SchedulerWorkloadAndLabelMatcher
+### SchedulerWorkloadAndLabelMatcher {#scheduler-workload-and-label-matcher}
 
 #### Properties
 
@@ -236,7 +236,7 @@ This override is applicable only if `auto_tokens` is set to false.
 </dd>
 </dl>
 
-### <span id="languagev1-concurrency-limiter"></span> languagev1ConcurrencyLimiter
+### languagev1ConcurrencyLimiter {#languagev1-concurrency-limiter}
 
 Concurrency Limiter is an actuator component that regulates flows in order to provide active service protection
 
@@ -272,7 +272,7 @@ output signals.
 </dd>
 </dl>
 
-### <span id="languagev1-rate-limiter"></span> languagev1RateLimiter
+### languagev1RateLimiter {#languagev1-rate-limiter}
 
 Limits the traffic on a control point to specified rate
 
@@ -331,7 +331,7 @@ TODO make it possible for this field to be optional – to achieve global rateli
 </dd>
 </dl>
 
-### <span id="policylanguagev1-flux-meter"></span> policylanguagev1FluxMeter
+### policylanguagev1FluxMeter {#policylanguagev1-flux-meter}
 
 FluxMeter gathers metrics for the traffic that matches its selector.
 
@@ -369,7 +369,7 @@ selector:
 </dd>
 </dl>
 
-### <span id="v1-address-extractor"></span> v1AddressExtractor
+### v1AddressExtractor {#v1-address-extractor}
 
 Display an [Address][ext-authz-address] as a single string, eg. `<ip>:<port>`
 
@@ -397,7 +397,7 @@ from: "source.address # or dstination.address"
 </dd>
 </dl>
 
-### <span id="v1-arithmetic-combinator"></span> v1ArithmeticCombinator
+### v1ArithmeticCombinator {#v1-arithmetic-combinator}
 
 Type of combinator that computes the arithmetic operation on the operand signals
 
@@ -427,7 +427,7 @@ In case of XOR and bitshifts, value of signals is cast to integers before perfor
 </dd>
 </dl>
 
-### <span id="v1-arithmetic-combinator-ins"></span> v1ArithmeticCombinatorIns
+### v1ArithmeticCombinatorIns {#v1-arithmetic-combinator-ins}
 
 Inputs for the Arithmetic Combinator component.
 
@@ -448,7 +448,7 @@ Inputs for the Arithmetic Combinator component.
 </dd>
 </dl>
 
-### <span id="v1-arithmetic-combinator-outs"></span> v1ArithmeticCombinatorOuts
+### v1ArithmeticCombinatorOuts {#v1-arithmetic-combinator-outs}
 
 Outputs for the Arithmetic Combinator component.
 
@@ -463,7 +463,7 @@ Outputs for the Arithmetic Combinator component.
 </dd>
 </dl>
 
-### <span id="v1-circuit"></span> v1Circuit
+### v1Circuit {#v1-circuit}
 
 Circuit is defined as a dataflow graph of inter-connected components
 
@@ -478,12 +478,12 @@ Signals are floating-point values.
 
 A signal also have a special **Invalid** value. It's usually used to
 communicate that signal doesn't have a meaningful value at the moment, eg.
-[PromQL](#-v1promql) emits such a value if it cannot execute a query.
+[PromQL](#v1-prom-q-l) emits such a value if it cannot execute a query.
 Components know when their input signals are invalid and can act
 accordingly. They can either propagate the invalidness, by making their
 output itself invalid (like eg.
-[ArithmeticCombinator](#-v1arithmeticcombinator)) or use some different
-logic, like eg. [Extrapolator](#-v1extrapolator). Refer to a component's
+[ArithmeticCombinator](#v1-arithmetic-combinator)) or use some different
+logic, like eg. [Extrapolator](#v1-extrapolator). Refer to a component's
 docs on how exactly it handles invalid inputs.
 :::
 
@@ -505,7 +505,7 @@ This interval is typically aligned with how often the corrective action (actuati
 </dd>
 </dl>
 
-### <span id="v1-classifier"></span> v1Classifier
+### v1Classifier {#v1-classifier}
 
 Set of classification rules sharing a common selector
 
@@ -545,7 +545,7 @@ how to extract and propagate flow labels with that key.
 </dd>
 </dl>
 
-### <span id="v1-component"></span> v1Component
+### v1Component {#v1-component}
 
 Computational block that form the circuit
 
@@ -560,16 +560,16 @@ The looped signals are saved in the tick they are generated and served in the su
 There are three categories of components:
 
 - "source" components – they take some sort of input from "the real world" and output
-  a signal based on this input. Example: [PromQL](#-v1promql). In the UI
+  a signal based on this input. Example: [PromQL](#v1-prom-q-l). In the UI
   they're represented by green color.
 - internal components – "pure" components that don't interact with the "real world".
-  Examples: [GradientController](#-v1gradientcontroller), [Max](#-v1max).
+  Examples: [GradientController](#v1-gradient-controller), [Max](#v1-max).
   :::note
   Internal components's output can depend on their internal state, in addition to the inputs.
-  Eg. see the [Exponential Moving Average filter](#-v1ema).
+  Eg. see the [Exponential Moving Average filter](#v1-e-m-a).
   :::
 - "sink" components – they affect the real world.
-  [ConcurrencyLimiter](#-languagev1concurrencylimiter) and [RateLimiter](#-languagev1ratelimiter).
+  [ConcurrencyLimiter](#languagev1-concurrency-limiter) and [RateLimiter](#languagev1-rate-limiter).
   Also sometimes called [_actuators_](/concepts/flow-control/actuators/actuators.md).
   In the UI, represented by orange color. Sink components are usually also
   "sources" too, they usually emit a feedback signal, like
@@ -577,10 +577,10 @@ There are three categories of components:
 
 :::tip
 Sometimes you may want to use a constant value as one of component's inputs.
-You can use the [Constant](#-constant) component for this.
+You can use the [Constant](#v1-constant) component for this.
 :::
 
-See also [Policy](#-v1policy) for a higher-level explanation of circuits.
+See also [Policy](#v1-policy) for a higher-level explanation of circuits.
 
 #### Properties
 
@@ -660,7 +660,7 @@ This controller can be used to build AIMD (Additive Increase, Multiplicative Dec
 </dd>
 </dl>
 
-### <span id="v1-constant"></span> v1Constant
+### v1Constant {#v1-constant}
 
 Component that emits a constant value as an output signal
 
@@ -681,7 +681,7 @@ Component that emits a constant value as an output signal
 </dd>
 </dl>
 
-### <span id="v1-constant-outs"></span> v1ConstantOuts
+### v1ConstantOuts {#v1-constant-outs}
 
 Outputs for the Constant component.
 
@@ -696,7 +696,7 @@ Outputs for the Constant component.
 </dd>
 </dl>
 
-### <span id="v1-control-point"></span> v1ControlPoint
+### v1ControlPoint {#v1-control-point}
 
 Identifies control point within a service that the rule or policy should apply to.
 Controlpoint is either a library feature name or one of ingress/egress traffic control point.
@@ -726,7 +726,7 @@ Usually powered by integration with a proxy (like envoy) or a web framework.
 </dd>
 </dl>
 
-### <span id="v1-decider"></span> v1Decider
+### v1Decider {#v1-decider}
 
 Type of combinator that computes the comparison operation on lhs and rhs signals and switches between `on_true` and `on_false` signals based on the result of the comparison
 
@@ -775,7 +775,7 @@ If the duration is zero, the transition will happen instantaneously.
 </dd>
 </dl>
 
-### <span id="v1-decider-ins"></span> v1DeciderIns
+### v1DeciderIns {#v1-decider-ins}
 
 Inputs for the Decider component.
 
@@ -808,7 +808,7 @@ Inputs for the Decider component.
 </dd>
 </dl>
 
-### <span id="v1-decider-outs"></span> v1DeciderOuts
+### v1DeciderOuts {#v1-decider-outs}
 
 Outputs for the Decider component.
 
@@ -823,7 +823,7 @@ Outputs for the Decider component.
 </dd>
 </dl>
 
-### <span id="v1-e-m-a"></span> v1EMA
+### v1EMA {#v1-e-m-a}
 
 Exponential Moving Average (EMA) is a type of moving average that applies exponenially more weight to recent signal readings
 
@@ -851,7 +851,7 @@ $$
 \alpha = \frac{2}{N + 1} \quad\text{where } N = \frac{\text{ema\_window}}{\text{evalutation\_period}}
 $$
 
-The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#-v1emains).
+The EMA filter also employs a min-max-envolope logic during warm up stage, explained [here](#v1-e-m-a-ins).
 
 #### Properties
 
@@ -896,7 +896,7 @@ The initial value of the EMA is the average of signal readings received during t
 </dd>
 </dl>
 
-### <span id="v1-e-m-a-ins"></span> v1EMAIns
+### v1EMAIns {#v1-e-m-a-ins}
 
 Inputs for the EMA component.
 
@@ -937,7 +937,7 @@ Used during the warm-up stage analoguously to `max_envelope`.
 </dd>
 </dl>
 
-### <span id="v1-e-m-a-outs"></span> v1EMAOuts
+### v1EMAOuts {#v1-e-m-a-outs}
 
 Outputs for the EMA component.
 
@@ -952,7 +952,7 @@ Outputs for the EMA component.
 </dd>
 </dl>
 
-### <span id="v1-equals-match-expression"></span> v1EqualsMatchExpression
+### v1EqualsMatchExpression {#v1-equals-match-expression}
 
 Label selector expression of the equal form "label == value".
 
@@ -973,7 +973,7 @@ Label selector expression of the equal form "label == value".
 </dd>
 </dl>
 
-### <span id="v1-extractor"></span> v1Extractor
+### v1Extractor {#v1-extractor}
 
 Defines a high-level way to specify how to extract a flow label value given http request metadata, without a need to write rego code
 
@@ -1033,7 +1033,7 @@ from: request.http.headers.user-agent
 </dd>
 </dl>
 
-### <span id="v1-extrapolator"></span> v1Extrapolator
+### v1Extrapolator {#v1-extrapolator}
 
 Extrapolates the input signal by repeating the last valid value during the period in which it is invalid
 
@@ -1062,7 +1062,7 @@ It does so until `maximum_extrapolation_interval` is reached, beyond which it em
 </dd>
 </dl>
 
-### <span id="v1-extrapolator-ins"></span> v1ExtrapolatorIns
+### v1ExtrapolatorIns {#v1-extrapolator-ins}
 
 Inputs for the Extrapolator component.
 
@@ -1077,7 +1077,7 @@ Inputs for the Extrapolator component.
 </dd>
 </dl>
 
-### <span id="v1-extrapolator-outs"></span> v1ExtrapolatorOuts
+### v1ExtrapolatorOuts {#v1-extrapolator-outs}
 
 Outputs for the Extrapolator component.
 
@@ -1092,7 +1092,7 @@ Outputs for the Extrapolator component.
 </dd>
 </dl>
 
-### <span id="v1-gradient-controller"></span> v1GradientController
+### v1GradientController {#v1-gradient-controller}
 
 Gradient controller is a type of controller which tries to adjust the
 control variable proportionally to the relative difference between setpoint
@@ -1165,7 +1165,7 @@ Value of tolerance should be close or equal to 1, eg. 1.1.
 </dd>
 </dl>
 
-### <span id="v1-gradient-controller-ins"></span> v1GradientControllerIns
+### v1GradientControllerIns {#v1-gradient-controller-ins}
 
 Inputs for the Gradient Controller component.
 
@@ -1212,7 +1212,7 @@ This signal is multiplied by the gradient to produce the output.
 </dd>
 </dl>
 
-### <span id="v1-gradient-controller-outs"></span> v1GradientControllerOuts
+### v1GradientControllerOuts {#v1-gradient-controller-outs}
 
 Outputs for the Gradient Controller component.
 
@@ -1227,7 +1227,7 @@ Outputs for the Gradient Controller component.
 </dd>
 </dl>
 
-### <span id="v1-json-extractor"></span> v1JSONExtractor
+### v1JSONExtractor {#v1-json-extractor}
 
 Deserialize a json, and extract one of the fields
 
@@ -1258,7 +1258,7 @@ eg. `/foo/bar`. If the pointer points into an object, it'd be stringified.
 </dd>
 </dl>
 
-### <span id="v1-j-w-t-extractor"></span> v1JWTExtractor
+### v1JWTExtractor {#v1-j-w-t-extractor}
 
 Parse the attribute as JWT and read the payload
 
@@ -1294,7 +1294,7 @@ eg. `/foo/bar`. If the pointer points into an object, it'd be stringified.
 </dd>
 </dl>
 
-### <span id="v1-k8s-label-matcher-requirement"></span> v1K8sLabelMatcherRequirement
+### v1K8sLabelMatcherRequirement {#v1-k8s-label-matcher-requirement}
 
 Label selector requirement which is a selector that contains values, a key, and an operator that relates the key and values.
 
@@ -1324,7 +1324,7 @@ If the operator is Exists or DoesNotExist, the values array must be empty.
 </dd>
 </dl>
 
-### <span id="v1-label-matcher"></span> v1LabelMatcher
+### v1LabelMatcher {#v1-label-matcher}
 
 Allows to define rules whether a map of
 [labels](/concepts/flow-control/label/label.md)
@@ -1367,7 +1367,7 @@ Note: The requirements are ANDed.
 </dd>
 </dl>
 
-### <span id="v1-load-shed-actuator"></span> v1LoadShedActuator
+### v1LoadShedActuator {#v1-load-shed-actuator}
 
 Takes the load shed factor input signal and publishes it to the schedulers in the data-plane
 
@@ -1382,7 +1382,7 @@ Takes the load shed factor input signal and publishes it to the schedulers in th
 </dd>
 </dl>
 
-### <span id="v1-load-shed-actuator-ins"></span> v1LoadShedActuatorIns
+### v1LoadShedActuatorIns {#v1-load-shed-actuator-ins}
 
 Input for the Load Shed Actuator component.
 
@@ -1393,12 +1393,12 @@ Input for the Load Shed Actuator component.
 <dd>
 
 ([V1Port](#v1-port)) Load shedding factor is a fraction of [incoming
-concurrency](#-v1schedulerouts) that needs to be dropped.
+concurrency](#v1-scheduler-outs) that needs to be dropped.
 
 </dd>
 </dl>
 
-### <span id="v1-match-expression"></span> v1MatchExpression
+### v1MatchExpression {#v1-match-expression}
 
 Defines a [map<string, string> → bool] expression to be evaluated on labels
 
@@ -1454,7 +1454,7 @@ all:
 </dd>
 </dl>
 
-### <span id="v1-matches-match-expression"></span> v1MatchesMatchExpression
+### v1MatchesMatchExpression {#v1-matches-match-expression}
 
 Label selector expression of the matches form "label matches regex".
 
@@ -1476,7 +1476,7 @@ It uses [golang's regular expression syntax](https://github.com/google/re2/wiki/
 </dd>
 </dl>
 
-### <span id="v1-max"></span> v1Max
+### v1Max {#v1-max}
 
 Takes a list of input signals and emits the signal with the maximum value
 
@@ -1499,7 +1499,7 @@ Max: output = max([]inputs).
 </dd>
 </dl>
 
-### <span id="v1-max-ins"></span> v1MaxIns
+### v1MaxIns {#v1-max-ins}
 
 Inputs for the Max component.
 
@@ -1514,7 +1514,7 @@ Inputs for the Max component.
 </dd>
 </dl>
 
-### <span id="v1-max-outs"></span> v1MaxOuts
+### v1MaxOuts {#v1-max-outs}
 
 Output for the Max component.
 
@@ -1529,7 +1529,7 @@ Output for the Max component.
 </dd>
 </dl>
 
-### <span id="v1-min"></span> v1Min
+### v1Min {#v1-min}
 
 Takes an array of input signals and emits the signal with the minimum value
 Min: output = min([]inputs).
@@ -1551,7 +1551,7 @@ Min: output = min([]inputs).
 </dd>
 </dl>
 
-### <span id="v1-min-ins"></span> v1MinIns
+### v1MinIns {#v1-min-ins}
 
 Inputs for the Min component.
 
@@ -1566,7 +1566,7 @@ Inputs for the Min component.
 </dd>
 </dl>
 
-### <span id="v1-min-outs"></span> v1MinOuts
+### v1MinOuts {#v1-min-outs}
 
 Output ports for the Min component.
 
@@ -1581,7 +1581,7 @@ Output ports for the Min component.
 </dd>
 </dl>
 
-### <span id="v1-path-template-matcher"></span> v1PathTemplateMatcher
+### v1PathTemplateMatcher {#v1-path-template-matcher}
 
 Matches HTTP Path to given path templates
 
@@ -1621,7 +1621,7 @@ Example:
 </dd>
 </dl>
 
-### <span id="v1-policy"></span> v1Policy
+### v1Policy {#v1-policy}
 
 Policy expresses reliability automation workflow that automatically protects services
 
@@ -1644,7 +1644,7 @@ Policy specification contains a circuit that defines the controller logic and re
 </dd>
 </dl>
 
-### <span id="v1-port"></span> v1Port
+### v1Port {#v1-port}
 
 Components are interconnected with each other via Ports
 
@@ -1659,7 +1659,7 @@ Components are interconnected with each other via Ports
 </dd>
 </dl>
 
-### <span id="v1-prom-q-l"></span> v1PromQL
+### v1PromQL {#v1-prom-q-l}
 
 Component that runs a Prometheus query periodically and returns the result as an output signal
 
@@ -1691,7 +1691,7 @@ fluxmeters here or link to appropriate place in docs.
 </dd>
 </dl>
 
-### <span id="v1-prom-q-l-outs"></span> v1PromQLOuts
+### v1PromQLOuts {#v1-prom-q-l-outs}
 
 Output for the PromQL component.
 
@@ -1706,7 +1706,7 @@ Output for the PromQL component.
 </dd>
 </dl>
 
-### <span id="v1-rate-limiter-ins"></span> v1RateLimiterIns
+### v1RateLimiterIns {#v1-rate-limiter-ins}
 
 Inputs for the RateLimiter component
 
@@ -1721,13 +1721,13 @@ Negative values disable the ratelimiter.
 
 :::tip
 Negative limit can be useful to _conditionally_ enable the ratelimiter
-under certain circumstances. [Decider](#-v1decider) might be helpful.
+under certain circumstances. [Decider](#v1-decider) might be helpful.
 :::
 
 </dd>
 </dl>
 
-### <span id="v1-resources"></span> v1Resources
+### v1Resources {#v1-resources}
 
 Resources that need to be setup for the policy to function
 
@@ -1754,7 +1754,7 @@ FluxMeters'-created metrics can be consumed as input to the circuit via the Prom
 </dd>
 </dl>
 
-### <span id="v1-rule"></span> v1Rule
+### v1Rule {#v1-rule}
 
 Rule describes a single Flow Classification Rule
 
@@ -1836,7 +1836,7 @@ sensitive labels.
 </dd>
 </dl>
 
-### <span id="v1-scheduler"></span> v1Scheduler
+### v1Scheduler {#v1-scheduler}
 
 Weighted Fair Queuing-based workload scheduler
 
@@ -1845,7 +1845,7 @@ Each Agent instantiates an independent copy of the scheduler, but output
 signal are aggregated across all agents.
 :::
 
-See [ConcurrencyLimiter](#-languagev1concurrencylimiter) for more context.
+See [ConcurrencyLimiter](#languagev1-concurrency-limiter) for more context.
 
 #### Properties
 
@@ -1939,7 +1939,7 @@ section](/concepts/flow-control/actuators/scheduler.md#workload).
 </dd>
 </dl>
 
-### <span id="v1-scheduler-outs"></span> v1SchedulerOuts
+### v1SchedulerOuts {#v1-scheduler-outs}
 
 Output for the Scheduler component.
 
@@ -1955,7 +1955,7 @@ Output for the Scheduler component.
 **Accepted tokens** are tokens associated with
 [flows](/concepts/flow-control/flow-control.md#flow) that were accepted by
 this scheduler. Number of tokens for a flow is determined by a
-[workload](#-schedulerworkload) that the flow was assigned to (either
+[workload](#scheduler-workload) that the flow was assigned to (either
 via `auto_tokens` or explicitly by `Workload.tokens`).
 :::
 
@@ -1972,7 +1972,7 @@ entering scheduler, including rejected ones.
 </dd>
 </dl>
 
-### <span id="v1-selector"></span> v1Selector
+### v1Selector {#v1-selector}
 
 Describes where a rule or actuation component should apply to
 
@@ -2019,7 +2019,7 @@ selector:
 must also be satisfied (in addition to service+control point matching)
 
 :::note
-[Classifiers](#-v1classifier) _can_ use flow labels created by some other
+[Classifiers](#v1-classifier) _can_ use flow labels created by some other
 classifier, but only if they were created at some previous control point
 (and propagated in baggage).
 
@@ -2041,7 +2041,7 @@ Note: Entity may belong to multiple services.
 </dd>
 </dl>
 
-### <span id="v1-sqrt"></span> v1Sqrt
+### v1Sqrt {#v1-sqrt}
 
 Takes an input signal and emits the square root of it multiplied by scale as an output
 
@@ -2072,7 +2072,7 @@ $$
 </dd>
 </dl>
 
-### <span id="v1-sqrt-ins"></span> v1SqrtIns
+### v1SqrtIns {#v1-sqrt-ins}
 
 Inputs for the Sqrt component.
 
@@ -2087,7 +2087,7 @@ Inputs for the Sqrt component.
 </dd>
 </dl>
 
-### <span id="v1-sqrt-outs"></span> v1SqrtOuts
+### v1SqrtOuts {#v1-sqrt-outs}
 
 Outputs for the Sqrt component.
 

--- a/docs/tools/swagger/swagger-templates/config.gotmpl
+++ b/docs/tools/swagger/swagger-templates/config.gotmpl
@@ -216,7 +216,7 @@ any
 {{- range .Operations }}
  {{- $opname := .Name }}
 
-### <span id="{{ dasherize .Name }}"></span> *{{ .Name }}*
+### *{{ .Name }}* {# {{- dasherize .Name -}} }
 {{ if .Summary }}{{ printf "\n" }}{{ trimSpace .Summary }}{{ end }}
 
 
@@ -264,7 +264,7 @@ Type: {{ template "fnSchemaSimple" . }}
 ## Objects
 {{- range .Models }}
 
-### <span id="{{ dasherize .Name }}"></span> {{ .Name }}
+### {{ .Name }} {# {{- dasherize .Name -}} }
 {{ template "fnModel" . }}
 {{- end }}
 


### PR DESCRIPTION
We were providing custom heading ids, but the way it was done, was not
understood by docusaurus and docusaurus was generating its own ids anyway.

* Provide custom heading ids the way docusaurus expects it,
* update all heading-links.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/356)
<!-- Reviewable:end -->
