### PR TITLE
panichandler: process panic handlers in the same go routine

### DIFF
--- a/plugins/service/aperture-plugin-sentry/sentry/sentrywriter.go
+++ b/plugins/service/aperture-plugin-sentry/sentry/sentrywriter.go
@@ -122,7 +122,7 @@ func bytesToStrUnsafe(data []byte) string {
 }
 
 // sentryPanicHandler is a panic handler that sends the fatal level event to Sentry with diagnostic information.
-func (s *SentryWriter) sentryPanicHandler(e interface{}, stacktrace panichandler.Callstack) {
+func (s *SentryWriter) sentryPanicHandler(e interface{}, _ panichandler.Callstack) {
 	duration, _ := time.ParseDuration(SentryFlushWait)
 
 	// Crash Log
@@ -215,14 +215,6 @@ func (s *SentryWriter) sentryPanicHandler(e interface{}, stacktrace panichandler
 			Message:  "No Version Information found",
 		})
 	}
-
-	// Stacktrace
-	sentry.AddBreadcrumb(&sentry.Breadcrumb{
-		Type:     "debug",
-		Category: "Stacktrace",
-		Level:    sentry.LevelInfo,
-		Data:     stacktrace.GetEntries(),
-	})
 
 	sentry.CurrentHub().Recover(e)
 	sentry.Flush(duration)


### PR DESCRIPTION
### Description of change
Sentry runs it's own stack capture therefore it's better to run the handler in the same go routine that panic'ed. Otherwise Sentry is unable to distinguish crashes from one another.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/875)
<!-- Reviewable:end -->
