### PR TITLE
Add ENV variable for armeria client and server

### DIFF
--- a/sdks/aperture-java/src/main/java/com/fluxninja/aperture/example/ArmeriaClient.java
+++ b/sdks/aperture-java/src/main/java/com/fluxninja/aperture/example/ArmeriaClient.java
@@ -10,15 +10,25 @@ import com.linecorp.armeria.common.HttpResponse;
 import java.time.Duration;
 
 public class ArmeriaClient {
+
+    public static final String DEFAULT_APP_PORT = "8080";
+    public static final String DEFAULT_AGENT_HOST = "localhost";
+    public static final String DEFAULT_AGENT_PORT = "8089";
     public static void main(String[] args) {
-        final String agentHost = "localhost";
-        final int agentPort = 8089;
+        String agentHost = System.getenv("FN_AGENT_HOST");
+        if (agentHost == null) {
+            agentHost = DEFAULT_AGENT_HOST;
+        }
+        String agentPort = System.getenv("FN_AGENT_PORT");
+        if (agentPort == null) {
+            agentPort = DEFAULT_AGENT_PORT;
+        }
 
         ApertureSDK apertureSDK;
         try {
             apertureSDK = ApertureSDK.builder()
                     .setHost(agentHost)
-                    .setPort(agentPort)
+                    .setPort(Integer.parseInt(agentPort))
                     .setDuration(Duration.ofMillis(1000))
                     .build();
         } catch (ApertureSDKException e) {

--- a/sdks/aperture-java/src/main/java/com/fluxninja/aperture/example/ArmeriaServer.java
+++ b/sdks/aperture-java/src/main/java/com/fluxninja/aperture/example/ArmeriaServer.java
@@ -11,6 +11,11 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 public class ArmeriaServer {
+
+    public static final String DEFAULT_APP_PORT = "8080";
+    public static final String DEFAULT_AGENT_HOST = "localhost";
+    public static final String DEFAULT_AGENT_PORT = "8089";
+
     public static HttpService createHelloHTTPService() {
         return new AbstractHttpService() {
             @Override
@@ -37,14 +42,20 @@ public class ArmeriaServer {
     }
 
     public static void main(String[] args) {
-        final String agentHost = "localhost";
-        final int agentPort = 8089;
+        String agentHost = System.getenv("FN_AGENT_HOST");
+        if (agentHost == null) {
+            agentHost = DEFAULT_AGENT_HOST;
+        }
+        String agentPort = System.getenv("FN_AGENT_PORT");
+        if (agentPort == null) {
+            agentPort = DEFAULT_AGENT_PORT;
+        }
 
         ApertureSDK apertureSDK;
         try {
             apertureSDK = ApertureSDK.builder()
                     .setHost(agentHost)
-                    .setPort(agentPort)
+                    .setPort(Integer.parseInt(agentPort))
                     .setDuration(Duration.ofMillis(1000))
                     .build();
         } catch (ApertureSDKException e) {


### PR DESCRIPTION
### Description of change
Fix https://github.com/fluxninja/aperture/issues/891

This PR fix the first part of the issue mention by @hasit  . Where ENV variable where missing from armeria client and server due to which aperture-java sdk was failing on Tilt playground when user clicked on `trigger library example`

as discuss with @krdln , raising this PR... second part will be done by @IridiumOxide soon.

cc @krdln 

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/913)
<!-- Reviewable:end -->
