### PR TITLE
Stop watching code directly from Tiltfile

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -986,16 +986,12 @@ resources = get_resource_list_to_deploy(to_run, run_only_listed, DEP_TREE, inver
 
 print("Will deploy resources:", ", ".join(resources))
 
-# Watch charts and code
+# Watch charts and crd definitions
 watch_file("Tiltfile")
 watch_file("./tanka/apps/")
 watch_file("./tanka/lib/")
 watch_file("./tanka/charts/")
-watch_file(GIT_ROOT + "/api/")
-watch_file(GIT_ROOT + "/cmd/")
-watch_file(GIT_ROOT + "/pkg/")
-watch_file(GIT_ROOT + "/plugins/")
-watch_file(GIT_ROOT + "/operator/")
+watch_file(GIT_ROOT + "/operator/config/crd")
 
 
 run_wavepool_generator = '''


### PR DESCRIPTION
### Description of change

This should help avoid refreshing the "(Tiltfile)" resource on code
changes (which happens even in manual mode!).

Watching code changes are handled by docker image watchers, so directly
watching these files is not necessary.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/755)
<!-- Reviewable:end -->
