### PR TITLE
Split scraping metrics for FN plugin

### DIFF
--- a/pkg/otel/config.go
+++ b/pkg/otel/config.go
@@ -248,7 +248,7 @@ func addPrometheusReceiver(cfg *otelParams) {
 	config.AddReceiver(ReceiverPrometheus, map[string]any{
 		"config": map[string]any{
 			"global": map[string]any{
-				"scrape_interval":     "1m",
+				"scrape_interval":     "1s",
 				"scrape_timeout":      "10s",
 				"evaluation_interval": "1m",
 			},
@@ -266,7 +266,7 @@ func addControllerPrometheusReceiver(config *otelcollector.OTELConfig, cfg *otel
 	config.AddReceiver(ReceiverPrometheus, map[string]any{
 		"config": map[string]any{
 			"global": map[string]any{
-				"scrape_interval":     "1m",
+				"scrape_interval":     "1s",
 				"scrape_timeout":      "10s",
 				"evaluation_interval": "1m",
 			},
@@ -295,9 +295,8 @@ func buildApertureSelfScrapeConfig(name string, cfg *otelParams) map[string]any 
 		"tls_config": map[string]any{
 			"insecure_skip_verify": true,
 		},
-		"scrape_interval": "1s",
-		"scrape_timeout":  "900ms",
-		"metrics_path":    "/metrics",
+		"scrape_timeout": "900ms",
+		"metrics_path":   "/metrics",
 		"static_configs": []map[string]any{
 			{
 				"targets": []string{cfg.listener.GetAddr()},
@@ -312,11 +311,10 @@ func buildApertureSelfScrapeConfig(name string, cfg *otelParams) map[string]any 
 
 func buildKubernetesNodesScrapeConfig(cfg *otelParams) map[string]any {
 	return map[string]any{
-		"job_name":        "kubernetes-nodes",
-		"scheme":          "https",
-		"scrape_interval": "2s",
-		"scrape_timeout":  "1500ms",
-		"metrics_path":    "/metrics/cadvisor",
+		"job_name":       "kubernetes-nodes",
+		"scheme":         "https",
+		"scrape_timeout": "1500ms",
+		"metrics_path":   "/metrics/cadvisor",
 		"authorization": map[string]any{
 			"credentials_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
 		},
@@ -351,11 +349,10 @@ func buildKubernetesNodesScrapeConfig(cfg *otelParams) map[string]any {
 
 func buildKubernetesPodsScrapeConfig(cfg *otelParams) map[string]any {
 	return map[string]any{
-		"job_name":        "kubernetes-pods",
-		"scheme":          "http",
-		"scrape_interval": "2s",
-		"scrape_timeout":  "1500ms",
-		"metrics_path":    "/metrics",
+		"job_name":       "kubernetes-pods",
+		"scheme":         "http",
+		"scrape_timeout": "1500ms",
+		"metrics_path":   "/metrics",
 		"kubernetes_sd_configs": []map[string]any{
 			{"role": "pod"},
 		},

--- a/plugins/service/aperture-plugin-fluxninja/otel/otel_test.go
+++ b/plugins/service/aperture-plugin-fluxninja/otel/otel_test.go
@@ -92,27 +92,27 @@ var _ = DescribeTable("FN Plugin OTEL", func(
 	Entry(
 		"add FN processors and exporters",
 		otelcollector.NewOTELConfig(),
-		baseOTELConfig(),
+		basePluginOTELConfig(),
 	),
 	Entry(
 		"add FN exporters to logs pipeline",
 		baseOTELConfigWithPipeline("logs", testPipeline()),
-		baseOTELConfigWithPipeline("logs", testPipelineWithFN()),
+		basePluginOTELConfigWithPipeline("logs", testPipelineWithFN()),
 	),
 	Entry(
 		"add FN exporters to traces pipeline",
 		baseOTELConfigWithPipeline("traces", testPipeline()),
-		baseOTELConfigWithPipeline("traces", testPipelineWithFN()),
+		basePluginOTELConfigWithPipeline("traces", testPipelineWithFN()),
 	),
 	Entry(
 		"add metrics/slow pipeline if metrics/fast pipeline exists",
 		baseOTELConfigWithPipeline("metrics/fast", testPipeline()),
-		baseOTELConfigWithMetrics("metrics/slow"),
+		basePluginOTELConfigWithMetrics("metrics/slow"),
 	),
 	Entry(
 		"add metrics/controller-slow pipeline if metrics/controller-fast pipeline exists",
 		baseOTELConfigWithPipeline("metrics/controller-fast", testPipeline()),
-		baseOTELConfigWithMetrics("metrics/controller-slow"),
+		basePluginOTELConfigWithMetrics("metrics/controller-slow"),
 	),
 )
 
@@ -122,8 +122,23 @@ func baseOTELConfigWithPipeline(name string, pipeline otelcollector.Pipeline) *o
 	return cfg
 }
 
-func baseOTELConfigWithMetrics(pipelineName string) *otelcollector.OTELConfig {
-	cfg := baseOTELConfig()
+func basePluginOTELConfigWithPipeline(name string, pipeline otelcollector.Pipeline) *otelcollector.OTELConfig {
+	cfg := basePluginOTELConfig()
+	cfg.Service.AddPipeline(name, pipeline)
+	return cfg
+}
+
+func basePluginOTELConfigWithMetrics(pipelineName string) *otelcollector.OTELConfig {
+	cfg := basePluginOTELConfig()
+	cfg.AddReceiver("prometheus/fluxninja", map[string]any{
+		"config": map[string]any{
+			"global": map[string]any{
+				// Here is different scrape interval than in the base otel config.
+				"scrape_interval": "10s",
+			},
+			"scrape_configs": []string{"foo", "bar"},
+		},
+	})
 	cfg.AddProcessor("batch/metrics-slow", batchprocessor.Config{
 		SendBatchSize: 10000,
 		Timeout:       10 * time.Second,
@@ -136,7 +151,7 @@ func baseOTELConfigWithMetrics(pipelineName string) *otelcollector.OTELConfig {
 		processors = append([]string{"enrichment"}, processors...)
 	}
 	cfg.Service.AddPipeline(pipelineName, otelcollector.Pipeline{
-		Receivers:  []string{"prometheus"},
+		Receivers:  []string{"prometheus/fluxninja"},
 		Processors: processors,
 		Exporters:  []string{"otlp/fluxninja"},
 	})
@@ -144,6 +159,21 @@ func baseOTELConfigWithMetrics(pipelineName string) *otelcollector.OTELConfig {
 }
 
 func baseOTELConfig() *otelcollector.OTELConfig {
+	cfg := otelcollector.NewOTELConfig()
+	cfg.AddReceiver("prometheus", map[string]any{
+		"config": map[string]any{
+			"global": map[string]any{
+				"scrape_interval": "1s",
+			},
+			// Put some scrape configs to be sure they are not overwritten.
+			"scrape_configs": []string{"foo", "bar"},
+		},
+	})
+	return cfg
+}
+
+// basePluginOTELConfig as produced by FN plugin
+func basePluginOTELConfig() *otelcollector.OTELConfig {
 	cfg := otelcollector.NewOTELConfig()
 	cfg.AddProcessor("attributes/fluxninja", map[string]interface{}{
 		"actions": []map[string]interface{}{


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For checkboxing items, change [ ] to [x]. -->

- [x] Tested in playground or other setup
- [x] Documentation is changed or added
- [x] Tests and/or benchmarks are included
- [x] Breaking changes

<!-- _NOTE: these things are not required to open a PR and can be done afterward / while the PR is open._ -->

### Description of change
Metrics scraped by prometheus have sampling rate determined by the scrape interval.
We don't want to send high sampled metrics to the FN Cloud, so in the plugin now duplicates the scraping config and changes the scrape interval.

This PR also changes the base scrape config to use only globally set scrape interval, instead of specyfing it per scrape target.

<!-- Please provide a description of the change here. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/481)
<!-- Reviewable:end -->
