### PR TITLE
Dry run docs and link versioning

### DIFF
--- a/docs/content/get-started/playground.md
+++ b/docs/content/get-started/playground.md
@@ -37,7 +37,7 @@ commands:
 ```sh
 $ git clone https://github.com/fluxninja/aperture.git
 # change directory to playground
-$ cd playground
+$ cd aperture/playground
 # start a local kubernetes cluster
 $ ctlptl apply -f ctlptl-kind-config.yaml
 # start Tilt and run services defined in Tiltfile

--- a/docs/content/get-started/policies/blueprints.md
+++ b/docs/content/get-started/policies/blueprints.md
@@ -8,6 +8,11 @@ keywords:
 sidebar_position: 1
 ---
 
+```mdx-code-block
+import {apertureVersion} from '@site/src/version';
+import CodeBlock from '@theme/CodeBlock';
+```
+
 ## Introduction
 
 Aperture comes with a pre-packaged list of [Aperture Policies][policies] and
@@ -21,30 +26,22 @@ standalone Aperture Blueprints.
 
 [jsonnet-lang]: https://jsonnet.org
 
-## Initial Setup
+## Tools
 
-Aperture Blueprints can be found in the [Aperture Repository][aperture-repo]
-under `blueprints/` directory.
+In order to generate Blueprints please install the pre-requisites [`jb`][jb] and
+[`jsonnet`][jsonnet].
 
-The Blueprint Generator (used to generate policy files from blueprints) depends
-on [jsonnet][go-jsonnet].
-
-[aperture-repo]: https://github.com/fluxninja/aperture/
 [jb]: https://github.com/jsonnet-bundler/jsonnet-bundler
-[go-jsonnet]: https://github.com/google/go-jsonnet
+[jsonnet]: https://github.com/google/jsonnet
 
 ## Generating Aperture Policies and Grafana Dashboards
 
-To generate files, `blueprints/scripts/generate-bundle.py` script can be used.
-The script takes as options an output directory path where files will be saved
-and a path to a config libsonnet file containing blueprint customization and
-configuration.
-
-Under the `blueprints/lib/1.0/blueprints` directory, the currently available
-blueprints can be found. In each blueprint, `bundle.libsonnet` can be used to
-generate the actual artifacts, and `config.libsonnet` comes with the default
-configuration for the given blueprint. This can be overridden by the `--config`
-option passed to the `generate-bundle.py` script.
+The available Aperture Blueprints can be found under <a
+href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/blueprints/lib/1.0/blueprints/`}>`blueprints/lib/1.0/blueprints`</a>.
+In each blueprint, `bundle.libsonnet` can be used to generate the actual
+artifacts, and `config.libsonnet` comes with the default configuration for the
+given blueprint. This can be overridden by the `--config` option passed to the
+`generate-bundle.py` script.
 
 Custom configurations can be merged with blueprints' `config.libsonnet`
 resulting in the final configuration, according to jsonnet language rules: keys
@@ -52,10 +49,17 @@ can be overwritten by reusing them in the custom configuration and nested
 objects can be merged by using `+:` operator. Check the `example` directory for
 more information.
 
-The full command using the example looks like this:
+To generate files, the script <a
+href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/blueprints/scripts/generate-bundle.py`}>`blueprints/scripts/generate-bundle.py`</a>
+can be used. This script takes arguments for the output directory path where
+files will be saved and a path to a config libsonnet file containing blueprint
+customization and configuration. The full command using an example config looks
+like this:
 
 ```sh
-jb install && ./scripts/generate-bundle.py --output _gen --config examples/latency-gradient/example.jsonnet
+cd blueprints/
+jb install
+./scripts/generate-bundle.py --output _gen --config examples/latency-gradient/example.jsonnet
 ```
 
 ## Using Aperture Blueprints as a jsonnet mixins library
@@ -106,11 +110,31 @@ The generated policy can be applied to the running instance of
 kubectl apply --namespace aperture-controller --filename [example file].yaml
 ```
 
+## Dry Run Mode
+
+Some of the Policy Blueprints can be configured to generate a Policy in
+`Dry Run` Mode. In the `Dry Run` mode, Actuation is disabled and the Policy runs
+in observation only mode. The decisions are still evaluated which helps
+understand how the policy would behave as the input signals change.
+
+For instance, setting `dynamicConfig.dryRun` option to `true` in the
+latency-gradient blueprint would generate a Dry Run policy.
+
+:::note
+
+The outcome of a `Dry Run` policy would be different compared to a policy that
+actuates. This is because actuation changes the system being controlled which
+would result in a different kind of Signal feedback. While `Dry Run` mode is not
+a simulation, it's still useful in understanding the signal processing and
+decisions made in each _execution cycle_.
+
+:::
+
 To understand what the above policy does, please see the
 [Basic Concurrency Limiting](/tutorials/flow-control/basic-concurrency-limiting.md)
 tutorial.
 
 [jsonnet]: https://github.com/google/go-jsonnet
-[tk]: https://grafana.com/oss/tanka/
-[policies]: /concepts/policy/policy.md
+
+[tk]: https://grafana.com/oss/tanka/ [policies]: /concepts/policy/policy.md
 [service]: /concepts/service.md

--- a/docs/content/tutorials/flow-control/basic-concurrency-limiting.md
+++ b/docs/content/tutorials/flow-control/basic-concurrency-limiting.md
@@ -82,22 +82,6 @@ At a high-level, this policy consists of:
 </Tabs>
 ```
 
-:::tip
-
-You can run the above policy in the `Dry Run` mode by setting the
-`dynamicConfig.dryRun` option to `true`. In the `Dry Run` mode, the policy
-doesn't actuate (i.e. traffic is never dropped) while still evaluating the
-decision it would take in each cycle. This helps understanding how the policy
-would behave as the input signals change.
-
-Note: In the `Dry Run` mode, because the policy doesn't actuate, the outcome
-would be very different in the live mode as input signals will change based on
-actuation decisions. While `Dry Run` mode is not a simulation, it's still useful
-in understanding the signal processing and decisions made in an _execution
-cycle_.
-
-:::
-
 ### Circuit Diagram
 
 <Zoom>
@@ -122,6 +106,14 @@ the latency within the tolerance limit (`1.1`) configured in the circuit.
 ![Basic Concurrency Limiting](./assets/basic-concurrency-limiting/basic-concurrency-limiting-playground.png)
 
 </Zoom>
+
+### Dry Run Mode
+
+You can run this policy in the `Dry Run` mode by setting the
+`dynamicConfig.dryRun` option to `true`. In the `Dry Run` mode, the policy
+doesn't actuate (i.e. traffic is never dropped) while still evaluating the
+decision it would take in each cycle. This helps understand how the policy would
+behave as the input signals change.
 
 ### Demo Video
 


### PR DESCRIPTION
### Description of change
* Dry run docs
* Add links to versioned Blueprints in GitHub
* Fix playground `cd` command
* Depends on [Tech docs PR](https://github.com/fluxninja/aperture-tech-docs/pull/97)

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/914)
<!-- Reviewable:end -->
