### PR TITLE
Response status in telemetry

### DIFF
--- a/pkg/otelcollector/consts.go
+++ b/pkg/otelcollector/consts.go
@@ -54,6 +54,12 @@ const (
 	ApertureClassifiersLabel = "aperture.classifiers"
 	// ApertureClassifierErrorsLabel describes encountered classifier errors for specified policy.
 	ApertureClassifierErrorsLabel = "aperture.classifier_errors"
+	// ApertureResponseStatusLabel label to denote OK or Error across all protocols.
+	ApertureResponseStatusLabel = "aperture.response_status"
+	// ApertureResponseStatusOK OK response across all protocols.
+	ApertureResponseStatusOK = ApertureFeatureStatusOK
+	// ApertureResponseStatusError Error response across all protocols.
+	ApertureResponseStatusError = ApertureFeatureStatusError
 
 	/* HTTP Specific labels. */
 

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
@@ -1,0 +1,145 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+
+	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/metrics"
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+)
+
+// AddCheckResponseBasedLabels adds the following labels:
+// * otelcollector.ApertureProcessingDurationLabel
+// * otelcollector.ApertureServicesLabel
+// * otelcollector.ApertureControlPointLabel
+// * otelcollector.ApertureRateLimitersLabel
+// * otelcollector.ApertureDroppingRateLimitersLabel
+// * otelcollector.ApertureConcurrencyLimitersLabel
+// * otelcollector.ApertureDroppingConcurrencyLimitersLabel
+// * otelcollector.ApertureWorkloadsLabel
+// * otelcollector.ApertureDroppingWorkloadsLabel
+// * otelcollector.ApertureFluxMetersLabel
+// * otelcollector.ApertureFlowLabelKeysLabel
+// * otelcollector.ApertureClassifiersLabel
+// * otelcollector.ApertureClassifierErrorsLabel
+// * otelcollector.ApertureDecisionTypeLabel
+// * otelcollector.ApertureRejectReasonLabel
+// * otelcollector.ApertureErrorLabel.
+func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse, sourceStr string) {
+	// Aperture Processing Duration
+	startTime := checkResponse.GetStart().AsTime()
+	endTime := checkResponse.GetEnd().AsTime()
+	if !startTime.IsZero() && !endTime.IsZero() {
+		attributes.PutDouble(otelcollector.ApertureProcessingDurationLabel, float64(endTime.Sub(startTime).Milliseconds()))
+	} else {
+		log.Sample(zerolog.Sometimes).Warn().Msgf("Aperture processing duration not found in %s access logs", sourceStr)
+	}
+	// Services
+	servicesValue := pcommon.NewValueSlice()
+	for _, service := range checkResponse.Services {
+		servicesValue.Slice().AppendEmpty().SetStr(service)
+	}
+	servicesValue.CopyTo(attributes.PutEmpty(otelcollector.ApertureServicesLabel))
+
+	// Control Point
+	attributes.PutString(otelcollector.ApertureControlPointLabel, checkResponse.GetControlPointInfo().String())
+
+	labels := map[string]pcommon.Value{
+		otelcollector.ApertureRateLimitersLabel:                pcommon.NewValueSlice(),
+		otelcollector.ApertureDroppingRateLimitersLabel:        pcommon.NewValueSlice(),
+		otelcollector.ApertureConcurrencyLimitersLabel:         pcommon.NewValueSlice(),
+		otelcollector.ApertureDroppingConcurrencyLimitersLabel: pcommon.NewValueSlice(),
+		otelcollector.ApertureWorkloadsLabel:                   pcommon.NewValueSlice(),
+		otelcollector.ApertureDroppingWorkloadsLabel:           pcommon.NewValueSlice(),
+		otelcollector.ApertureFluxMetersLabel:                  pcommon.NewValueSlice(),
+		otelcollector.ApertureFlowLabelKeysLabel:               pcommon.NewValueSlice(),
+		otelcollector.ApertureClassifiersLabel:                 pcommon.NewValueSlice(),
+		otelcollector.ApertureClassifierErrorsLabel:            pcommon.NewValueSlice(),
+		otelcollector.ApertureDecisionTypeLabel:                pcommon.NewValueStr(checkResponse.DecisionType.String()),
+		otelcollector.ApertureRejectReasonLabel:                pcommon.NewValueStr(checkResponse.GetRejectReason().String()),
+		otelcollector.ApertureErrorLabel:                       pcommon.NewValueStr(checkResponse.GetError().String()),
+	}
+	for _, decision := range checkResponse.LimiterDecisions {
+		if decision.GetRateLimiterInfo() != nil {
+			rawValue := []string{
+				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, decision.GetPolicyName()),
+				fmt.Sprintf("%s:%v", metrics.ComponentIndexLabel, decision.GetComponentIndex()),
+				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, decision.GetPolicyHash()),
+			}
+			value := strings.Join(rawValue, ",")
+			labels[otelcollector.ApertureRateLimitersLabel].Slice().AppendEmpty().SetStr(value)
+			if decision.Dropped {
+				labels[otelcollector.ApertureDroppingRateLimitersLabel].Slice().AppendEmpty().SetStr(value)
+			}
+		}
+		if cl := decision.GetConcurrencyLimiterInfo(); cl != nil {
+			rawValue := []string{
+				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, decision.GetPolicyName()),
+				fmt.Sprintf("%s:%v", metrics.ComponentIndexLabel, decision.GetComponentIndex()),
+				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, decision.GetPolicyHash()),
+			}
+			value := strings.Join(rawValue, ",")
+			labels[otelcollector.ApertureConcurrencyLimitersLabel].Slice().AppendEmpty().SetStr(value)
+			if decision.Dropped {
+				labels[otelcollector.ApertureDroppingConcurrencyLimitersLabel].Slice().AppendEmpty().SetStr(value)
+			}
+
+			workloadsRawValue := []string{
+				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, decision.GetPolicyName()),
+				fmt.Sprintf("%s:%v", metrics.ComponentIndexLabel, decision.GetComponentIndex()),
+				fmt.Sprintf("%s:%v", metrics.WorkloadIndexLabel, cl.GetWorkloadIndex()),
+				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, decision.GetPolicyHash()),
+			}
+			value = strings.Join(workloadsRawValue, ",")
+			labels[otelcollector.ApertureWorkloadsLabel].Slice().AppendEmpty().SetStr(value)
+			if decision.Dropped {
+				labels[otelcollector.ApertureDroppingWorkloadsLabel].Slice().AppendEmpty().SetStr(value)
+			}
+		}
+	}
+	for _, fluxMeter := range checkResponse.FluxMeterInfos {
+		value := fluxMeter.GetFluxMeterName()
+		labels[otelcollector.ApertureFluxMetersLabel].Slice().AppendEmpty().SetStr(value)
+	}
+
+	for _, flowLabelKey := range checkResponse.GetFlowLabelKeys() {
+		labels[otelcollector.ApertureFlowLabelKeysLabel].Slice().AppendEmpty().SetStr(flowLabelKey)
+	}
+
+	for _, classifier := range checkResponse.ClassifierInfos {
+		rawValue := []string{
+			fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, classifier.PolicyName),
+			fmt.Sprintf("%s:%v", metrics.ClassifierIndexLabel, classifier.ClassifierIndex),
+		}
+		value := strings.Join(rawValue, ",")
+		labels[otelcollector.ApertureClassifiersLabel].Slice().AppendEmpty().SetStr(value)
+
+		// add errors as attributes as well
+		if classifier.Error != flowcontrolv1.ClassifierInfo_ERROR_NONE {
+			errorsValue := []string{
+				classifier.Error.String(),
+				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, classifier.PolicyName),
+				fmt.Sprintf("%s:%v", metrics.ClassifierIndexLabel, classifier.ClassifierIndex),
+				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, classifier.PolicyHash),
+			}
+			joinedValue := strings.Join(errorsValue, ",")
+			labels[otelcollector.ApertureClassifierErrorsLabel].Slice().AppendEmpty().SetStr(joinedValue)
+		}
+	}
+
+	for key, value := range labels {
+		value.CopyTo(attributes.PutEmpty(key))
+	}
+}
+
+// AddFlowLabels adds flow labels from check response to attributes.
+func AddFlowLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse) {
+	for key, value := range checkResponse.TelemetryFlowLabels {
+		pcommon.NewValueStr(value).CopyTo(attributes.PutEmpty(key))
+	}
+}

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
@@ -29,7 +29,8 @@ import (
 // * otelcollector.ApertureClassifierErrorsLabel
 // * otelcollector.ApertureDecisionTypeLabel
 // * otelcollector.ApertureRejectReasonLabel
-// * otelcollector.ApertureErrorLabel.
+// * otelcollector.ApertureErrorLabel,
+// * dynamic flow labels.
 func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse, sourceStr string) {
 	// Aperture Processing Duration
 	startTime := checkResponse.GetStart().AsTime()
@@ -111,6 +112,10 @@ func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcont
 		labels[otelcollector.ApertureFlowLabelKeysLabel].Slice().AppendEmpty().SetStr(flowLabelKey)
 	}
 
+	for key, value := range checkResponse.GetTelemetryFlowLabels() {
+		pcommon.NewValueStr(value).CopyTo(attributes.PutEmpty(key))
+	}
+
 	for _, classifier := range checkResponse.ClassifierInfos {
 		rawValue := []string{
 			fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, classifier.PolicyName),
@@ -134,12 +139,5 @@ func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcont
 
 	for key, value := range labels {
 		value.CopyTo(attributes.PutEmpty(key))
-	}
-}
-
-// AddFlowLabels adds flow labels from check response to attributes.
-func AddFlowLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse) {
-	for key, value := range checkResponse.TelemetryFlowLabels {
-		pcommon.NewValueStr(value).CopyTo(attributes.PutEmpty(key))
 	}
 }

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels_test.go
@@ -1,0 +1,140 @@
+package internal_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+	"github.com/fluxninja/aperture/pkg/otelcollector/metricsprocessor/internal"
+)
+
+var _ = DescribeTable("Check Response labels", func(checkResponse *flowcontrolv1.CheckResponse, after map[string]interface{}) {
+	attributes := pcommon.NewMap()
+	internal.AddCheckResponseBasedLabels(attributes, checkResponse, "source")
+	for k, v := range after {
+		Expect(attributes.AsRaw()).To(HaveKeyWithValue(k, v))
+	}
+},
+	Entry("Sets processing duration",
+		&flowcontrolv1.CheckResponse{
+			Start: timestamppb.New(time.Date(1969, time.Month(7), 20, 17, 0, 0, 0, time.UTC)),
+			End:   timestamppb.New(time.Date(1969, time.Month(7), 20, 17, 0, 1, 0, time.UTC)),
+		},
+		map[string]interface{}{otelcollector.ApertureProcessingDurationLabel: float64(1000)},
+	),
+
+	Entry("Sets services",
+		&flowcontrolv1.CheckResponse{
+			Services: []string{"svc1", "svc2"},
+		},
+		map[string]interface{}{otelcollector.ApertureServicesLabel: []interface{}{"svc1", "svc2"}},
+	),
+
+	Entry("Sets control point",
+		&flowcontrolv1.CheckResponse{
+			ControlPointInfo: &flowcontrolv1.ControlPointInfo{
+				Type: flowcontrolv1.ControlPointInfo_TYPE_INGRESS,
+			},
+		},
+		map[string]interface{}{otelcollector.ApertureControlPointLabel: "type:TYPE_INGRESS"},
+	),
+
+	Entry("Sets rate limiters",
+		&flowcontrolv1.CheckResponse{
+			LimiterDecisions: []*flowcontrolv1.LimiterDecision{
+				{
+					PolicyName:     "foo",
+					PolicyHash:     "foo-hash",
+					ComponentIndex: 2,
+					Dropped:        true,
+					Details: &flowcontrolv1.LimiterDecision_RateLimiterInfo_{
+						RateLimiterInfo: &flowcontrolv1.LimiterDecision_RateLimiterInfo{
+							Remaining: 1,
+							Current:   1,
+							Label:     "test",
+						},
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			otelcollector.ApertureRateLimitersLabel:         []interface{}{"policy_name:foo,component_index:2,policy_hash:foo-hash"},
+			otelcollector.ApertureDroppingRateLimitersLabel: []interface{}{"policy_name:foo,component_index:2,policy_hash:foo-hash"},
+		},
+	),
+
+	Entry("Sets concurrency limiters",
+		&flowcontrolv1.CheckResponse{
+			LimiterDecisions: []*flowcontrolv1.LimiterDecision{
+				{
+					PolicyName:     "foo",
+					PolicyHash:     "foo-hash",
+					ComponentIndex: 1,
+					Dropped:        true,
+					Details: &flowcontrolv1.LimiterDecision_ConcurrencyLimiterInfo_{
+						ConcurrencyLimiterInfo: &flowcontrolv1.LimiterDecision_ConcurrencyLimiterInfo{
+							WorkloadIndex: "0",
+						},
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			otelcollector.ApertureConcurrencyLimitersLabel:         []interface{}{"policy_name:foo,component_index:1,policy_hash:foo-hash"},
+			otelcollector.ApertureDroppingConcurrencyLimitersLabel: []interface{}{"policy_name:foo,component_index:1,policy_hash:foo-hash"},
+		},
+	),
+
+	Entry("Sets flux meters",
+		&flowcontrolv1.CheckResponse{
+			FluxMeterInfos: []*flowcontrolv1.FluxMeterInfo{
+				{FluxMeterName: "foo"},
+				{FluxMeterName: "bar"},
+			},
+		},
+		map[string]interface{}{otelcollector.ApertureFluxMetersLabel: []interface{}{"foo", "bar"}},
+	),
+
+	Entry("Sets flow labels",
+		&flowcontrolv1.CheckResponse{
+			FlowLabelKeys: []string{"someLabel", "otherLabel"},
+		},
+		map[string]interface{}{otelcollector.ApertureFlowLabelKeysLabel: []interface{}{"someLabel", "otherLabel"}},
+	),
+
+	Entry("Sets telemetry flow labels",
+		&flowcontrolv1.CheckResponse{
+			TelemetryFlowLabels: map[string]string{
+				"someLabel":  "someValue",
+				"otherLabel": "otherValue",
+			},
+		},
+		map[string]interface{}{
+			"someLabel":  "someValue",
+			"otherLabel": "otherValue",
+		},
+	),
+
+	Entry("Sets classifiers",
+		&flowcontrolv1.CheckResponse{
+			ClassifierInfos: []*flowcontrolv1.ClassifierInfo{
+				{
+					PolicyName:      "foo",
+					PolicyHash:      "bar",
+					ClassifierIndex: 42,
+					LabelKey:        "timing",
+					Error:           flowcontrolv1.ClassifierInfo_ERROR_MULTI_EXPRESSION,
+				},
+			},
+		},
+		map[string]interface{}{
+			otelcollector.ApertureClassifiersLabel:      []interface{}{"policy_name:foo,classifier_index:42"},
+			otelcollector.ApertureClassifierErrorsLabel: []interface{}{"ERROR_MULTI_EXPRESSION,policy_name:foo,classifier_index:42,policy_hash:bar"},
+		},
+	),
+)

--- a/pkg/otelcollector/metricsprocessor/internal/envoy_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/envoy_labels.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// AddEnvoySpecificLabels adds labels specific to Envoy data source.
+func AddEnvoySpecificLabels(attributes pcommon.Map) {
+	treatAsZero := []string{otelcollector.EnvoyMissingAttributeValue}
+	// Retrieve request length
+	requestLength, _ := otelcollector.GetFloat64(attributes, otelcollector.EnvoyBytesSentLabel, treatAsZero)
+	attributes.PutDouble(otelcollector.HTTPRequestContentLength, requestLength)
+	// Retrieve response lengths
+	responseLength, _ := otelcollector.GetFloat64(attributes, otelcollector.EnvoyBytesReceivedLabel, treatAsZero)
+	attributes.PutDouble(otelcollector.HTTPResponseContentLength, responseLength)
+
+	// Compute durations
+	responseDuration, responseDurationExists := otelcollector.GetFloat64(attributes, otelcollector.EnvoyResponseDurationLabel, treatAsZero)
+	authzDuration, authzDurationExists := otelcollector.GetFloat64(attributes, otelcollector.EnvoyAuthzDurationLabel, treatAsZero)
+
+	if responseDurationExists {
+		attributes.PutDouble(otelcollector.FlowDurationLabel, responseDuration)
+	}
+
+	if responseDurationExists && authzDurationExists {
+		attributes.PutDouble(otelcollector.WorkloadDurationLabel, responseDuration-authzDuration)
+	}
+}

--- a/pkg/otelcollector/metricsprocessor/internal/envoy_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/envoy_labels.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/fluxninja/aperture/pkg/otelcollector"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/fluxninja/aperture/pkg/otelcollector"
 )
 
 // AddEnvoySpecificLabels adds labels specific to Envoy data source.

--- a/pkg/otelcollector/metricsprocessor/internal/envoy_labels_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/envoy_labels_test.go
@@ -1,0 +1,43 @@
+package internal_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+	"github.com/fluxninja/aperture/pkg/otelcollector/metricsprocessor/internal"
+)
+
+var _ = DescribeTable("Envoy labels", func(before, after map[string]float64) {
+	attributes := pcommon.NewMap()
+	for k, v := range before {
+		attributes.PutDouble(k, v)
+	}
+	internal.AddEnvoySpecificLabels(attributes)
+	for k, v := range after {
+		rawOut, exists := attributes.Get(k)
+		Expect(exists).To(BeTrue())
+		Expect(rawOut.Double()).To(Equal(v))
+	}
+},
+	Entry("Sets request content length",
+		map[string]float64{otelcollector.EnvoyBytesSentLabel: 123},
+		map[string]float64{otelcollector.HTTPRequestContentLength: 123},
+	),
+	Entry("Sets response content length",
+		map[string]float64{otelcollector.EnvoyBytesReceivedLabel: 123},
+		map[string]float64{otelcollector.HTTPResponseContentLength: 123},
+	),
+	Entry("Sets flow duration",
+		map[string]float64{otelcollector.EnvoyResponseDurationLabel: 123},
+		map[string]float64{otelcollector.FlowDurationLabel: 123},
+	),
+	Entry("Sets workload duration",
+		map[string]float64{
+			otelcollector.EnvoyResponseDurationLabel: 123,
+			otelcollector.EnvoyAuthzDurationLabel:    23,
+		},
+		map[string]float64{otelcollector.WorkloadDurationLabel: 100},
+	),
+)

--- a/pkg/otelcollector/metricsprocessor/internal/internal_suite_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/internal_suite_test.go
@@ -1,0 +1,13 @@
+package internal_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Suite")
+}

--- a/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
+++ b/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+)
+
+/*
+ * IncludeList: This IncludeList is applied to logs and spans at during the enrichment process, after check response based labels are attached and metrics have been parsed.
+ */
+var (
+	_includeAttributesCommon = []string{
+		otelcollector.ApertureSourceLabel,
+		otelcollector.WorkloadDurationLabel,
+		otelcollector.FlowDurationLabel,
+		otelcollector.ApertureProcessingDurationLabel,
+		otelcollector.ApertureDecisionTypeLabel,
+		otelcollector.ApertureErrorLabel,
+		otelcollector.ApertureRejectReasonLabel,
+		otelcollector.ApertureRateLimitersLabel,
+		otelcollector.ApertureDroppingRateLimitersLabel,
+		otelcollector.ApertureConcurrencyLimitersLabel,
+		otelcollector.ApertureDroppingConcurrencyLimitersLabel,
+		otelcollector.ApertureWorkloadsLabel,
+		otelcollector.ApertureDroppingWorkloadsLabel,
+		otelcollector.ApertureFluxMetersLabel,
+		otelcollector.ApertureFlowLabelKeysLabel,
+		otelcollector.ApertureClassifiersLabel,
+		otelcollector.ApertureClassifierErrorsLabel,
+		otelcollector.ApertureServicesLabel,
+		otelcollector.ApertureControlPointLabel,
+		otelcollector.ApertureResponseStatusLabel,
+	}
+
+	_includeAttributesHTTP = []string{
+		otelcollector.HTTPStatusCodeLabel,
+		otelcollector.HTTPRequestContentLength,
+		otelcollector.HTTPResponseContentLength,
+	}
+
+	_includeAttributesSDK = []string{
+		otelcollector.ApertureFeatureStatusLabel,
+	}
+
+	includeListHTTP = otelcollector.FormIncludeList(append(_includeAttributesCommon, _includeAttributesHTTP...))
+	includeListSDK  = otelcollector.FormIncludeList(append(_includeAttributesCommon, _includeAttributesSDK...))
+)
+
+// EnforceIncludeListHTTP filters attributes for HTTP telemetry.
+func EnforceIncludeListHTTP(attributes pcommon.Map) {
+	otelcollector.EnforceIncludeList(attributes, includeListHTTP)
+}
+
+// EnforceIncludeListSDK filters attributes for SDK telemetry.
+func EnforceIncludeListSDK(attributes pcommon.Map) {
+	otelcollector.EnforceIncludeList(attributes, includeListSDK)
+}

--- a/pkg/otelcollector/metricsprocessor/internal/sdk_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/sdk_labels.go
@@ -1,0 +1,61 @@
+package internal
+
+import (
+	"time"
+
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+)
+
+// AddSDKSpecificLabels adds labels specific to SDK data source.
+func AddSDKSpecificLabels(attributes pcommon.Map) {
+	// Compute durations
+	flowStart, flowStartExists := getSDKLabelTimestampValue(attributes, otelcollector.ApertureFlowStartTimestampLabel)
+	workloadStart, workloadStartExists := getSDKLabelTimestampValue(attributes, otelcollector.ApertureWorkloadStartTimestampLabel)
+	flowEnd, flowEndExists := getSDKLabelTimestampValue(attributes, otelcollector.ApertureFlowEndTimestampLabel)
+
+	if flowStartExists && flowEndExists {
+		flowDuration := flowEnd.Sub(flowStart)
+		attributes.PutDouble(otelcollector.FlowDurationLabel, float64(flowDuration.Milliseconds()))
+	}
+	if workloadStartExists && flowEndExists {
+		workloadDuration := flowEnd.Sub(workloadStart)
+		attributes.PutDouble(otelcollector.WorkloadDurationLabel, float64(workloadDuration.Milliseconds()))
+	}
+}
+
+func getSDKLabelTimestampValue(attributes pcommon.Map, labelKey string) (time.Time, bool) {
+	return getLabelTimestampValue(attributes, labelKey, otelcollector.ApertureSourceSDK)
+}
+
+func getLabelTimestampValue(attributes pcommon.Map, labelKey, source string) (time.Time, bool) {
+	value, exists := getLabelValue(attributes, labelKey, source)
+	if !exists {
+		return time.Time{}, false
+	}
+	return _getLabelTimestampValue(value, labelKey, source)
+}
+
+func getLabelValue(attributes pcommon.Map, labelKey, source string) (pcommon.Value, bool) {
+	value, exists := attributes.Get(labelKey)
+	if !exists {
+		log.Sample(zerolog.Sometimes).Warn().Str("source", source).Str("key", labelKey).Msg("Label not found")
+		return pcommon.Value{}, false
+	}
+	return value, exists
+}
+
+func _getLabelTimestampValue(value pcommon.Value, labelKey, source string) (time.Time, bool) {
+	var valueInt int64
+	if value.Type() == pcommon.ValueTypeInt {
+		valueInt = value.Int()
+	} else {
+		log.Sample(zerolog.Sometimes).Warn().Str("source", source).Str("key", labelKey).Msg("Failed to parse a timestamp field")
+		return time.Time{}, false
+	}
+
+	return time.Unix(0, valueInt), true
+}

--- a/pkg/otelcollector/metricsprocessor/internal/sdk_labels_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/sdk_labels_test.go
@@ -1,0 +1,38 @@
+package internal_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+	"github.com/fluxninja/aperture/pkg/otelcollector/metricsprocessor/internal"
+)
+
+var _ = DescribeTable("SDK labels", func(before map[string]int64, after map[string]float64) {
+	attributes := pcommon.NewMap()
+	for k, v := range before {
+		attributes.PutInt(k, v)
+	}
+	internal.AddSDKSpecificLabels(attributes)
+	for k, v := range after {
+		rawOut, exists := attributes.Get(k)
+		Expect(exists).To(BeTrue())
+		Expect(rawOut.Double()).To(Equal(v))
+	}
+},
+	Entry("Sets flow duration",
+		map[string]int64{
+			otelcollector.ApertureFlowStartTimestampLabel: 123e6,
+			otelcollector.ApertureFlowEndTimestampLabel:   246e6,
+		},
+		map[string]float64{otelcollector.FlowDurationLabel: 123},
+	),
+	Entry("Sets workload duration",
+		map[string]int64{
+			otelcollector.ApertureWorkloadStartTimestampLabel: 123e6,
+			otelcollector.ApertureFlowEndTimestampLabel:       246e6,
+		},
+		map[string]float64{otelcollector.WorkloadDurationLabel: 123},
+	),
+)

--- a/pkg/otelcollector/metricsprocessor/internal/status.go
+++ b/pkg/otelcollector/metricsprocessor/internal/status.go
@@ -1,0 +1,66 @@
+package internal
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
+	"github.com/fluxninja/aperture/pkg/metrics"
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+)
+
+// StatusesFromAttributes gets HTTP status code and Feature status from attributes.
+func StatusesFromAttributes(attributes pcommon.Map) (statusCode string, featureStatus string) {
+	rawStatusCode, exists := attributes.Get(otelcollector.HTTPStatusCodeLabel)
+	if exists {
+		statusCode = rawStatusCode.Str()
+	}
+	rawFeatureStatus, exists := attributes.Get(otelcollector.ApertureFeatureStatusLabel)
+	if exists {
+		featureStatus = rawFeatureStatus.Str()
+	}
+	return
+}
+
+// StatusLabelsForMetrics returns labels maps used which describe Histogram.
+func StatusLabelsForMetrics(
+	decisionType flowcontrolv1.CheckResponse_DecisionType,
+	statusCode string,
+	featureStatus string,
+) map[string]string {
+	return map[string]string{
+		metrics.ResponseStatusLabel: responseStatusForMetrics(statusCode, featureStatus),
+		metrics.DecisionTypeLabel:   decisionType.String(),
+		metrics.StatusCodeLabel:     statusCode,
+		metrics.FeatureStatusLabel:  featureStatus,
+	}
+}
+
+func responseStatusForMetrics(statusCode, featureStatus string) string {
+	return responseStatus(
+		statusCode,
+		featureStatus,
+		metrics.ResponseStatusOK,
+		metrics.ResponseStatusError)
+}
+
+// ResponseStatusForTelemetry returns response status for telemetry based on
+// HTTP status code and Feature status.
+func ResponseStatusForTelemetry(statusCode, featureStatus string) string {
+	return responseStatus(
+		statusCode,
+		featureStatus,
+		otelcollector.ApertureResponseStatusOK,
+		otelcollector.ApertureResponseStatusError)
+}
+
+func responseStatus(statusCode, featureStatus, okStatus, errorStatus string) string {
+	if strings.HasPrefix(statusCode, "2") {
+		return okStatus
+	}
+	if featureStatus != "" {
+		return featureStatus
+	}
+	return errorStatus
+}

--- a/pkg/otelcollector/metricsprocessor/internal/status.go
+++ b/pkg/otelcollector/metricsprocessor/internal/status.go
@@ -56,7 +56,11 @@ func ResponseStatusForTelemetry(statusCode, featureStatus string) string {
 }
 
 func responseStatus(statusCode, featureStatus, okStatus, errorStatus string) string {
-	if strings.HasPrefix(statusCode, "2") {
+	// Checking status code this way instead of parsing int properly handles empty
+	// string as well.
+	if strings.HasPrefix(statusCode, "1") ||
+		strings.HasPrefix(statusCode, "2") ||
+		strings.HasPrefix(statusCode, "3") {
 		return okStatus
 	}
 	if featureStatus != "" {

--- a/pkg/otelcollector/metricsprocessor/internal/status_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/status_test.go
@@ -1,0 +1,71 @@
+package internal_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
+	"github.com/fluxninja/aperture/pkg/metrics"
+	"github.com/fluxninja/aperture/pkg/otelcollector"
+	"github.com/fluxninja/aperture/pkg/otelcollector/metricsprocessor/internal"
+)
+
+var _ = Describe("Status", func() {
+	Context("StatusesFromAttributes", func() {
+		It("Read both statuses if exist", func() {
+			attributes := pcommon.NewMap()
+			attributes.PutStr(otelcollector.HTTPStatusCodeLabel, "201")
+			attributes.PutStr(otelcollector.ApertureFeatureStatusLabel, otelcollector.ApertureResponseStatusOK)
+			statusCode, featureStatus := internal.StatusesFromAttributes(attributes)
+			Expect(statusCode).To(Equal("201"))
+			Expect(featureStatus).To(Equal(otelcollector.ApertureResponseStatusOK))
+		})
+
+		It("Defaults to empty if not exist", func() {
+			attributes := pcommon.NewMap()
+			statusCode, featureStatus := internal.StatusesFromAttributes(attributes)
+			Expect(statusCode).To(Equal(""))
+			Expect(featureStatus).To(Equal(""))
+		})
+	})
+
+	DescribeTable("StatusLabelsForMetrics", func(
+		decisionType flowcontrolv1.CheckResponse_DecisionType,
+		statusCode string,
+		featureStatus string,
+		expectedResponseStatus string,
+	) {
+		result := internal.StatusLabelsForMetrics(decisionType, statusCode, featureStatus)
+		Expect(result).To(HaveLen(4))
+		Expect(result).To(HaveKeyWithValue(metrics.ResponseStatusLabel, expectedResponseStatus))
+		Expect(result).To(HaveKeyWithValue(metrics.DecisionTypeLabel, decisionType.String()))
+		Expect(result).To(HaveKeyWithValue(metrics.StatusCodeLabel, statusCode))
+		Expect(result).To(HaveKeyWithValue(metrics.FeatureStatusLabel, featureStatus))
+	},
+		Entry("Works for HTTP status OK",
+			flowcontrolv1.CheckResponse_DECISION_TYPE_ACCEPTED,
+			"201",
+			"",
+			metrics.ResponseStatusOK,
+		),
+		Entry("Works for HTTP status Error",
+			flowcontrolv1.CheckResponse_DECISION_TYPE_ACCEPTED,
+			"404",
+			"",
+			metrics.ResponseStatusError,
+		),
+		Entry("Works for Feature status OK",
+			flowcontrolv1.CheckResponse_DECISION_TYPE_ACCEPTED,
+			"",
+			metrics.FeatureStatusOK,
+			metrics.ResponseStatusOK,
+		),
+		Entry("Works for Feature status Error",
+			flowcontrolv1.CheckResponse_DECISION_TYPE_ACCEPTED,
+			"",
+			metrics.FeatureStatusError,
+			metrics.ResponseStatusError,
+		),
+	)
+})

--- a/pkg/otelcollector/metricsprocessor/processor.go
+++ b/pkg/otelcollector/metricsprocessor/processor.go
@@ -98,10 +98,6 @@ func (p *metricsProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) (plog.
 			p.updateMetrics(attributes, checkResponse, []string{otelcollector.EnvoyMissingAttributeValue})
 			internal.EnforceIncludeListHTTP(attributes)
 		}
-
-		// Add dynamic Flow labels
-		internal.AddFlowLabels(attributes, checkResponse)
-
 		return nil
 	})
 	return ld, err

--- a/pkg/otelcollector/metricsprocessor/processor.go
+++ b/pkg/otelcollector/metricsprocessor/processor.go
@@ -3,8 +3,6 @@ package metricsprocessor
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -15,6 +13,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/fluxninja/aperture/pkg/metrics"
 	"github.com/fluxninja/aperture/pkg/otelcollector"
+	"github.com/fluxninja/aperture/pkg/otelcollector/metricsprocessor/internal"
 	"github.com/fluxninja/aperture/pkg/policies/dataplane/iface"
 	"github.com/rs/zerolog"
 )
@@ -75,238 +74,37 @@ func (p *metricsProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) (plog.
 				return retErr("aperture check response label not found in Envoy access logs")
 			}
 
-			addSDKSpecificLabels(attributes)
+			internal.AddSDKSpecificLabels(attributes)
 		} else if sourceStr == otelcollector.ApertureSourceEnvoy {
 			success := otelcollector.GetStruct(attributes, otelcollector.ApertureCheckResponseLabel, checkResponse, []string{otelcollector.EnvoyMissingAttributeValue})
 			if !success {
 				return retErr("aperture check response label not found in SDK access logs")
 			}
 
-			addEnvoySpecificLabels(attributes)
+			internal.AddEnvoySpecificLabels(attributes)
 		} else {
 			return retErr("aperture source label not recognized")
 		}
 
-		statusCode, featureStatus := statusesFromAttributes(attributes)
-		attributes.PutStr(otelcollector.ApertureResponseStatusLabel, responseStatusForTelemetry(statusCode, featureStatus))
-		addCheckResponseBasedLabels(attributes, checkResponse, sourceStr)
+		statusCode, featureStatus := internal.StatusesFromAttributes(attributes)
+		attributes.PutStr(otelcollector.ApertureResponseStatusLabel, internal.ResponseStatusForTelemetry(statusCode, featureStatus))
+		internal.AddCheckResponseBasedLabels(attributes, checkResponse, sourceStr)
 
 		// Update metrics and enforce include list to eliminate any excess attributes
 		if sourceStr == otelcollector.ApertureSourceSDK {
 			p.updateMetrics(attributes, checkResponse, []string{})
-			enforceIncludeListSDK(attributes)
+			internal.EnforceIncludeListSDK(attributes)
 		} else if sourceStr == otelcollector.ApertureSourceEnvoy {
 			p.updateMetrics(attributes, checkResponse, []string{otelcollector.EnvoyMissingAttributeValue})
-			enforceIncludeListHTTP(attributes)
+			internal.EnforceIncludeListHTTP(attributes)
 		}
 
 		// Add dynamic Flow labels
-		addFlowLabels(attributes, checkResponse)
+		internal.AddFlowLabels(attributes, checkResponse)
 
 		return nil
 	})
 	return ld, err
-}
-
-func addSDKSpecificLabels(attributes pcommon.Map) {
-	// Compute durations
-	flowStart, flowStartExists := getSDKLabelTimestampValue(attributes, otelcollector.ApertureFlowStartTimestampLabel)
-	workloadStart, workloadStartExists := getSDKLabelTimestampValue(attributes, otelcollector.ApertureWorkloadStartTimestampLabel)
-	flowEnd, flowEndExists := getSDKLabelTimestampValue(attributes, otelcollector.ApertureFlowEndTimestampLabel)
-
-	if flowStartExists && flowEndExists {
-		flowDuration := flowEnd.Sub(flowStart)
-		attributes.PutDouble(otelcollector.FlowDurationLabel, float64(flowDuration.Milliseconds()))
-	}
-	if workloadStartExists && flowEndExists {
-		workloadDuration := flowEnd.Sub(workloadStart)
-		attributes.PutDouble(otelcollector.WorkloadDurationLabel, float64(workloadDuration.Milliseconds()))
-	}
-}
-
-func addEnvoySpecificLabels(attributes pcommon.Map) {
-	treatAsZero := []string{otelcollector.EnvoyMissingAttributeValue}
-	// Retrieve request length
-	requestLength, _ := otelcollector.GetFloat64(attributes, otelcollector.EnvoyBytesSentLabel, treatAsZero)
-	attributes.PutDouble(otelcollector.HTTPRequestContentLength, requestLength)
-	// Retrieve response lengths
-	responseLength, _ := otelcollector.GetFloat64(attributes, otelcollector.EnvoyBytesReceivedLabel, treatAsZero)
-	attributes.PutDouble(otelcollector.HTTPResponseContentLength, responseLength)
-
-	// Compute durations
-	responseDuration, responseDurationExists := otelcollector.GetFloat64(attributes, otelcollector.EnvoyResponseDurationLabel, treatAsZero)
-	authzDuration, authzDurationExists := otelcollector.GetFloat64(attributes, otelcollector.EnvoyAuthzDurationLabel, treatAsZero)
-
-	if responseDurationExists {
-		attributes.PutDouble(otelcollector.FlowDurationLabel, responseDuration)
-	}
-
-	if responseDurationExists && authzDurationExists {
-		attributes.PutDouble(otelcollector.WorkloadDurationLabel, responseDuration-authzDuration)
-	}
-}
-
-func getSDKLabelTimestampValue(attributes pcommon.Map, labelKey string) (time.Time, bool) {
-	return getLabelTimestampValue(attributes, labelKey, otelcollector.ApertureSourceSDK)
-}
-
-func getLabelTimestampValue(attributes pcommon.Map, labelKey, source string) (time.Time, bool) {
-	value, exists := getLabelValue(attributes, labelKey, source)
-	if !exists {
-		return time.Time{}, false
-	}
-	return _getLabelTimestampValue(value, labelKey, source)
-}
-
-func _getLabelTimestampValue(value pcommon.Value, labelKey, source string) (time.Time, bool) {
-	var valueInt int64
-	if value.Type() == pcommon.ValueTypeInt {
-		valueInt = value.Int()
-	} else {
-		log.Sample(zerolog.Sometimes).Warn().Str("source", source).Str("key", labelKey).Msg("Failed to parse a timestamp field")
-		return time.Time{}, false
-	}
-
-	return time.Unix(0, valueInt), true
-}
-
-func getLabelValue(attributes pcommon.Map, labelKey, source string) (pcommon.Value, bool) {
-	value, exists := attributes.Get(labelKey)
-	if !exists {
-		log.Sample(zerolog.Sometimes).Warn().Str("source", source).Str("key", labelKey).Msg("Label not found")
-		return pcommon.Value{}, false
-	}
-	return value, exists
-}
-
-// addCheckResponseBasedLabels adds the following labels:
-// * otelcollector.ApertureProcessingDurationLabel
-// * otelcollector.ApertureServicesLabel
-// * otelcollector.ApertureControlPointLabel
-// * otelcollector.ApertureRateLimitersLabel
-// * otelcollector.ApertureDroppingRateLimitersLabel
-// * otelcollector.ApertureConcurrencyLimitersLabel
-// * otelcollector.ApertureDroppingConcurrencyLimitersLabel
-// * otelcollector.ApertureWorkloadsLabel
-// * otelcollector.ApertureDroppingWorkloadsLabel
-// * otelcollector.ApertureFluxMetersLabel
-// * otelcollector.ApertureFlowLabelKeysLabel
-// * otelcollector.ApertureClassifiersLabel
-// * otelcollector.ApertureClassifierErrorsLabel
-// * otelcollector.ApertureDecisionTypeLabel
-// * otelcollector.ApertureRejectReasonLabel
-// * otelcollector.ApertureErrorLabel.
-func addCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse, sourceStr string) {
-	// Aperture Processing Duration
-	startTime := checkResponse.GetStart().AsTime()
-	endTime := checkResponse.GetEnd().AsTime()
-	if !startTime.IsZero() && !endTime.IsZero() {
-		attributes.PutDouble(otelcollector.ApertureProcessingDurationLabel, float64(endTime.Sub(startTime).Milliseconds()))
-	} else {
-		log.Sample(zerolog.Sometimes).Warn().Msgf("Aperture processing duration not found in %s access logs", sourceStr)
-	}
-	// Services
-	servicesValue := pcommon.NewValueSlice()
-	for _, service := range checkResponse.Services {
-		servicesValue.Slice().AppendEmpty().SetStr(service)
-	}
-	servicesValue.CopyTo(attributes.PutEmpty(otelcollector.ApertureServicesLabel))
-
-	// Control Point
-	attributes.PutString(otelcollector.ApertureControlPointLabel, checkResponse.GetControlPointInfo().String())
-
-	labels := map[string]pcommon.Value{
-		otelcollector.ApertureRateLimitersLabel:                pcommon.NewValueSlice(),
-		otelcollector.ApertureDroppingRateLimitersLabel:        pcommon.NewValueSlice(),
-		otelcollector.ApertureConcurrencyLimitersLabel:         pcommon.NewValueSlice(),
-		otelcollector.ApertureDroppingConcurrencyLimitersLabel: pcommon.NewValueSlice(),
-		otelcollector.ApertureWorkloadsLabel:                   pcommon.NewValueSlice(),
-		otelcollector.ApertureDroppingWorkloadsLabel:           pcommon.NewValueSlice(),
-		otelcollector.ApertureFluxMetersLabel:                  pcommon.NewValueSlice(),
-		otelcollector.ApertureFlowLabelKeysLabel:               pcommon.NewValueSlice(),
-		otelcollector.ApertureClassifiersLabel:                 pcommon.NewValueSlice(),
-		otelcollector.ApertureClassifierErrorsLabel:            pcommon.NewValueSlice(),
-		otelcollector.ApertureDecisionTypeLabel:                pcommon.NewValueStr(checkResponse.DecisionType.String()),
-		otelcollector.ApertureRejectReasonLabel:                pcommon.NewValueStr(checkResponse.GetRejectReason().String()),
-		otelcollector.ApertureErrorLabel:                       pcommon.NewValueStr(checkResponse.GetError().String()),
-	}
-	for _, decision := range checkResponse.LimiterDecisions {
-		if decision.GetRateLimiterInfo() != nil {
-			rawValue := []string{
-				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, decision.GetPolicyName()),
-				fmt.Sprintf("%s:%v", metrics.ComponentIndexLabel, decision.GetComponentIndex()),
-				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, decision.GetPolicyHash()),
-			}
-			value := strings.Join(rawValue, ",")
-			labels[otelcollector.ApertureRateLimitersLabel].Slice().AppendEmpty().SetStr(value)
-			if decision.Dropped {
-				labels[otelcollector.ApertureDroppingRateLimitersLabel].Slice().AppendEmpty().SetStr(value)
-			}
-		}
-		if cl := decision.GetConcurrencyLimiterInfo(); cl != nil {
-			rawValue := []string{
-				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, decision.GetPolicyName()),
-				fmt.Sprintf("%s:%v", metrics.ComponentIndexLabel, decision.GetComponentIndex()),
-				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, decision.GetPolicyHash()),
-			}
-			value := strings.Join(rawValue, ",")
-			labels[otelcollector.ApertureConcurrencyLimitersLabel].Slice().AppendEmpty().SetStr(value)
-			if decision.Dropped {
-				labels[otelcollector.ApertureDroppingConcurrencyLimitersLabel].Slice().AppendEmpty().SetStr(value)
-			}
-
-			workloadsRawValue := []string{
-				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, decision.GetPolicyName()),
-				fmt.Sprintf("%s:%v", metrics.ComponentIndexLabel, decision.GetComponentIndex()),
-				fmt.Sprintf("%s:%v", metrics.WorkloadIndexLabel, cl.GetWorkloadIndex()),
-				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, decision.GetPolicyHash()),
-			}
-			value = strings.Join(workloadsRawValue, ",")
-			labels[otelcollector.ApertureWorkloadsLabel].Slice().AppendEmpty().SetStr(value)
-			if decision.Dropped {
-				labels[otelcollector.ApertureDroppingWorkloadsLabel].Slice().AppendEmpty().SetStr(value)
-			}
-		}
-	}
-	for _, fluxMeter := range checkResponse.FluxMeterInfos {
-		value := fluxMeter.GetFluxMeterName()
-		labels[otelcollector.ApertureFluxMetersLabel].Slice().AppendEmpty().SetStr(value)
-	}
-
-	for _, flowLabelKey := range checkResponse.GetFlowLabelKeys() {
-		labels[otelcollector.ApertureFlowLabelKeysLabel].Slice().AppendEmpty().SetStr(flowLabelKey)
-	}
-
-	for _, classifier := range checkResponse.ClassifierInfos {
-		rawValue := []string{
-			fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, classifier.PolicyName),
-			fmt.Sprintf("%s:%v", metrics.ClassifierIndexLabel, classifier.ClassifierIndex),
-		}
-		value := strings.Join(rawValue, ",")
-		labels[otelcollector.ApertureClassifiersLabel].Slice().AppendEmpty().SetStr(value)
-
-		// add errors as attributes as well
-		if classifier.Error != flowcontrolv1.ClassifierInfo_ERROR_NONE {
-			errorsValue := []string{
-				classifier.Error.String(),
-				fmt.Sprintf("%s:%v", metrics.PolicyNameLabel, classifier.PolicyName),
-				fmt.Sprintf("%s:%v", metrics.ClassifierIndexLabel, classifier.ClassifierIndex),
-				fmt.Sprintf("%s:%v", metrics.PolicyHashLabel, classifier.PolicyHash),
-			}
-			joinedValue := strings.Join(errorsValue, ",")
-			labels[otelcollector.ApertureClassifierErrorsLabel].Slice().AppendEmpty().SetStr(joinedValue)
-		}
-	}
-
-	for key, value := range labels {
-		value.CopyTo(attributes.PutEmpty(key))
-	}
-}
-
-func addFlowLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse) {
-	for key, value := range checkResponse.TelemetryFlowLabels {
-		pcommon.NewValueStr(value).CopyTo(attributes.PutEmpty(key))
-	}
 }
 
 func (p *metricsProcessor) updateMetrics(
@@ -348,7 +146,7 @@ func (p *metricsProcessor) updateMetrics(
 
 	if len(checkResponse.FluxMeterInfos) > 0 {
 		// Update flux meter metrics
-		statusCode, featureStatus := statusesFromAttributes(attributes)
+		statusCode, featureStatus := internal.StatusesFromAttributes(attributes)
 		for _, fluxMeter := range checkResponse.FluxMeterInfos {
 			p.updateMetricsForFluxMeters(
 				fluxMeter,
@@ -443,109 +241,9 @@ func (p *metricsProcessor) updateMetricsForFluxMeters(
 	// metricValue is the value at fluxMeter's AttributeKey
 	metricValue, _ := otelcollector.GetFloat64(attributes, fluxMeter.GetAttributeKey(), treatAsZero)
 
-	labels := statusLabelsForMetrics(decisionType, statusCode, featureStatus)
+	labels := internal.StatusLabelsForMetrics(decisionType, statusCode, featureStatus)
 	fluxMeterHistogram := fluxMeter.GetHistogram(labels)
 	if fluxMeterHistogram != nil {
 		fluxMeterHistogram.Observe(metricValue)
 	}
-}
-
-func statusesFromAttributes(attributes pcommon.Map) (statusCode string, featureStatus string) {
-	rawStatusCode, exists := attributes.Get(otelcollector.HTTPStatusCodeLabel)
-	if exists {
-		statusCode = rawStatusCode.Str()
-	}
-	rawFeatureStatus, exists := attributes.Get(otelcollector.ApertureFeatureStatusLabel)
-	if exists {
-		featureStatus = rawFeatureStatus.Str()
-	}
-	return
-}
-
-func statusLabelsForMetrics(
-	decisionType flowcontrolv1.CheckResponse_DecisionType,
-	statusCode string,
-	featureStatus string,
-) map[string]string {
-	return map[string]string{
-		metrics.ResponseStatusLabel: responseStatusForMetrics(statusCode, featureStatus),
-		metrics.DecisionTypeLabel:   decisionType.String(),
-		metrics.StatusCodeLabel:     statusCode,
-		metrics.FeatureStatusLabel:  featureStatus,
-	}
-}
-
-func responseStatusForMetrics(statusCode, featureStatus string) string {
-	return responseStatus(
-		statusCode,
-		featureStatus,
-		metrics.ResponseStatusOK,
-		metrics.ResponseStatusError)
-}
-
-func responseStatusForTelemetry(statusCode, featureStatus string) string {
-	return responseStatus(
-		statusCode,
-		featureStatus,
-		otelcollector.ApertureResponseStatusOK,
-		otelcollector.ApertureResponseStatusError)
-}
-
-func responseStatus(statusCode, featureStatus, okStatus, errorStatus string) string {
-	if strings.HasPrefix(statusCode, "2") {
-		return okStatus
-	}
-	if featureStatus != "" {
-		return featureStatus
-	}
-	return errorStatus
-}
-
-/*
- * IncludeList: This IncludeList is applied to logs and spans at during the enrichment process, after check response based labels are attached and metrics have been parsed.
- */
-var (
-	_includeAttributesCommon = []string{
-		otelcollector.ApertureSourceLabel,
-		otelcollector.WorkloadDurationLabel,
-		otelcollector.FlowDurationLabel,
-		otelcollector.ApertureProcessingDurationLabel,
-		otelcollector.ApertureDecisionTypeLabel,
-		otelcollector.ApertureErrorLabel,
-		otelcollector.ApertureRejectReasonLabel,
-		otelcollector.ApertureRateLimitersLabel,
-		otelcollector.ApertureDroppingRateLimitersLabel,
-		otelcollector.ApertureConcurrencyLimitersLabel,
-		otelcollector.ApertureDroppingConcurrencyLimitersLabel,
-		otelcollector.ApertureWorkloadsLabel,
-		otelcollector.ApertureDroppingWorkloadsLabel,
-		otelcollector.ApertureFluxMetersLabel,
-		otelcollector.ApertureFlowLabelKeysLabel,
-		otelcollector.ApertureClassifiersLabel,
-		otelcollector.ApertureClassifierErrorsLabel,
-		otelcollector.ApertureServicesLabel,
-		otelcollector.ApertureControlPointLabel,
-		otelcollector.ApertureResponseStatusLabel,
-	}
-
-	_includeAttributesHTTP = []string{
-		otelcollector.HTTPStatusCodeLabel,
-		otelcollector.HTTPRequestContentLength,
-		otelcollector.HTTPResponseContentLength,
-	}
-
-	_includeAttributesSDK = []string{
-		otelcollector.ApertureFeatureStatusLabel,
-	}
-
-	includeListHTTP = otelcollector.FormIncludeList(append(_includeAttributesCommon, _includeAttributesHTTP...))
-	includeListSDK  = otelcollector.FormIncludeList(append(_includeAttributesCommon, _includeAttributesSDK...))
-)
-
-func enforceIncludeListHTTP(attributes pcommon.Map) {
-	otelcollector.EnforceIncludeList(attributes, includeListHTTP)
-}
-
-func enforceIncludeListSDK(attributes pcommon.Map) {
-	otelcollector.EnforceIncludeList(attributes, includeListSDK)
 }

--- a/pkg/otelcollector/metricsprocessor/processor_test.go
+++ b/pkg/otelcollector/metricsprocessor/processor_test.go
@@ -207,10 +207,11 @@ workload_latency_ms_count{component_index="1",decision_type="DECISION_TYPE_REJEC
 `
 
 		expectedLabels = map[string]interface{}{
-			oc.ApertureDecisionTypeLabel: flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED.String(),
-			oc.ApertureErrorLabel:        flowcontrolv1.CheckResponse_ERROR_NONE.String(),
-			oc.ApertureRejectReasonLabel: flowcontrolv1.CheckResponse_REJECT_REASON_NONE.String(),
-			oc.ApertureClassifiersLabel:  []interface{}{"policy_name:foo,classifier_index:1"},
+			oc.ApertureDecisionTypeLabel:   flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED.String(),
+			oc.ApertureErrorLabel:          flowcontrolv1.CheckResponse_ERROR_NONE.String(),
+			oc.ApertureRejectReasonLabel:   flowcontrolv1.CheckResponse_REJECT_REASON_NONE.String(),
+			oc.ApertureResponseStatusLabel: oc.ApertureResponseStatusOK,
+			oc.ApertureClassifiersLabel:    []interface{}{"policy_name:foo,classifier_index:1"},
 
 			oc.ApertureClassifierErrorsLabel: []interface{}{fmt.Sprintf("%s,policy_name:foo,classifier_index:1,policy_hash:foo-hash",
 				flowcontrolv1.ClassifierInfo_ERROR_EMPTY_RESULTSET.String())},

--- a/pkg/policies/dataplane/engine_test.go
+++ b/pkg/policies/dataplane/engine_test.go
@@ -99,10 +99,18 @@ var _ = Describe("Dataplane Engine", func() {
 	})
 
 	Context("Flux meter", func() {
+		var labels map[string]string
+
 		BeforeEach(func() {
 			mockFluxmeter.EXPECT().GetFluxMeterName().Return("test").AnyTimes()
 			mockFluxmeter.EXPECT().GetSelector().Return(selector).AnyTimes()
-			mockFluxmeter.EXPECT().GetHistogram(flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED, "200", "").Return(histogram).AnyTimes()
+			labels = map[string]string{
+				metrics.ResponseStatusLabel: metrics.ResponseStatusOK,
+				metrics.FeatureStatusLabel:  "",
+				metrics.StatusCodeLabel:     "200",
+				metrics.DecisionTypeLabel:   flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED.String(),
+			}
+			mockFluxmeter.EXPECT().GetHistogram(labels).Return(histogram).AnyTimes()
 			mockFluxmeter.EXPECT().GetFluxMeterID().Return(fluxMeterID).AnyTimes()
 		})
 
@@ -139,7 +147,7 @@ var _ = Describe("Dataplane Engine", func() {
 			err := engine.RegisterFluxMeter(mockFluxmeter)
 			Expect(err).NotTo(HaveOccurred())
 			fluxMeter := engine.GetFluxMeter("test")
-			h := fluxMeter.GetHistogram(flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED, "200", "")
+			h := fluxMeter.GetHistogram(labels)
 			Expect(h).To(Equal(histogram))
 		})
 	})
@@ -152,7 +160,6 @@ var _ = Describe("Dataplane Engine", func() {
 
 			mockFluxmeter.EXPECT().GetFluxMeterName().Return("test").AnyTimes()
 			mockFluxmeter.EXPECT().GetSelector().Return(selector).AnyTimes()
-			mockFluxmeter.EXPECT().GetHistogram(flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED, "503", "").Return(histogram).AnyTimes()
 			mockFluxmeter.EXPECT().GetFluxMeterID().Return(fluxMeterID).AnyTimes()
 		})
 

--- a/pkg/policies/dataplane/iface/flux-meter.go
+++ b/pkg/policies/dataplane/iface/flux-meter.go
@@ -4,7 +4,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	selectorv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/common/selector/v1"
-	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
 )
 
 //go:generate mockgen -source=flux-meter.go -destination=../../mocks/mock_flux_meter.go -package=mocks
@@ -33,6 +32,11 @@ type FluxMeter interface {
 	// GetFluxMeterID returns the flux meter ID
 	GetFluxMeterID() FluxMeterID
 
-	// GetHistogram returns the histogram observer for the flowcontrolv1.DecisionType
-	GetHistogram(decisionType flowcontrolv1.CheckResponse_DecisionType, statusCode string, featureStatus string) prometheus.Observer
+	// GetHistogram returns the histogram observer for given labels.
+	// It expects the following labels to be set:
+	//  * metrics.DecisionTypeLabel,
+	//  * metrics.ResponseStatusLabel,
+	//  * metrics.StatusCodeLabel,
+	//  * metrics.FeatureStatusLabel.
+	GetHistogram(labels map[string]string) prometheus.Observer
 }

--- a/pkg/policies/dataplane/resources/fluxmeter/flux-meter.go
+++ b/pkg/policies/dataplane/resources/fluxmeter/flux-meter.go
@@ -3,14 +3,12 @@ package fluxmeter
 import (
 	"context"
 	"path"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
 
 	selectorv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/common/selector/v1"
-	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
 	policylanguagev1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/language/v1"
 	wrappersv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/wrappers/v1"
 	"github.com/fluxninja/aperture/pkg/agentinfo"
@@ -240,36 +238,12 @@ func (fluxMeter *FluxMeter) GetFluxMeterID() iface.FluxMeterID {
 }
 
 // GetHistogram returns the histogram.
-func (fluxMeter *FluxMeter) GetHistogram(decisionType flowcontrolv1.CheckResponse_DecisionType,
-	statusCode string,
-	featureStatus string,
-) prometheus.Observer {
+func (fluxMeter *FluxMeter) GetHistogram(labels map[string]string) prometheus.Observer {
 	logger := fluxMeter.registry.GetLogger()
-	labels := make(map[string]string)
-	// Default ResponseStatusLabel is ResponseStatusFailure
-	labels[metrics.ResponseStatusLabel] = metrics.ResponseStatusError
-	// Set ResponseStatusLabel based on protocol specific status
-	if statusCode != "" {
-		// Set ResponseStatusLabel=ResponseStatusSuccess if status code is 2xx
-		if strings.HasPrefix(statusCode, "2") {
-			labels[metrics.ResponseStatusLabel] = metrics.ResponseStatusOK
-		} else {
-			labels[metrics.ResponseStatusLabel] = metrics.ResponseStatusError
-		}
-	} else if featureStatus != "" {
-		// pass through in case of feature status
-		labels[metrics.ResponseStatusLabel] = featureStatus
-	}
-
-	labels[metrics.DecisionTypeLabel] = decisionType.String()
-	labels[metrics.StatusCodeLabel] = statusCode
-	labels[metrics.FeatureStatusLabel] = featureStatus
-
 	fluxMeterHistogram, err := fluxMeter.histMetricVec.GetMetricWith(labels)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Getting latency histogram")
 		return nil
 	}
-
 	return fluxMeterHistogram
 }

--- a/pkg/policies/mocks/mock_flux_meter.go
+++ b/pkg/policies/mocks/mock_flux_meter.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	selectorv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/common/selector/v1"
-	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/v1"
 	iface "github.com/fluxninja/aperture/pkg/policies/dataplane/iface"
 	gomock "github.com/golang/mock/gomock"
 	prometheus "github.com/prometheus/client_golang/prometheus"
@@ -80,17 +79,17 @@ func (mr *MockFluxMeterMockRecorder) GetFluxMeterName() *gomock.Call {
 }
 
 // GetHistogram mocks base method.
-func (m *MockFluxMeter) GetHistogram(decisionType flowcontrolv1.CheckResponse_DecisionType, statusCode, featureStatus string) prometheus.Observer {
+func (m *MockFluxMeter) GetHistogram(labels map[string]string) prometheus.Observer {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistogram", decisionType, statusCode, featureStatus)
+	ret := m.ctrl.Call(m, "GetHistogram", labels)
 	ret0, _ := ret[0].(prometheus.Observer)
 	return ret0
 }
 
 // GetHistogram indicates an expected call of GetHistogram.
-func (mr *MockFluxMeterMockRecorder) GetHistogram(decisionType, statusCode, featureStatus interface{}) *gomock.Call {
+func (mr *MockFluxMeterMockRecorder) GetHistogram(labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistogram", reflect.TypeOf((*MockFluxMeter)(nil).GetHistogram), decisionType, statusCode, featureStatus)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistogram", reflect.TypeOf((*MockFluxMeter)(nil).GetHistogram), labels)
 }
 
 // GetSelector mocks base method.


### PR DESCRIPTION
### Description of change
This introduces `aperture.response_status` column in telemetry. It mirrors the implementation of `response_status` label for metrics.
This also extends above logic to include `1xx`, `2xx`, and `3xx` codes as OK instead of only `2xx` codes.

Besides this, some cleanup is done:
1. Above logic is moved from `FluxMeter` to OTEL package. **This changes FluxMeter interface!**
2. A log of logic is moved from `metricsprocessor` to `metricsprocessor/internal` for better visibility and easier separation of functions which are called directly in metricsprocessor and helpers,
3. The above made creating UT much easier, so this PR also includes some.

Ref: https://github.com/fluxninja/cloud/issues/6788

##### Checklist

- [x] Tested in playground or other setup
- [x] Tests and/or benchmarks are included
- [x] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/828)
<!-- Reviewable:end -->
