### PR TITLE
rollupprocessor: Apply per-batch attribute cardinality limit

### DIFF
--- a/cmd/aperture-agent/agent/otel-component.go
+++ b/cmd/aperture-agent/agent/otel-component.go
@@ -124,9 +124,11 @@ func addLogsPipeline(cfg *otelcollector.OtelParams) {
 	config := cfg.Config
 	// Common dependencies for pipelines
 	config.AddReceiver(otelcollector.ReceiverOTLP, otlpreceiver.Config{})
-	config.AddProcessor(otelcollector.ProcessorMetrics, metricsprocessor.Config{})
+	// Note: Passing map[string]interface{}{} instead of real config, so that
+	// processors' configs' default work.
+	config.AddProcessor(otelcollector.ProcessorMetrics, map[string]interface{}{})
 	config.AddBatchProcessor(otelcollector.ProcessorBatchPrerollup, cfg.BatchPrerollup.Timeout.AsDuration(), cfg.BatchPostrollup.SendBatchSize)
-	config.AddProcessor(otelcollector.ProcessorRollup, rollupprocessor.Config{})
+	config.AddProcessor(otelcollector.ProcessorRollup, map[string]interface{}{})
 	config.AddBatchProcessor(otelcollector.ProcessorBatchPostrollup, cfg.BatchPostrollup.Timeout.AsDuration(), cfg.BatchPostrollup.SendBatchSize)
 	config.AddExporter(otelcollector.ExporterLogging, nil)
 

--- a/docs/content/concepts/flow-control/flow-label.md
+++ b/docs/content/concepts/flow-control/flow-label.md
@@ -91,6 +91,10 @@ OLAP-style telemetry data is generated as OpenTelemetry logs and is saved in an
 OLAP database. This is done by creating multi-dimensional rollups from flow
 labels.
 
+OLAP-style telemetry doesn't work well with high-cardinality labels, thus if
+high-cardinality label is detected, some of its values may be replaced with
+`REDACTED_VIA_CARDINALITY_LIMIT` string.
+
 #### Default labels
 
 These are protocol-level labels (e.g. http, network) extracted by the

--- a/pkg/otelcollector/rollupprocessor/config.go
+++ b/pkg/otelcollector/rollupprocessor/config.go
@@ -6,7 +6,8 @@ import (
 
 // Config defines configuration for rollup processor.
 type Config struct {
-	config.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	config.ProcessorSettings  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	AttributeCardinalityLimit int                      `mapstructure:"attribute_cardinality_limit"`
 }
 
 var _ config.Processor = (*Config)(nil)

--- a/pkg/otelcollector/rollupprocessor/factory.go
+++ b/pkg/otelcollector/rollupprocessor/factory.go
@@ -23,7 +23,8 @@ func NewFactory() component.ProcessorFactory {
 
 func createDefaultConfig() config.Processor {
 	return &Config{
-		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
+		ProcessorSettings:         config.NewProcessorSettings(config.NewComponentID(typeStr)),
+		AttributeCardinalityLimit: defaultAttributeCardinalityLimit,
 	}
 }
 


### PR DESCRIPTION
Resolves #535 

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added
- [x] Tests and/or benchmarks are included
- [x] Breaking changes
- [x] Benchmarked in playground
    - It adds 0.19% of total agent runtime (3% of rollupprocessor itself). IMO acceptable and not worth optimizing further (at least right now)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/782)
<!-- Reviewable:end -->
