### PR TITLE
Downgrade bitnami/common to 1.17.1

### DIFF
--- a/manifests/charts/aperture-agent/Chart.lock
+++ b/manifests/charts/aperture-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.1.1
-digest: sha256:15f49767c97b6d234ed3926e5a5f6238b28257a28a5ebe62f9512228279641a0
-generated: "2022-10-28T18:53:59.289226605-07:00"
+  version: 1.17.1
+digest: sha256:52b0f2fd311a6cc6a4442ea902b3b5d6a9900cf14a19ee58a28bec2a53ac9d29
+generated: "2022-10-31T11:22:40.872556163+01:00"

--- a/manifests/charts/aperture-agent/Chart.yaml
+++ b/manifests/charts/aperture-agent/Chart.yaml
@@ -7,4 +7,4 @@ icon: https://raw.githubusercontent.com/fluxninja/aperture/gh-pages/FluxNinja--m
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: "=2.1.1"
+    version: "=1.17.1"

--- a/manifests/charts/aperture-controller/Chart.lock
+++ b/manifests/charts/aperture-controller/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.1.1
+  version: 1.17.1
 - name: etcd
   repository: https://charts.bitnami.com/bitnami
   version: 8.5.8
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.17.0
-digest: sha256:93fe41a9a1173b2747aa92f5235a54f7d46df8557188c6665367eab07506c130
-generated: "2022-10-28T18:54:04.286784523-07:00"
+digest: sha256:a7512ae68c774ff9550d0f4ea79cd4fe75716df843f82d99c89d7940bca6303f
+generated: "2022-10-31T11:23:00.126852766+01:00"

--- a/manifests/charts/aperture-controller/Chart.yaml
+++ b/manifests/charts/aperture-controller/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://raw.githubusercontent.com/fluxninja/aperture/gh-pages/FluxNinja--m
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: "=2.1.1"
+    version: "=1.17.1"
   - name: etcd
     version: "=8.5.8"
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
With 2.0.0 an incompatible change was made to image construction logic

See: https://github.com/bitnami/charts/issues/11858#issuecomment-1296892579

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/849)
<!-- Reviewable:end -->
