### PR TITLE
Start checking for plugin build errors in Dockerfiles 🙃

### DIFF
--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -28,13 +28,15 @@ FROM base AS plugins-builder
 # Plugins build
 RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.cache/go-build/ \
-  /bin/bash -c 'shopt -s nullglob; for plugin in ./plugins/{service,agent}/aperture-plugin-*; do\
-  echo "building plugin $plugin";\
-  CGO_ENABLED=1 TARGET="/plugins/$(basename $plugin).so" PREFIX="aperture" SOURCE="$plugin" LDFLAGS="-s -w" \
-  ./pkg/plugins/build.sh;\
+  /bin/bash -c \
+  'set -euo pipefail; \
+  shopt -s nullglob; \
+  for plugin in ./plugins/{service,agent}/aperture-plugin-*; do\
+    echo "building plugin $plugin";\
+    CGO_ENABLED=1 TARGET="/plugins/$(basename $plugin).so" PREFIX="aperture" SOURCE="$plugin" LDFLAGS="-s -w" \
+    ./pkg/plugins/build.sh;\
   done\
   '
-
 
 # Final image
 FROM alpine:3.15.0

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -27,10 +27,13 @@ RUN --mount=type=cache,target=/go/pkg/ \
 FROM base AS plugins-builder
 RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.cache/go-build/ \
-  /bin/bash -c 'shopt -s nullglob; for plugin in ./plugins/{service,controller}/aperture-plugin-*; do\
-  echo "building plugin $plugin";\
-  CGO_ENABLED=1 TARGET="/plugins/$(basename $plugin).so" PREFIX="aperture" SOURCE="$plugin" LDFLAGS="-s -w" \
-  ./pkg/plugins/build.sh;\
+  /bin/bash -c \
+  'set -euo pipefail; \
+  shopt -s nullglob; \
+  for plugin in ./plugins/{service,controller}/aperture-plugin-*; do\
+    echo "building plugin $plugin";\
+    CGO_ENABLED=1 TARGET="/plugins/$(basename $plugin).so" PREFIX="aperture" SOURCE="$plugin" LDFLAGS="-s -w" \
+      ./pkg/plugins/build.sh;\
   done\
   '
 

--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -199,7 +199,6 @@ DEP_TREE = {
                     "context": GIT_ROOT,
                     "dockerfile": GIT_ROOT + "/cmd/aperture-agent/Dockerfile",
                     "ssh": "default",
-                    "ignore": ["operator"],
                 }
             ],
             "kinds": [


### PR DESCRIPTION
Also, removed the "operator" ignore (introduced in #744) from agent in playground Tiltfile
– looks like this is actually needed by plugin.

Interestingly, playground wasn't broken due to failed plugin build, as the
plugin isn't needed there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/753)
<!-- Reviewable:end -->
