### PR TITLE
Expand top-level Flow Control concept

### DIFF
--- a/docs/content/concepts/flow-control/flow-control.md
+++ b/docs/content/concepts/flow-control/flow-control.md
@@ -11,24 +11,113 @@ keywords:
 # Flow Control
 
 Reliable operations at web-scale are impossible without effective flow control.
+Aperture splits the process of flow control in two layers:
 
-Aperture provides sophisticated flow control capabilities by locating Aperture
-Agents next to your service instances as a sidecar. Aperture Agents monitor
-golden signals using an in-built telemetry system and a programmable,
-high-fidelity flow classifier used to label requests based on attributes such as
-customer tier or request type. These metrics are analyzed by the controller.
-
-The Aperture Controller is powered by always-on, dataflow-driven policies that
-continuously track deviations from service-level objectives (SLOs) and calculate
-recovery or escalation actions. The policies running in the controller are
-expressed as circuits, much like circuit networks in the game Factorio.
+- Governing the flow control process and making high-level decisions. This is
+  done by Aperture Controller and controlled by _policies_. You can read more
+  about them in [the next chapter][policies].
+- Actual execution of flow control, performed by Aperture Agent via
+  [actuators][actuators]. The Agent also handles other flow-control related
+  tasks, like gathering metrics and classifying traffic. This will be the focus
+  of this chapter.
 
 ## What is a flow? {#flow}
 
 A flow is the fundamental unit of work from the perspective of an Aperture
 Agent. It could be an API call, a feature, or even a database query. A flow in
-Aperture is similar to
-[OpenTelemetry Span](https://opentelemetry.io/docs/reference/specification/trace/api/#span).
+Aperture is similar to [OpenTelemetry Span][span].
 
-Flow are observed and controlled by Aperture Agents by using data-plane
-components such as Classifiers, FluxMeters and Actuators.
+## Control points and services {#control-point}
+
+To describe where the flows are happening, Aperture divides the world into
+control points, located in services:
+
+:::info
+
+Aperture defines a service as a collection of entities delivering a common
+functionality, such as checkout, billing etc.
+[Read more on Service page](service.md).
+
+:::
+
+```mermaid
+graph LR
+  users(("users"))
+  subgraph Frontend Service
+    fingress["ingress"]
+    recommendations{{"recommendations"}}
+    live-update{{"live-update"}}
+    fegress["egress"]
+  end
+  subgraph Checkout Service
+    cingress["ingress"]
+    cegress["egress"]
+  end
+  subgraph Database Service
+    dbingress["ingress"]
+  end
+  users -.-> fingress
+  fegress -.-> cingress
+  cegress -.-> dbingress
+```
+
+There are two types of control points:
+
+- **Traffic** control points. Every incoming API request to a service is a flow
+  at its **ingress** control point. Likewise every outgoing request from a
+  service is a flow at its **egress** control point.
+
+- **Feature** control points. When using Aperture library, you can define
+  arbitrary piece of code as a feature and give it a name. In the example above,
+  frontend service defines two features: _recommendations_ and _live-update_.
+  Let's imagine that…
+  - …recommendations processing is heavyweight and slows down the frontend
+    service (or some other downstream service), thus we want to track its
+    execution time and perhaps conditionally disable recommendations via some
+    policy. This is the typical type of feature.
+  - …live-update feature “just” switches on auto-refresh flag for on-client code
+    – it's basically a boolean feature-flag. While there's no inherent
+    “processing” for this feature, enabling it have consequences to the system
+    (as the client will make more requests in the future). This is a bit less
+    common type of a feature, but still useful.
+
+:::note
+
+Control point definition doesn't care about which particular entity (like a pod)
+is handling particular flow. A single control point covers _all_ the entities
+belonging to the same service.
+
+:::
+
+## Integrations
+
+For Aperture to be able to act at any of the control points, you need to install
+integrations that will communicate with the Aperture Agent.
+
+- _Traffic_ control points: We provide integration istructions for
+  [Istio/Envoy][istio].
+
+  In principle, any web proxy or web framework could be integrated with Aperture
+  in this way, if it can use [Envoy's External Authorization API][ext-authz],
+  and will send appropriate telemetry.
+
+- _Feature_ control points: We provide [Aperture library][aperture-go] for the
+  Go programming language. More to come.
+
+  A library needs to be able to make `Check()` calls into FlowControl and also
+  send appropriate telemetry.
+
+:::note
+
+Exact instructions on custom proxies / web frameworks / library integrations
+will be added in the future.
+
+:::
+
+[policies]: ../policies/policies.md
+[actuators]: ./actuators/actuators.md
+[span]: https://opentelemetry.io/docs/reference/specification/trace/api/#span
+[istio]: /get-started/istio.md
+[ext-authz]:
+  https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto#authorization-service-proto
+[aperture-go]: https://github.com/FluxNinja/aperture-go

--- a/docs/content/concepts/flow-control/label/classifier.md
+++ b/docs/content/concepts/flow-control/label/classifier.md
@@ -20,19 +20,19 @@ the request attributes may look like.
 
 :::note
 
-At _feature_ control points developers already can provide arbitrary flow labels
-– either by setting baggage, or directly as arguments to the `Check()` call.
-Since at feature control points flow labels can be easily controlled,
-classifiers are available only on at _traffic_ control points.
+At _feature_ [control points][control-point] developers already can provide
+arbitrary flow labels – either by setting baggage, or directly as arguments to
+the `Check()` call. Since at feature control points flow labels can be easily
+controlled, classifiers are available only on at _traffic_ control points.
 
 :::
 
 Classifier-created flow label is immediately available for usage in other
-components at the same control point. The flow-label is also injected as
-baggage, so it will be available on every subsequent control point too (assuming
-you have [baggage propagation][baggage] configured in your system). If you're a
-[FluxNinja Cloud plugin][plugin] user, such flow label will also be available in
-the Cloud for analytics.
+components at the same [control point][control-point]. The flow-label is also
+injected as baggage, so it will be available on every subsequent control point
+too (assuming you have [baggage propagation][baggage] configured in your
+system). If you're a [FluxNinja Cloud plugin][plugin] user, such flow label will
+also be available in the Cloud for analytics.
 
 :::note
 
@@ -119,3 +119,4 @@ See [full example in reference][reference]
 [label-matcher]: ../selector.md#label-matcher
 [policies]: /concepts/policies/policies.md
 [rego]: https://www.openpolicyagent.org/docs/latest/policy-language/
+[control-point]: ../flow-control.md#control-point

--- a/docs/content/concepts/flow-control/label/label.md
+++ b/docs/content/concepts/flow-control/label/label.md
@@ -23,10 +23,10 @@ baggage, flow classifiers and explicit labels from the Aperture library call.
 
 ### Request labels
 
-For each _traffic_ control point (where flows are http or grpc requests), some
-basic metadata is available as _request labels_. These are `request_id` ,
-`request_method`, `request_path`, `request_host`, `request_scheme`,
-`request_size`, `request_protocol` (mapped from fields of
+For each _traffic_ [control point][control-point] (where flows are http or grpc
+requests), some basic metadata is available as _request labels_. These are
+`request_id` , `request_method`, `request_path`, `request_host`,
+`request_scheme`, `request_size`, `request_protocol` (mapped from fields of
 [HttpRequest][authz-request-http]). Also, (non-pseudo) headers are available as
 `request_header_<headername>`, where `<headername>` is a headername normalised
 to lowercase, eg. `request_header_user-agent`.
@@ -36,7 +36,8 @@ to lowercase, eg. `request_header_user-agent`.
 Baggage propagation is a powerful concept that allows attaching metadata to a
 whole request chain or to a whole [trace][traces]. If you already have baggage
 propagation configured in your system, you can access the baggage as flow
-labels. This is supported on both _traffic_ and _feature_ control points.
+labels. This is supported on both _traffic_ and _feature_ [control
+points][control-point].
 
 - _traffic_: Baggage is pulled from the [_baggage_][baggage] header,
 - _feature_: Baggage is automatically pulled from context on each `Check()`
@@ -101,3 +102,4 @@ TODO perhaps we should invert the default?
 [baggage]: https://www.w3.org/TR/baggage/#baggage-http-header-format
 [traces]:
   https://opentelemetry.io/docs/concepts/observability-primer/#distributed-traces
+[control-point]: ../flow-control.md#control-point


### PR DESCRIPTION
* Removed intro paragraphs (as they're already present in introduction).
* Explained how flow control splits between policies and dataplane components.
* Explained what are control points.

TODO:
* [ ] Fix inline mermaid diagram colors.
* [x] Link to control point explanation wherever we talk about control points.

(but these could be done in subsequent PRs)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/381)
<!-- Reviewable:end -->
