### PR TITLE
Add .dockerignore and use caching in operator Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,8 @@ workflows:
           base-revision: << pipeline.git.base_revision >>
           config-path: .circleci/continue-workflows.yml
           mapping: |
-            (cmd|pkg|plugins|api)/.* updated-aperture true
+            .dockerignore updated-aperture true
+            (cmd|pkg|plugins|api|test)/.* updated-aperture true
             operator/(api|config|controllers|hack)/.*|operator/main.go updated-aperture-operator true
             (go.mod|go.sum) updated-aperture true
             docs/.* updated-aperture-docs true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+!go.???
+!cmd
+!pkg
+!plugins
+!api
+!operator
+!tools

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,22 +1,13 @@
-# Build the manager binary
+# syntax=docker/dockerfile:1
 FROM golang:1.19 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+COPY --link . .
+ENV GOPRIVATE=github.com/aperture-control,github.com/fluxninja
 
-# Copy the go source
-COPY api/ api/
-COPY operator/ operator/
-COPY pkg/ pkg/
-COPY plugins/ plugins/
-
-# Build
-RUN CGO_ENABLED=0 go build -a -o aperture-operator operator/main.go
+RUN --mount=type=cache,target=/go/pkg/ \
+    --mount=type=cache,target=/root/.cache/go-build/ \
+    CGO_ENABLED=0 go build -a -o aperture-operator operator/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -106,6 +106,7 @@ DEP_TREE = {
                     "context": GIT_ROOT,
                     "dockerfile": GIT_ROOT + "/operator/Dockerfile",
                     "ssh": "default",
+                    "ignore": ["cmd"],
                 }
             ],
             "port_forwards": {
@@ -198,6 +199,7 @@ DEP_TREE = {
                     "context": GIT_ROOT,
                     "dockerfile": GIT_ROOT + "/cmd/aperture-agent/Dockerfile",
                     "ssh": "default",
+                    "ignore": ["operator"],
                 }
             ],
             "kinds": [
@@ -286,6 +288,7 @@ DEP_TREE = {
                     "context": GIT_ROOT,
                     "dockerfile": GIT_ROOT + "/tools/demo_app/Dockerfile",
                     "ssh": "default",
+                    "ignore": ["operator", "plugins", "cmd"],
                 }
             ],
             "child_resources": [


### PR DESCRIPTION
This should avoid spurious rebuilds in Tilt caused by stray files.
It definitely made Tilt less sluggish on my machine.

* Added .dockerignore.
* Added it to path-filtering mapping, to ensure everything still builds.
* Added `test` subdir to updated-aperture triggers, I guess it was missing.
* In addition to .dockerignore, ignored `operator` dir for agent and  demoapp (operator is for some reason > 1MB and bloats the docker  context).
* Use caching in operator Dockerfile (as we do in other Dockerfiles).