### PR TITLE
Cap request timeout in scheduler by grpc client timeout

### DIFF
--- a/pkg/flowcontrol/common/flowcontrol.go
+++ b/pkg/flowcontrol/common/flowcontrol.go
@@ -53,7 +53,7 @@ func (h *Handler) CheckWithValues(
 	controlPoint selectors.ControlPoint,
 	labels map[string]string,
 ) *flowcontrolv1.CheckResponse {
-	checkResponse := h.engine.ProcessRequest(controlPoint, serviceIDs, labels)
+	checkResponse := h.engine.ProcessRequest(ctx, controlPoint, serviceIDs, labels)
 	h.metrics.CheckResponse(checkResponse.DecisionType, checkResponse.GetRejectReason(), checkResponse.GetError())
 	return checkResponse
 }

--- a/pkg/policies/dataplane/actuators/concurrency/scheduler/wfq.go
+++ b/pkg/policies/dataplane/actuators/concurrency/scheduler/wfq.go
@@ -284,10 +284,12 @@ func (sched *WFQScheduler) enter(rContext RequestContext) (admitted bool, qReque
 	// update timeout value to be global minimum
 	if rContext.Timeout != 0 && rContext.Timeout < sched.minTimeout {
 		// also see - https://github.com/fluxninja/aperture/issues/778
-		if rContext.Timeout > minNonzeroTimeout {
-			sched.minTimeout = rContext.Timeout
-			sched.auditDuration = sched.minTimeout / 2
+		timeout := rContext.Timeout
+		if rContext.Timeout < minNonzeroTimeout {
+			timeout = minNonzeroTimeout
 		}
+		sched.minTimeout = timeout
+		sched.auditDuration = sched.minTimeout / 2
 	}
 
 	if sched.manager.PreprocessRequest(now, rContext) {

--- a/pkg/policies/dataplane/actuators/concurrency/scheduler/wfq.go
+++ b/pkg/policies/dataplane/actuators/concurrency/scheduler/wfq.go
@@ -12,6 +12,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	// Smallest timeout that won't get treated as no timeout.
+	minNonzeroTimeout = 5 * time.Millisecond
+)
+
 // Internal structure for tracking the request in the scheduler queue.
 type queuedRequest struct {
 	enqueueTime time.Time // Time when this request was enqueued
@@ -130,9 +135,8 @@ type WFQScheduler struct {
 	auditDuration time.Duration
 	vt            uint64 // virtual time
 	// generation helps close the queue in face of concurrent requests leaving the queue while new requests also arrive.
-	generation     uint64
-	defaultTimeout time.Duration
-	queueOpen      bool // This tracks overload state
+	generation uint64
+	queueOpen  bool // This tracks overload state
 }
 
 // WFQMetrics holds metrics related to internal workings of WFQScheduler.
@@ -153,15 +157,13 @@ func (sched *WFQScheduler) GetPendingRequests() int {
 
 // NewWFQScheduler creates a new weighted fair queue scheduler,
 // timeout -- timeout for requests.
-func NewWFQScheduler(timeout time.Duration, tokenManger TokenManager, clk clockwork.Clock, metrics *WFQMetrics) Scheduler {
+func NewWFQScheduler(tokenManger TokenManager, clk clockwork.Clock, metrics *WFQMetrics) Scheduler {
 	sched := new(WFQScheduler)
 	sched.queueOpen = false
 	sched.generation = 0
 	sched.vt = 0
 	sched.flows = make(map[string]*flowInfo)
-	sched.minTimeout = timeout
 	sched.auditDuration = sched.minTimeout / 2
-	sched.defaultTimeout = timeout
 	sched.manager = tokenManger
 	sched.clk = clk
 
@@ -182,17 +184,21 @@ func (sched *WFQScheduler) Schedule(rContext RequestContext) bool {
 		return true
 	}
 
-	// Assign default timeout to this request if it is not set
-	if rContext.Timeout == 0 {
-		rContext.Timeout = sched.defaultTimeout
+	// HACK treat small timeouts as zero to avoid running heapAudits too often
+	// https://github.com/fluxninja/aperture/issues/778
+	if rContext.Timeout < minNonzeroTimeout {
+		rContext.Timeout = 0
 	}
 
 	// Unable to schedule right now, so queue the request
-	qRequest := sched.enter(rContext)
-
-	if qRequest == nil {
+	admitted, qRequest := sched.enter(rContext)
+	if admitted {
 		// scheduler is not in overload situation and the request was able to get tokens
 		return true
+	}
+
+	if qRequest == nil {
+		return false
 	}
 
 	// scheduler is in overload situation and we have to wait for ready signal and tokens
@@ -270,9 +276,12 @@ func (sched *WFQScheduler) auditHeap(now time.Time) {
 }
 
 // Attempt to queue this request.
-// If queued successfully, return a valid heapRequest.
-// Otherwise, request was handled right away without queuing - return nil.
-func (sched *WFQScheduler) enter(rContext RequestContext) (qRequest *queuedRequest) {
+//
+// Returns whether request was admitted right away without queueing.
+// If admitted == false, might return a valid heapRequest
+// If admitted == false and qRequest == nil, request was neither admitted nor
+// queued (rejected right away).
+func (sched *WFQScheduler) enter(rContext RequestContext) (admitted bool, qRequest *queuedRequest) {
 	sched.lock.Lock()
 	defer sched.lock.Unlock()
 
@@ -285,7 +294,7 @@ func (sched *WFQScheduler) enter(rContext RequestContext) (qRequest *queuedReque
 	}
 
 	if sched.manager.PreprocessRequest(now, rContext) {
-		return nil
+		return true, nil
 	}
 
 	// try to schedule right now
@@ -293,11 +302,16 @@ func (sched *WFQScheduler) enter(rContext RequestContext) (qRequest *queuedReque
 		ok := sched.manager.TakeIfAvailable(now, float64(rContext.Tokens))
 		if ok {
 			// we got the tokens, no need to queue
-			return nil
+			return true, nil
 		}
 	}
 
 	// we are in overload situation, attempt to queue
+
+	if rContext.Timeout == 0 {
+		// Not possible to queue requests with zero timeout.
+		return false, nil
+	}
 
 	firstRequest := false
 
@@ -366,7 +380,7 @@ func (sched *WFQScheduler) enter(rContext RequestContext) (qRequest *queuedReque
 		// This is the only request in queue at this time, wake it up
 		qRequest.ready <- true
 	}
-	return qRequest
+	return false, qRequest
 }
 
 // adjust queue counters. Note: qRequest pointer should not be used after calling this function as it will get recycled via Pool.

--- a/pkg/policies/dataplane/actuators/rate/rate-limiter.go
+++ b/pkg/policies/dataplane/actuators/rate/rate-limiter.go
@@ -379,7 +379,7 @@ func (rateLimiter *rateLimiter) GetSelector() *selectorv1.Selector {
 }
 
 // RunLimiter runs the limiter.
-func (rateLimiter *rateLimiter) RunLimiter(labels map[string]string) *flowcontrolv1.LimiterDecision {
+func (rateLimiter *rateLimiter) RunLimiter(ctx context.Context, labels map[string]string) *flowcontrolv1.LimiterDecision {
 	reason := flowcontrolv1.LimiterDecision_LIMITER_REASON_UNSPECIFIED
 
 	label, ok, remaining, current := rateLimiter.TakeN(labels, 1)

--- a/pkg/policies/dataplane/iface/engine.go
+++ b/pkg/policies/dataplane/iface/engine.go
@@ -1,6 +1,8 @@
 package iface
 
 import (
+	"context"
+
 	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
 	"github.com/fluxninja/aperture/pkg/policies/dataplane/selectors"
 )
@@ -9,7 +11,12 @@ import (
 
 // Engine is an interface for registering fluxmeters and schedulers.
 type Engine interface {
-	ProcessRequest(controlPoint selectors.ControlPoint, serviceIDs []string, labels map[string]string) *flowcontrolv1.CheckResponse
+	ProcessRequest(
+		ctx context.Context,
+		controlPoint selectors.ControlPoint,
+		serviceIDs []string,
+		labels map[string]string,
+	) *flowcontrolv1.CheckResponse
 
 	RegisterConcurrencyLimiter(sa ConcurrencyLimiter) error
 	UnregisterConcurrencyLimiter(sa ConcurrencyLimiter) error

--- a/pkg/policies/dataplane/iface/limiter.go
+++ b/pkg/policies/dataplane/iface/limiter.go
@@ -1,6 +1,7 @@
 package iface
 
 import (
+	"context"
 	"strconv"
 
 	selectorv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/common/selector/v1"
@@ -27,7 +28,7 @@ func (limiterID LimiterID) String() string {
 type Limiter interface {
 	GetPolicyName() string
 	GetSelector() *selectorv1.Selector
-	RunLimiter(labels map[string]string) *flowcontrolv1.LimiterDecision
+	RunLimiter(ctx context.Context, labels map[string]string) *flowcontrolv1.LimiterDecision
 	GetLimiterID() LimiterID
 }
 

--- a/pkg/policies/mocks/mock_engine.go
+++ b/pkg/policies/mocks/mock_engine.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
@@ -79,17 +80,17 @@ func (mr *MockEngineMockRecorder) GetRateLimiter(limiterID interface{}) *gomock.
 }
 
 // ProcessRequest mocks base method.
-func (m *MockEngine) ProcessRequest(controlPoint selectors.ControlPoint, serviceIDs []string, labels map[string]string) *flowcontrolv1.CheckResponse {
+func (m *MockEngine) ProcessRequest(ctx context.Context, controlPoint selectors.ControlPoint, serviceIDs []string, labels map[string]string) *flowcontrolv1.CheckResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessRequest", controlPoint, serviceIDs, labels)
+	ret := m.ctrl.Call(m, "ProcessRequest", ctx, controlPoint, serviceIDs, labels)
 	ret0, _ := ret[0].(*flowcontrolv1.CheckResponse)
 	return ret0
 }
 
 // ProcessRequest indicates an expected call of ProcessRequest.
-func (mr *MockEngineMockRecorder) ProcessRequest(controlPoint, serviceIDs, labels interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) ProcessRequest(ctx, controlPoint, serviceIDs, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessRequest", reflect.TypeOf((*MockEngine)(nil).ProcessRequest), controlPoint, serviceIDs, labels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessRequest", reflect.TypeOf((*MockEngine)(nil).ProcessRequest), ctx, controlPoint, serviceIDs, labels)
 }
 
 // RegisterConcurrencyLimiter mocks base method.

--- a/pkg/policies/mocks/mock_limiter.go
+++ b/pkg/policies/mocks/mock_limiter.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	selectorv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/common/selector/v1"
@@ -80,17 +81,17 @@ func (mr *MockLimiterMockRecorder) GetSelector() *gomock.Call {
 }
 
 // RunLimiter mocks base method.
-func (m *MockLimiter) RunLimiter(labels map[string]string) *flowcontrolv1.LimiterDecision {
+func (m *MockLimiter) RunLimiter(ctx context.Context, labels map[string]string) *flowcontrolv1.LimiterDecision {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunLimiter", labels)
+	ret := m.ctrl.Call(m, "RunLimiter", ctx, labels)
 	ret0, _ := ret[0].(*flowcontrolv1.LimiterDecision)
 	return ret0
 }
 
 // RunLimiter indicates an expected call of RunLimiter.
-func (mr *MockLimiterMockRecorder) RunLimiter(labels interface{}) *gomock.Call {
+func (mr *MockLimiterMockRecorder) RunLimiter(ctx, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunLimiter", reflect.TypeOf((*MockLimiter)(nil).RunLimiter), labels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunLimiter", reflect.TypeOf((*MockLimiter)(nil).RunLimiter), ctx, labels)
 }
 
 // MockRateLimiter is a mock of RateLimiter interface.
@@ -173,17 +174,17 @@ func (mr *MockRateLimiterMockRecorder) GetSelector() *gomock.Call {
 }
 
 // RunLimiter mocks base method.
-func (m *MockRateLimiter) RunLimiter(labels map[string]string) *flowcontrolv1.LimiterDecision {
+func (m *MockRateLimiter) RunLimiter(ctx context.Context, labels map[string]string) *flowcontrolv1.LimiterDecision {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunLimiter", labels)
+	ret := m.ctrl.Call(m, "RunLimiter", ctx, labels)
 	ret0, _ := ret[0].(*flowcontrolv1.LimiterDecision)
 	return ret0
 }
 
 // RunLimiter indicates an expected call of RunLimiter.
-func (mr *MockRateLimiterMockRecorder) RunLimiter(labels interface{}) *gomock.Call {
+func (mr *MockRateLimiterMockRecorder) RunLimiter(ctx, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunLimiter", reflect.TypeOf((*MockRateLimiter)(nil).RunLimiter), labels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunLimiter", reflect.TypeOf((*MockRateLimiter)(nil).RunLimiter), ctx, labels)
 }
 
 // TakeN mocks base method.
@@ -283,15 +284,15 @@ func (mr *MockConcurrencyLimiterMockRecorder) GetSelector() *gomock.Call {
 }
 
 // RunLimiter mocks base method.
-func (m *MockConcurrencyLimiter) RunLimiter(labels map[string]string) *flowcontrolv1.LimiterDecision {
+func (m *MockConcurrencyLimiter) RunLimiter(ctx context.Context, labels map[string]string) *flowcontrolv1.LimiterDecision {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunLimiter", labels)
+	ret := m.ctrl.Call(m, "RunLimiter", ctx, labels)
 	ret0, _ := ret[0].(*flowcontrolv1.LimiterDecision)
 	return ret0
 }
 
 // RunLimiter indicates an expected call of RunLimiter.
-func (mr *MockConcurrencyLimiterMockRecorder) RunLimiter(labels interface{}) *gomock.Call {
+func (mr *MockConcurrencyLimiterMockRecorder) RunLimiter(ctx, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunLimiter", reflect.TypeOf((*MockConcurrencyLimiter)(nil).RunLimiter), labels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunLimiter", reflect.TypeOf((*MockConcurrencyLimiter)(nil).RunLimiter), ctx, labels)
 }


### PR DESCRIPTION
### Description of change

Grpc client timeout is pulled by scheduler from Context.Deadline() and
is used to cap the timeout computed by `tokens*factor`. Note that a lot
things can happen before request is received and processed by scheduler,
so the capped timeout can end up a lot smaller than original client
timeout (even zero or negative). Also, as a temporary hack, timeouts
smaller than 5ms are capped to 0 (this is to avoid running heapAudits
too often).

To support this, now requestContext.timeout == 0 means "don't attempt to
enqueue" and "default timeout" is now removed from scheduler

##### Checklist

- [ ] Tested in playground or other setup

Resolves #671

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/779)
<!-- Reviewable:end -->
