### PR TITLE
position change for installation and playground

### DIFF
--- a/docs/content/get-started/installation/_category_.yml
+++ b/docs/content/get-started/installation/_category_.yml
@@ -1,5 +1,5 @@
 label: Installation
-position: 1
+position: 2
 collapsible: true
 collapsed: true
 link:

--- a/docs/content/get-started/playground.md
+++ b/docs/content/get-started/playground.md
@@ -6,7 +6,7 @@ keywords:
   - policies
   - rate limit
   - concurrency control
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 Playground is a Kubernetes based environment for exploring the capabilities of
@@ -31,6 +31,7 @@ Playground is currently not supported on Apple Silicon (e.g. M1 processor) becau
 Assuming that you have already cloned the aperture repository and brought up a [local Kubernetes cluster](#prerequisites-k8s), proceed to install the [required tools](#tools). In order to bring up the Playground, run the following commands:
 
 ```sh
+$ git clone https://github.com/fluxninja/aperture.git
 # change directory to playground
 $ cd playground
 # start Tilt and run services defined in Tiltfile


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For checkboxing items, change [ ] to [x]. -->

- [x] Documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterward / while the PR is open._ -->

### Description of change

<!-- Please provide a description of the change here. -->
Reversed the position of Installation and Playground. Now Playground will be first and Installation will be second. 
cc @jaidesai-fn

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/526)
<!-- Reviewable:end -->
