### PR TITLE
scheduler: default to non continuousTracking behavior for load shed t…

### DIFF
--- a/pkg/policies/dataplane/actuators/concurrency/auto-tokens.go
+++ b/pkg/policies/dataplane/actuators/concurrency/auto-tokens.go
@@ -109,12 +109,12 @@ func (atFactory *autoTokensFactory) newAutoTokens(
 // autoTokens struct tokens per workload.
 type autoTokens struct {
 	mutex                 sync.RWMutex
-	tokensDecision        *policydecisionsv1.TokensDecision
 	tokensDecisionWatcher notifiers.Watcher
+	registry              status.Registry
+	tokensDecision        *policydecisionsv1.TokensDecision
 	policyName            string
 	policyHash            string
 	componentIdx          int64
-	registry              status.Registry
 }
 
 func (at *autoTokens) tokenUpdateCallback(event notifiers.Event, unmarshaller config.Unmarshaller) {

--- a/pkg/policies/dataplane/actuators/concurrency/load-shed-actuator.go
+++ b/pkg/policies/dataplane/actuators/concurrency/load-shed-actuator.go
@@ -197,8 +197,8 @@ func (lsaFactory *loadShedActuatorFactory) newLoadShedActuator(conLimiter *concu
 				},
 			}
 
-			// Initialize the token bucket
-			lsa.tokenBucketLoadShed = scheduler.NewTokenBucketLoadShed(clock.Now(), tokenBucketMetrics, 10, time.Second)
+			// Initialize the token bucket (non continuous tracking mode)
+			lsa.tokenBucketLoadShed = scheduler.NewTokenBucketLoadShed(clock.Now(), 10, time.Second, tokenBucketMetrics)
 
 			err = lsaFactory.loadShedDecisionWatcher.AddKeyNotifier(decisionNotifier)
 			if err != nil {

--- a/pkg/policies/dataplane/actuators/concurrency/scheduler/token-bucket.go
+++ b/pkg/policies/dataplane/actuators/concurrency/scheduler/token-bucket.go
@@ -18,10 +18,10 @@ type TokenBucketMetrics struct {
 type tokenBucketBase struct {
 	// Token Bucket
 	latestTime      time.Time // Latest time for which we know the tokens in the bucket
-	fillRate        float64   // Tokens added per second
-	bucketCapacity  float64   // Overall capacity of the bucket, currently the same as fillRate
-	availableTokens float64   // Available Tokens as of latestTime (can be a negative or a fractional number)
 	metrics         *TokenBucketMetrics
+	fillRate        float64 // Tokens added per second
+	bucketCapacity  float64 // Overall capacity of the bucket, currently the same as fillRate
+	availableTokens float64 // Available Tokens as of latestTime (can be a negative or a fractional number)
 }
 
 func (tbb *tokenBucketBase) setFillRateGauge(v float64) {
@@ -113,8 +113,8 @@ func (tbb *tokenBucketBase) getFillRate() float64 {
 
 // BasicTokenBucket is a basic token bucket implementation.
 type BasicTokenBucket struct {
-	tbb  *tokenBucketBase
 	lock sync.Mutex
+	tbb  *tokenBucketBase
 }
 
 // NewBasicTokenBucket creates a new BasicTokenBucket with adjusted fill rate.

--- a/pkg/policies/dataplane/actuators/concurrency/scheduler/wfq_test.go
+++ b/pkg/policies/dataplane/actuators/concurrency/scheduler/wfq_test.go
@@ -256,7 +256,8 @@ func BenchmarkTokenBucketLoadShed(b *testing.B) {
 	}
 	c := clockwork.NewRealClock()
 	startTime := c.Now()
-	manager := NewTokenBucketLoadShed(startTime, getMetrics(), _testSlotCount, _testSlotDuration)
+	manager := NewTokenBucketLoadShed(startTime, _testSlotCount, _testSlotDuration, getMetrics())
+	manager.SetContinuousTracking(true)
 	manager.SetLoadShedFactor(startTime, 1.0)
 
 	timeout := 5 * time.Millisecond
@@ -544,7 +545,8 @@ func TestLoadShedBucket(t *testing.T) {
 	c := clockwork.NewFakeClock()
 	go updateClock(t, c, timeout, flows)
 
-	loadShedBucket := NewTokenBucketLoadShed(c.Now(), getMetrics(), _testSlotCount, _testSlotDuration)
+	loadShedBucket := NewTokenBucketLoadShed(c.Now(), _testSlotCount, _testSlotDuration, getMetrics())
+	loadShedBucket.SetContinuousTracking(true)
 	sched := NewWFQScheduler(timeout, loadShedBucket, c, schedMetrics)
 
 	trainAndDeplete := func() {
@@ -595,7 +597,8 @@ func TestPanic(t *testing.T) {
 
 	c := clockwork.NewRealClock()
 	startTime := c.Now()
-	manager := NewTokenBucketLoadShed(startTime, getMetrics(), _testSlotCount, _testSlotDuration)
+	manager := NewTokenBucketLoadShed(startTime, _testSlotCount, _testSlotDuration, getMetrics())
+	manager.SetContinuousTracking(true)
 	manager.SetLoadShedFactor(startTime, 0.5)
 	if manager.LoadShedFactor() != 0.5 {
 		t.Logf("LoadShedFactor is not 0.5\n")


### PR DESCRIPTION
…oken bucket

### Description of change
Allows snapshoting token fill rates based on current window counter as and when controller published load shed decisions instead of continuous updates on future window counter expiry.

##### Checklist

- [X] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/747)
<!-- Reviewable:end -->
