### PR TITLE
playground grafana: Set scrape interval in prometheus data source

### DIFF
--- a/playground/tanka/lib/apps/aperture-grafana/main.libsonnet
+++ b/playground/tanka/lib/apps/aperture-grafana/main.libsonnet
@@ -19,6 +19,9 @@ local dataSources =
         type: 'prometheus',
         access: 'proxy',
         url: 'http://controller-prometheus-server',
+        jsonData: {
+          timeInterval: '1s',
+        },
       }),
     operationsPrometheus:
       dataSource.new('operations-prometheus') +


### PR DESCRIPTION
This increases level of detail in charts, because default interval (15s)
resulted in effectively capping interval in queries to 1m.

Before (start & stop of workload generator):

![image](https://user-images.githubusercontent.com/3074996/200807913-24cd734a-f200-4b58-80d5-395e2680f236.png)

After:

![image](https://user-images.githubusercontent.com/3074996/200808037-0d28f84c-e1ce-48e7-9934-131c8fc8db2b.png)

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/908)
<!-- Reviewable:end -->
