### PR TITLE
add git branch and git commit hash for docker build

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -667,6 +667,14 @@ commands:
         description: |
           Which ssh socket to forward to the docker build process
         type: string
+      git-branch:
+        type: string
+        description: Use the name of the current branch been used for Image build
+        default: ${CIRCLE_BRANCH}
+      git-commit-hash:
+        type: string
+        description: Use the hash of the current commit.
+        default: ${CIRCLE_SHA1}
     steps:
       - when:
           condition: <<parameters.lint-dockerfile>>
@@ -697,6 +705,8 @@ commands:
             PARAM_TAG: <<parameters.tag>>
             PARAM_USE_BUILDKIT: <<parameters.use-buildkit>>
             PARAM_SSH_FORWARD: <<parameters.ssh>>
+            PARAM_GIT_BRANCH: <<parameters.git-branch>>
+            PARAM_GIT_COMMIT_HASH: <<parameters.git-commit-hash>>
           name: <<parameters.step-name>>
           no_output_timeout: << parameters.no_output_timeout >>
   aperture_docker_tag:

--- a/.circleci/scripts/docker_build.sh
+++ b/.circleci/scripts/docker_build.sh
@@ -50,6 +50,8 @@ fi
 build_args=(
     "--file=$PARAM_DOCKERFILE_PATH/$PARAM_DOCKERFILE_NAME"
     "$DOCKER_TAGS_ARG"
+    "--build-arg=$PARAM_GIT_BRANCH"
+    "--build-arg=$PARAM_GIT_COMMIT_HASH"
 )
 
 if [ -n "$PARAM_SSH_FORWARD" ]; then


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For checkboxing items, change [ ] to [x]. -->

- [x] Tested in playground or other setup
- [x] Documentation is changed or added


<!-- _NOTE: these things are not required to open a PR and can be done afterward / while the PR is open._ -->

### Description of change

<!-- Please provide a description of the change here. -->

When we are building binaries `GIT_BRANCH` and `GIT_COMMIT_HASH` are missing from binaries and Docker images. 
I saw that both the field are passed as ENV when we run [CI](https://github.com/fluxninja/aperture/blob/main/.circleci/config.yml#L134) to build the binaries. But the same data is missing from the Docker build . So I have added it as the ARG using `--build-arg` flag when we are building the docker image when running the CI. 

Fixes https://github.com/fluxninja/cloud/issues/5286


cc @sbienkow-ninja , @kwapik 