### PR TITLE
Publish Reject Workload Metrics

### DIFF
--- a/pkg/otelcollector/metricsprocessor/processor.go
+++ b/pkg/otelcollector/metricsprocessor/processor.go
@@ -81,7 +81,7 @@ func (p *metricsProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) (plog.
 				return retErr("aperture check response label not found in Envoy access logs")
 			}
 
-			internal.AddEnvoySpecificLabels(attributes)
+			internal.AddEnvoySpecificLabels(attributes, checkResponse)
 		} else {
 			return retErr("aperture source label not recognized")
 		}


### PR DESCRIPTION
### Description of change
* Publish Reject Workload Metrics for workload and flux-meter metrics in order to be plot reject throughput in Grafana

##### Checklist

- [ ] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/841)
<!-- Reviewable:end -->
