### PR TITLE
Fix Wrong link associated in playground docs

### DIFF
--- a/docs/content/get-started/playground.md
+++ b/docs/content/get-started/playground.md
@@ -67,7 +67,7 @@ with Aperture. There is an instance of Grafana running on the cluster as well
 for viewing metrics from experiments.
 
 The Playground is preloaded with a
-[Latency Gradient Concurrency Control](/tutorials/flow-control/concurrency-limiter.md)
+[Latency Gradient Concurrency Control](/tutorials/flow-control/basic-concurrency-limiting.md)
 policy which protects the demo application against sudden surges in traffic
 load. You can verify it using the following command:
 

--- a/docs/content/get-started/playground.md
+++ b/docs/content/get-started/playground.md
@@ -67,7 +67,7 @@ with Aperture. There is an instance of Grafana running on the cluster as well
 for viewing metrics from experiments.
 
 The Playground is preloaded with a
-[Latency Gradient Concurrency Control](/tutorials/flow-control/dynamic-rate-limiting.md)
+[Latency Gradient Concurrency Control](/tutorials/flow-control/concurrency-limiter.md)
 policy which protects the demo application against sudden surges in traffic
 load. You can verify it using the following command:
 


### PR DESCRIPTION
### Description of change
Closes: #889 

##### Checklist

- [ ] Tested in playground or other setup
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/890)
<!-- Reviewable:end -->
