### PR TITLE
Rename request flow labels according to OTEL semantic conventions

### DIFF
--- a/docs/content/concepts/flow-control/label/classifier.md
+++ b/docs/content/concepts/flow-control/label/classifier.md
@@ -90,9 +90,9 @@ Aperture aims to expand the set of extractors to cover most-common usecases.
 
 Extracting value from header may seem not useful, as the value is already
 available as flow label
-([as `request_header_<header>`](label.md#request-labels)), but adding flow label
-explicitly may still be userful, as it enables baggage propagation and telemetry
-for this flow label.
+([as `http.request.header.<header>`](label.md#request-labels)), but adding flow
+label explicitly may still be userful, as it enables baggage propagation and
+telemetry for this flow label.
 
 :::
 

--- a/docs/content/concepts/flow-control/label/label.md
+++ b/docs/content/concepts/flow-control/label/label.md
@@ -25,11 +25,14 @@ baggage, flow classifiers and explicit labels from the Aperture library call.
 
 For each _traffic_ [control point][control-point] (where flows are http or grpc
 requests), some basic metadata is available as _request labels_. These are
-`request_id` , `request_method`, `request_path`, `request_host`,
-`request_scheme`, `request_size`, `request_protocol` (mapped from fields of
-[HttpRequest][authz-request-http]). Also, (non-pseudo) headers are available as
-`request_header_<headername>`, where `<headername>` is a headername normalised
-to lowercase, eg. `request_header_user-agent`.
+`http.method` , `http.target`, `http.host`, `http.scheme`,
+`http.request_content_length` and `http.flavor`. Additionally all (non-pseudo)
+headers are available as `http.request.header.header_name`, eg.
+`http.request.header.user_agent` (note the snake_case!). Values of these labels
+are described by [OpenTelemetry semantic conventions for HTTP
+spans][otel-conventions]. The only exception is `http.host` attribute, which is
+equal to Host/Authority header. This is thus similar to `net.peer.name` OTEL
+attribute, but is provided for both ingress and egress control points.
 
 ### Baggage
 
@@ -66,9 +69,8 @@ also takes an explicit `labels` map in the `Check()` call.
 
 ## Interaction with FluxNinja Cloud plugin {#plugin}
 
-All the flow labels except the request labels are used as labels of flow events.
-These events are rolled up and sent to the analytics database in the cloud. This
-allows:
+All the flow labels are used as labels of flow events. These events are rolled
+up and sent to the analytics database in the cloud. This allows:
 
 - for the flow labels to be used as filters,
 - to see analytics for each flow label, eg. distribution of its values.
@@ -97,9 +99,9 @@ select which labels to include in telemetry.
 [workload]: /concepts/flow-control/actuators/scheduler.md#workload
 [ratelimiter]: /concepts/flow-control/actuators/rate-limiter.md
 [fluxmeter]: /concepts/flow-control/fluxmeter.md
-[authz-request-http]:
-  https://github.com/envoyproxy/envoy/blob/637a92a56e2739b5f78441c337171968f18b46ee/api/envoy/service/auth/v3/attribute_context.proto#L102
 [baggage]: https://www.w3.org/TR/baggage/#baggage-http-header-format
 [traces]:
   https://opentelemetry.io/docs/concepts/observability-primer/#distributed-traces
 [control-point]: ../flow-control.md#control-point
+[otel-conventions]:
+  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md

--- a/pkg/policies/controlplane/validator_test.go
+++ b/pkg/policies/controlplane/validator_test.go
@@ -197,7 +197,7 @@ data:
                     priority: 200
                   label_matcher:
                     match_labels:
-                      request_header_user-type: "subscriber"
+                      http.request.header.user_type: "subscriber"
               out_ports:
                 accepted_concurrency:
                   signal_name: "ACCEPTED_CONCURRENCY"
@@ -345,6 +345,6 @@ const rateLimitPolicy = `
               service: "service1-demo-app.demoapp.svc.cluster.local"
               control_point:
                 traffic: "ingress"
-            label_key: "request_header_user-type"
+            label_key: "http.request.header.user_type"
             limit_reset_interval: "1s"
 `

--- a/pkg/selectors/labels.go
+++ b/pkg/selectors/labels.go
@@ -66,7 +66,7 @@ func (l Labels) CombinedWith(newLabels LabelSources) Labels {
 			labels[requestLabelPrefix+"host"] = http.Host
 			labels[requestLabelPrefix+"scheme"] = http.Scheme
 			labels[requestLabelPrefix+"request_content_length"] = strconv.FormatInt(http.Size, 10)
-			labels[requestLabelPrefix+"flavor"] = convertProtocol(http.Protocol)
+			labels[requestLabelPrefix+"flavor"] = CanonicalizeOtelHTTPFlavor(http.Protocol)
 		}
 		for k, v := range newLabels.Request.GetHttp().GetHeaders() {
 			if strings.HasPrefix(k, ":") {
@@ -76,20 +76,20 @@ func (l Labels) CombinedWith(newLabels LabelSources) Labels {
 				// Request.Http.
 				continue
 			}
-			labels[requestLabelHeaderPrefix+convertHeaderKey(k)] = v
+			labels[requestLabelHeaderPrefix+canonicalizeOtelHeaderKey(k)] = v
 		}
 	}
 
 	return Labels(labels)
 }
 
-// convertHeaderKey converts envoy's header naming convention to OTEL's one.
-func convertHeaderKey(key string) string {
+// canonicalizeOtelHeaderKey converts envoy's header naming convention to Otel's one.
+func canonicalizeOtelHeaderKey(key string) string {
 	return strings.ReplaceAll(key, "-", "_")
 }
 
-// convertProtocol converts envoy's protocol to OTEL kind of HTTP protocol.
-func convertProtocol(protocolName string) string {
+// CanonicalizeOtelHTTPFlavor converts envoy's protocol to Otel kind of HTTP protocol.
+func CanonicalizeOtelHTTPFlavor(protocolName string) string {
 	switch protocolName {
 	case "HTTP/1.0":
 		return "1.0"

--- a/pkg/selectors/labels_test.go
+++ b/pkg/selectors/labels_test.go
@@ -6,7 +6,7 @@ import (
 
 	ext_authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 
-	selectors "github.com/fluxninja/aperture/pkg/selectors"
+	"github.com/fluxninja/aperture/pkg/selectors"
 )
 
 var _ = Describe("Flow labels", func() {

--- a/pkg/selectors/labels_test.go
+++ b/pkg/selectors/labels_test.go
@@ -1,0 +1,45 @@
+package selectors_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ext_authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+
+	selectors "github.com/fluxninja/aperture/pkg/selectors"
+)
+
+var _ = Describe("Flow labels", func() {
+	It("should contain all the request labels with OTEL-compatible keys", func() {
+		req := &ext_authz.AttributeContext_Request{
+			Http: &ext_authz.AttributeContext_HttpRequest{
+				Id:     "123",
+				Method: "GET",
+				Headers: map[string]string{
+					"cache-control": "max-age=0",
+				},
+				Path:     "/foo/bar",
+				Host:     "example.com",
+				Scheme:   "https",
+				Size:     9000,
+				Protocol: "HTTP/2",
+			},
+		}
+		existingLabels := map[string]string{
+			"hello": "world",
+		}
+
+		labels := selectors.NewLabels(selectors.LabelSources{
+			Flow:    existingLabels,
+			Request: req,
+		})
+		Expect(labels).To(HaveKeyWithValue("hello", "world"))
+		Expect(labels).To(HaveKeyWithValue("http.method", "GET"))
+		Expect(labels).To(HaveKeyWithValue("http.target", "/foo/bar"))
+		Expect(labels).To(HaveKeyWithValue("http.host", "example.com"))
+		Expect(labels).To(HaveKeyWithValue("http.scheme", "https"))
+		Expect(labels).To(HaveKeyWithValue("http.request_content_length", "9000"))
+		Expect(labels).To(HaveKeyWithValue("http.flavor", "2.0"))
+		Expect(labels).To(HaveKeyWithValue("http.request.header.cache_control", "max-age=0"))
+	})
+})

--- a/pkg/selectors/selectors_suite_test.go
+++ b/pkg/selectors/selectors_suite_test.go
@@ -1,0 +1,13 @@
+package selectors_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSelectors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Selectors Suite")
+}

--- a/playground/tanka/apps/demoapp/mixins.libsonnet
+++ b/playground/tanka/apps/demoapp/mixins.libsonnet
@@ -44,11 +44,11 @@ local policy = latencyGradientPolicy({
     workloads: [
       WorkloadWithLabelMatcher.new(
         workload=Workload.withPriority(50),
-        label_matcher=LabelMatcher.withMatchLabels({ 'request_header_user-type': 'guest' })
+        label_matcher=LabelMatcher.withMatchLabels({ 'http.request.header.user_type': 'guest' })
       ),
       WorkloadWithLabelMatcher.new(
         workload=Workload.withPriority(200),
-        label_matcher=LabelMatcher.withMatchLabels({ 'request_header_user-type': 'subscriber' })
+        label_matcher=LabelMatcher.withMatchLabels({ 'http.request.header.user_type': 'subscriber' })
       ),
     ],
   },


### PR DESCRIPTION
Make labels to be consistent with OTEL semantics

Resolves #341 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/380)
<!-- Reviewable:end -->
