### PR TITLE
Enable race detection for agent and controller using `--race` flag in tilt dev environment

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -681,9 +681,10 @@ jobs:
             mkdir -p $HOME/go
             GOPATH=$HOME/go
             PATH=$PATH:$GOPATH/bin
+            RACE=""
 
-            export GIT_BRANCH GIT_COMMIT_HASH GOOS VERSION GOPATH PATH
-            declare -p GIT_BRANCH GIT_COMMIT_HASH GOOS VERSION GOPATH PATH >> "${BASH_ENV}"
+            export GIT_BRANCH GIT_COMMIT_HASH GOOS VERSION GOPATH PATH RACE
+            declare -p GIT_BRANCH GIT_COMMIT_HASH GOOS VERSION GOPATH PATH RACE >> "${BASH_ENV}"
           environment:
             RELEASE_TAG: <<pipeline.git.tag>>
       - restore_cache:

--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -15,6 +15,8 @@ ARG GIT_BRANCH
 ENV GIT_BRANCH=${GIT_BRANCH}
 ARG VERSION
 ENV VERSION=${VERSION}
+ARG RACE
+ENV RACE=${RACE}
 
 FROM base AS builder
 RUN --mount=type=cache,target=/go/pkg/ \

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -15,6 +15,8 @@ ARG GIT_BRANCH
 ENV GIT_BRANCH=${GIT_BRANCH}
 ARG VERSION
 ENV VERSION=${VERSION}
+ARG RACE
+ENV RACE=${RACE}
 
 FROM base AS builder
 RUN --mount=type=cache,target=/go/pkg/ \

--- a/pkg/info/build.sh
+++ b/pkg/info/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eux
 
 # This script builds a Go binary and injects build-time variables.
@@ -23,4 +23,8 @@ LDFLAGS="\
     -X 'github.com/fluxninja/aperture/pkg/info.GitCommitHash=${GIT_COMMIT_HASH}' \
     -X 'github.com/fluxninja/aperture/pkg/info.Prefix=${PREFIX}' \
 "
-go build --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"
+if [[ -z "${RACE}" ]]; then
+    go build --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"
+else
+    go build --race --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"
+fi

--- a/pkg/plugins/build.sh
+++ b/pkg/plugins/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eux
 
 # This script builds a Go plugin and injects build-time variables.
@@ -19,4 +19,8 @@ LDFLAGS="\
     -X 'main.GitBranch=${GIT_BRANCH}' \
     -X 'main.GitCommitHash=${GIT_COMMIT_HASH}' \
 "
-go build -buildmode=plugin --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"
+if [[ -z "${RACE}" ]]; then
+    go build -buildmode=plugin --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"
+else
+    go build -buildmode=plugin --race --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"
+fi

--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -101,6 +101,7 @@ DEP_TREE = {
                     "context": GIT_ROOT,
                     "dockerfile": GIT_ROOT + "/cmd/aperture-controller/Dockerfile",
                     "ssh": "default",
+                    "build_args":{'RACE': ""},
                 },
                 {
                     "ref": "aperture-operator",
@@ -200,6 +201,7 @@ DEP_TREE = {
                     "context": GIT_ROOT,
                     "dockerfile": GIT_ROOT + "/cmd/aperture-agent/Dockerfile",
                     "ssh": "default",
+                    "build_args":{'RACE':""},
                 }
             ],
             "kinds": [
@@ -821,7 +823,7 @@ def forward_port_delayed(workload, labels, resource_deps, namespace, service, lo
     )
 
 
-def declare_resources(resources, dep_tree, inv_dep_tree):
+def declare_resources(resources, dep_tree, inv_dep_tree,race_arg):
     """
     Declares resource-specific actions (images, ports, etc)
     Generating manifests with tanka is done separately, in order to speed up builds
@@ -829,6 +831,12 @@ def declare_resources(resources, dep_tree, inv_dep_tree):
     for resource in resources:
         resource_info = inv_dep_tree[resource]
         labels = resource_info.get("labels", [])
+        if race_arg:
+            images = resource_info.get("images",{})
+            if resource == "controller":
+                images[0]["build_args"]["RACE"] = "Yes"
+            if resource == "agent":
+                images[0]["build_args"]["RACE"] = "Yes"
         for image in resource_info.get("images", []):
             if 'tag' in image.keys():
                 # We will be pulling existing image
@@ -984,6 +992,7 @@ config.define_bool("manual", usage="Set trigger mode to manual")
 config.define_bool("only", usage="Only deploy explicitly resources, without handling dependencies")
 config.define_bool("verbose", usage="Enable verbose logging")
 config.define_bool("trace", usage="Enable trace logging")
+config.define_bool("race",usage="Enable race detector for agent and controller")
 cfg = config.parse()
 # Enable all resources, as calling `config.parse()` by default disables all
 config.set_enabled_resources([])
@@ -995,6 +1004,7 @@ if cfg.get("list-resources", False):
 if cfg.get("manual", False):
     trigger_mode(TRIGGER_MODE_MANUAL)
 
+get_race = cfg.get("race",False)
 
 cfg_trace = cfg.get("trace", os.getenv("NINJA_TILT_TRACE", "false"))
 TRACE = cfg_trace == True
@@ -1096,5 +1106,4 @@ cmd_button('aperture-java-trigger',
         icon_name='ads_click',
         text='Trigger library example',
 )
-
-declare_resources(resources, DEP_TREE, inverted_dep_tree)
+declare_resources(resources, DEP_TREE, inverted_dep_tree,get_race)


### PR DESCRIPTION
### Description of change
Fix  https://github.com/fluxninja/aperture/issues/758

Add `--race` flag which build the agent and controller binary passing `go build --race ....` flag.
Usage:
```
tilt up -- --race
```

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/922)
<!-- Reviewable:end -->
