### PR TITLE
Fixed controller init container image issue

### DIFF
--- a/manifests/charts/aperture-controller/README.md
+++ b/manifests/charts/aperture-controller/README.md
@@ -165,17 +165,27 @@
 
 ### etcd
 
-| Name                    | Description                                                  | Value    |
-| ----------------------- | ------------------------------------------------------------ | -------- |
-| `etcd.enabled`          | Whether to deploy a small etcd cluster as part of this chart | `true`   |
-| `etcd.auth.rbac.create` | specifies whether to create the RBAC resources for Etcd      | `false`  |
-| `etcd.auth.token.type`  | specifies the type of token to use                           | `simple` |
+| Name                                  | Description                                                                            | Value               |
+| ------------------------------------- | -------------------------------------------------------------------------------------- | ------------------- |
+| `etcd.enabled`                        | Whether to deploy a small etcd cluster as part of this chart                           | `true`              |
+| `etcd.auth.rbac.create`               | specifies whether to create the RBAC resources for Etcd                                | `false`             |
+| `etcd.auth.token.type`                | specifies the type of token to use                                                     | `simple`            |
+| `etcd.initContainer.enabled`          | Create init container to check the health of Etcd before starting Aperture Controller. | `true`              |
+| `etcd.initContainer.image.registry`   | Init container image registry.                                                         | `docker.io/bitnami` |
+| `etcd.initContainer.image.repository` | Init container image repository.                                                       | `etcd`              |
+| `etcd.initContainer.image.tag`        | Init container image tag.                                                              | `3.5`               |
+| `etcd.initContainer.image.pullPolicy` | Init container image pull policy.                                                      | `IfNotPresent`      |
 
 
 ### prometheus
 
-| Name                 | Description                                     | Value  |
-| -------------------- | ----------------------------------------------- | ------ |
-| `prometheus.enabled` | specifies whether to deploy embedded prometheus | `true` |
+| Name                                        | Description                                                                                     | Value                   |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------- |
+| `prometheus.enabled`                        | specifies whether to deploy embedded prometheus                                                 | `true`                  |
+| `prometheus.initContainer.enabled`          | Create init container to check the readiness of Prometheus before starting Aperture Controller. | `true`                  |
+| `prometheus.initContainer.image.registry`   | Init container image registry.                                                                  | `docker.io/linuxserver` |
+| `prometheus.initContainer.image.repository` | Init container image repository.                                                                | `yq`                    |
+| `prometheus.initContainer.image.tag`        | Init container image tag.                                                                       | `3.1.0`                 |
+| `prometheus.initContainer.image.pullPolicy` | Init container image pull policy.                                                               | `IfNotPresent`          |
 
 

--- a/manifests/charts/aperture-controller/templates/controller.yaml
+++ b/manifests/charts/aperture-controller/templates/controller.yaml
@@ -122,9 +122,10 @@ spec:
   {{- end }}
   {{- if or .Values.controller.initContainers .Values.etcd.enabled .Values.prometheus.enabled }}
   initContainers:
-    {{- if .Values.etcd.enabled }}
+    {{- if and .Values.etcd.enabled .Values.etcd.initContainer.enabled }}
     - name: wait-for-etcd
-      image: bitnami/etcd:3.5
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.etcd.initContainer.image "global" .Values.global) }}
+      imagePullPolicy: {{ .Values.etcd.initContainer.image.pullPolicy }}
       command:
         - 'sh'
         - '-c'
@@ -137,9 +138,10 @@ spec:
         - mountPath: /etc/aperture/aperture-controller/config
           name: aperture-controller-config
     {{- end }}
-    {{- if .Values.prometheus.enabled }}
+    {{- if and .Values.prometheus.enabled .Values.prometheus.initContainer.enabled }}
     - name: wait-for-prometheus
-      image: bitnami/etcd:3.5
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.prometheus.initContainer.image "global" .Values.global) }}
+      imagePullPolicy: {{ .Values.prometheus.initContainer.image.pullPolicy }}
       command:
         - 'sh'
         - '-c'

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -531,9 +531,22 @@ controller:
 ## @param etcd.enabled Whether to deploy a small etcd cluster as part of this chart
 ## @param etcd.auth.rbac.create specifies whether to create the RBAC resources for Etcd
 ## @param etcd.auth.token.type specifies the type of token to use
+## @param etcd.initContainer.enabled Create init container to check the health of Etcd before starting Aperture Controller.
+## @param etcd.initContainer.image.registry Init container image registry.
+## @param etcd.initContainer.image.repository Init container image repository.
+## @param etcd.initContainer.image.tag Init container image tag.
+## @param etcd.initContainer.image.pullPolicy Init container image pull policy.
+##
 ##
 etcd:
   enabled: true
+  initContainer:
+    enabled: true
+    image:
+      registry: docker.io/bitnami
+      repository: etcd
+      tag: 3.5
+      pullPolicy: IfNotPresent
   auth:
     rbac:
       create: false
@@ -542,6 +555,11 @@ etcd:
 
 ## @section prometheus
 ## @param prometheus.enabled specifies whether to deploy embedded prometheus
+## @param prometheus.initContainer.enabled Create init container to check the readiness of Prometheus before starting Aperture Controller.
+## @param prometheus.initContainer.image.registry Init container image registry.
+## @param prometheus.initContainer.image.repository Init container image repository.
+## @param prometheus.initContainer.image.tag Init container image tag.
+## @param prometheus.initContainer.image.pullPolicy Init container image pull policy.
 ## @skip prometheus.server
 ## @skip prometheus.alertmanager
 ## @skip prometheus.nodeExporter
@@ -551,6 +569,13 @@ etcd:
 ##
 prometheus:
   enabled: true
+  initContainer:
+    enabled: true
+    image:
+      registry: docker.io/linuxserver
+      repository: yq
+      tag: 3.1.0
+      pullPolicy: IfNotPresent
   server:
     image:
       tag: v2.33.5


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For checkboxing items, change [ ] to [x]. -->

- [x] Tested in playground or other setup

<!-- _NOTE: these things are not required to open a PR and can be done afterward / while the PR is open._ -->

### Description of change

<!-- Please provide a description of the change here. -->
Used a different image for Prometheus readiness check as the earlier one was updated last night and `curl` was removed from it.
Have made the images and init containers configurable so that user can also change the images if they want to.

Fixes #658

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/659)
<!-- Reviewable:end -->
