### PR TITLE
Docs: Aperture version is self-contained inside docs

### DIFF
--- a/docs/content/get-started/policies/blueprints.md
+++ b/docs/content/get-started/policies/blueprints.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 ---
 
 ```mdx-code-block
-import {apertureVersion} from '@site/src/version';
+import {apertureVersion} from '../../introduction.md';
 ```
 
 ## Introduction
@@ -134,6 +134,6 @@ To understand what the above policy does, please see the
 tutorial.
 
 [jsonnet]: https://github.com/google/go-jsonnet
-
-[tk]: https://grafana.com/oss/tanka/ [policies]: /concepts/policy/policy.md
+[tk]: https://grafana.com/oss/tanka/
+[policies]: /concepts/policy/policy.md
 [service]: /concepts/service.md

--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -12,6 +12,10 @@ keywords:
   - cloud
 ---
 
+```mdx-code-block
+export const apertureVersion = "0.9.0";
+```
+
 # Introduction
 
 ```mdx-code-block


### PR DESCRIPTION
### Description of change
* Version of Aperture is versioned with the docs and exported as a variable.
* Links, install commands etc. can be templated based on the version variable.

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/920)
<!-- Reviewable:end -->
