### PR TITLE
Switched to SSH instead of HTTP for GitHub operations

### DIFF
--- a/.circleci/scripts/helm_release.sh
+++ b/.circleci/scripts/helm_release.sh
@@ -4,12 +4,12 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/fluxninja/aperture.git"
+REPO_URL="git@github.com:fluxninja/aperture.git"
 BRANCH="gh-pages"
 TARGET_DIR="."
 INDEX_DIR="."
 CHARTS_URL="https://fluxninja.github.io/aperture/"
-COMMIT_EMAIL="${CIRCLE_PROJECT_USERNAME}@users.noreply.github.com"
+COMMIT_EMAIL="ops@fluxninja.com"
 
 CHARTS=()
 CHARTS_TMP_DIR=$(mktemp -d)
@@ -79,7 +79,6 @@ upload(){
   cd aperture
   git config user.name "${CIRCLE_PROJECT_USERNAME}"
   git config user.email "${COMMIT_EMAIL}"
-  git remote set-url origin "${REPO_URL}"
   git checkout "${BRANCH}"
 
   charts=$(cd "${CHARTS_TMP_DIR}" && find . -print0 | xargs -0)


### PR DESCRIPTION
### Description of change

We were using HTTP for communicating with GitHub which is incorrect as it requires providing the token which expires after some time.
Switched to using the SSH as we already store the SSH Keys for Aperture in CircleCi

Fixes #768

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/769)
<!-- Reviewable:end -->
