### PR TITLE
Ignore negative workload latency

### DIFF
--- a/pkg/otelcollector/metricsprocessor/internal/envoy_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/envoy_labels.go
@@ -25,6 +25,10 @@ func AddEnvoySpecificLabels(attributes pcommon.Map) {
 	}
 
 	if responseDurationExists && authzDurationExists {
-		attributes.PutDouble(otelcollector.WorkloadDurationLabel, responseDuration-authzDuration)
+		workloadDuration := responseDuration - authzDuration
+		// discard negative values which can happen in case of connection resets
+		if workloadDuration > 0 {
+			attributes.PutDouble(otelcollector.WorkloadDurationLabel, workloadDuration)
+		}
 	}
 }


### PR DESCRIPTION
### Issue
* Workload latency in case of Envoy is calculated as:
```
workload_latency = response_latency - aperture_latency
```
* Workload Latency can become negative in case of connection reset
  * If the connection is aborted by Client or Server Envoy immediately terminates the connection for the other endpoint.
  * In the Access Log, status code is set as 0 and `response_latency` is set as zero.
  * If Authz call to Aperture Agent had succeeded for this request, then aperture_latency is greater than zero.
  * This would lead the `workload_latency` to be computed as negative.
![Screenshot from 2022-10-28 19-24-44](https://user-images.githubusercontent.com/3925292/198775984-661e8293-e2eb-4357-a616-8552946572a0.png)

### Fix
* Ignore negative workload latency I.E. don't populate the workload latency column
* Publish Prometheus metrics for flux-meter or workload latency only if the metric column is found

##### Checklist

- [ ] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/839)
<!-- Reviewable:end -->
