### PR TITLE
Fix sleep reference error in load test scenario

### DIFF
--- a/tools/load_generator/scenarios/load_test.js
+++ b/tools/load_generator/scenarios/load_test.js
@@ -1,5 +1,5 @@
 import http from "k6/http";
-import { check } from "k6";
+import { check, sleep } from "k6";
 import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
 
 export let vuStages = [


### PR DESCRIPTION
When loading the traffic using the load_test scenario scripts: `time="2022-09-08T16:41:23Z" level=error msg="ReferenceError: sleep is not defined\n\tat file:///test/load_test.js:48:10(54)\n\tat native\n" executor=ramping-vus scenario=guests source=stacktrace
`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/383)
<!-- Reviewable:end -->
