### PR TITLE
Added Init containers for Etcd and Prometheus in controller

### DIFF
--- a/manifests/charts/aperture-controller/templates/controller.yaml
+++ b/manifests/charts/aperture-controller/templates/controller.yaml
@@ -123,8 +123,41 @@ spec:
   {{- if .Values.controller.sidecars }}
   sidecars: {{ .Values.controller.sidecars | toYaml | nindent 4 }}
   {{- end }}
-  {{- if .Values.controller.initContainers }}
-  initContainers: {{ .Values.controller.initContainers | toYaml | nindent 4 }}
+  {{- if or .Values.controller.initContainers .Values.etcd.enabled .Values.prometheus.enabled }}
+  initContainers:
+    {{- if .Values.etcd.enabled }}
+    - name: wait-for-etcd
+      image: bitnami/etcd:3.5
+      command:
+        - 'sh'
+        - '-c'
+        - >
+          while (etcdctl --endpoints $(yq -r '.etcd.endpoints[]' /etc/aperture/aperture-controller/config/aperture-controller.yaml) endpoint health); res=$?; [ $res != 0 ]; do
+            echo "Waiting for Etcd to be Healthy";
+          done;
+          echo "Etcd is healthy."
+      volumeMounts:
+        - mountPath: /etc/aperture/aperture-controller/config
+          name: aperture-controller-config
+    {{- end }}
+    {{- if .Values.prometheus.enabled }}
+    - name: wait-for-prometheus
+      image: bitnami/etcd:3.5
+      command:
+        - 'sh'
+        - '-c'
+        - >
+          while [ "$(curl -s -o /dev/null -w '%{http_code}' $(yq -r '.prometheus.address' /etc/aperture/aperture-controller/config/aperture-controller.yaml)/-/ready)" != "200" ] ; do
+            echo "Waiting for Prometheus to be Ready"; sleep 2;
+          done;
+          echo "Prometheus is ready."
+      volumeMounts:
+        - mountPath: /etc/aperture/aperture-controller/config
+          name: aperture-controller-config
+    {{- end }}
+    {{- if .Values.controller.initContainers }}
+    {{ .Values.controller.initContainers | toYaml | nindent 4 }}
+    {{- end }}
   {{- end }}
   {{- if .Values.commonLabels }}
   labels: {{ .Values.commonLabels | toYaml | nindent 4 }}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For checkboxing items, change [ ] to [x]. -->

- [x] Tested in playground or other setup

<!-- _NOTE: these things are not required to open a PR and can be done afterward / while the PR is open._ -->

### Description of change

<!-- Please provide a description of the change here. -->
Added Init containers to check the health of embedded Etcd and Prometheus before starting the Controller container.to prevent unwanted controller pod restarts.

Fixes https://github.com/fluxninja/cloud/issues/5304

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/551)
<!-- Reviewable:end -->
