### PR TITLE
Disable ext_authz request body buffering by default

### DIFF
--- a/docs/content/concepts/flow-control/flow-classifier.md
+++ b/docs/content/concepts/flow-control/flow-classifier.md
@@ -75,6 +75,15 @@ Each classification rule consists of:
 There are two ways to specify a classification rule: using declarative
 extractors and [rego][rego] modules. [See examples in reference][rule].
 
+:::caution Request body availability
+
+Possibility of extracting values from request body depends on how [External
+Authorization in Envoy][ext-authz-extension] was configured. Sample [Istio
+Configuration][install-istio] provided by FluxNinja doesn't enable request body
+buffering by default, as it _might_ break some streaming APIs.
+
+:::
+
 ### Extractors ([reference][extractor]) {#extractors}
 
 Extractors are declarative recipes how to extract flow label value fom metadata.
@@ -114,6 +123,7 @@ language][rego].
 
 See [full example in reference][reference]
 
+[ext-authz-extension]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter#config-http-filters-ext-authz
 [ext-authz]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto#authorization-service-proto
 [attr-context]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto
 [rego-playground]: https://play.openpolicyagent.org/p/mG0sXxCNdQ
@@ -130,3 +140,4 @@ See [full example in reference][reference]
 [rego]: https://www.openpolicyagent.org/docs/latest/policy-language/
 [rego-kw]: https://www.openpolicyagent.org/docs/latest/policy-reference/#reserved-names
 [control-point]: /concepts/flow-control/flow-control.md#control-point
+[install-istio]: /get-started/installation/agent/envoy/istio.md

--- a/docs/content/get-started/installation/agent/envoy/istio.md
+++ b/docs/content/get-started/installation/agent/envoy/istio.md
@@ -243,9 +243,6 @@ Aperture Agent in Sidecar mode, use `localhost` as Target URL.
        typed_config:
          "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz"
          transport_api_version: V3
-         with_request_body:
-           max_request_bytes: 8192
-           allow_partial_message: true
          failure_mode_allow: true
          grpc_service:
            google_grpc:
@@ -290,9 +287,6 @@ Aperture Agent in Sidecar mode, use `localhost` as Target URL.
        typed_config:
          "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz"
          transport_api_version: V3
-         with_request_body:
-           max_request_bytes: 8192
-           allow_partial_message: true
          failure_mode_allow: true
          grpc_service:
            google_grpc:

--- a/manifests/charts/istioconfig/templates/envoy_filter.yaml
+++ b/manifests/charts/istioconfig/templates/envoy_filter.yaml
@@ -165,9 +165,6 @@ spec:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
           transport_api_version: V3
-          with_request_body:
-            max_request_bytes: {{ .Values.envoyFilter.maxRequestBytes }}
-            allow_partial_message: true
           failure_mode_allow: true
           grpc_service:
             google_grpc:
@@ -198,9 +195,6 @@ spec:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
           transport_api_version: V3
-          with_request_body:
-            max_request_bytes: {{ .Values.envoyFilter.maxRequestBytes }}
-            allow_partial_message: true
           failure_mode_allow: true
           grpc_service:
             google_grpc:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For checkboxing items, change [ ] to [x]. -->

- [x] Tested in playground or other setup
- [x] Documentation is changed or added
- [x] Breaking changes

<!-- _NOTE: these things are not required to open a PR and can be done afterward / while the PR is open._ -->

### Description of change

Ext authz's request body buffering was causing troubles with
client-streaming APIs, such as some ETCD apis used by Aperture Agent
(which communicates through envoy when deployed as sidecar). Disabling
request body buffering until we figure out a better solution.

Fixes https://github.com/fluxninja/cloud/issues/5862
See https://github.com/fluxninja/aperture/issues/479

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/480)
<!-- Reviewable:end -->
