### PR TITLE
Fix agent_group population in logs

### DIFF
--- a/cmd/aperture-agent/agent/otel-component.go
+++ b/cmd/aperture-agent/agent/otel-component.go
@@ -130,11 +130,11 @@ func addLogsPipeline(cfg *otelcollector.OtelParams) {
 	config.AddExporter(otelcollector.ExporterLogging, nil)
 
 	processors := []string{
-		otelcollector.ProcessorAgentGroup,
 		otelcollector.ProcessorMetrics,
 		otelcollector.ProcessorBatchPrerollup,
 		otelcollector.ProcessorRollup,
 		otelcollector.ProcessorBatchPostrollup,
+		otelcollector.ProcessorAgentGroup,
 	}
 
 	config.Service.AddPipeline("logs", otelcollector.Pipeline{


### PR DESCRIPTION


<!--
Thank you for your pull request. Please provide a description and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist

<!-- Remove items that do not apply. For checkboxing items, change [ ] to [x]. -->

- [x] Tested in playground or other setup

<!-- _NOTE: these things are not required to open a PR and can be done afterward / while the PR is open._ -->

### Description of change
The Agent Group Processor was misplaced before the metrics processor, which was filtering out the `agent_group` attribute.
<!-- Please provide a description of the change here. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/700)
<!-- Reviewable:end -->
