### PR TITLE
Fixed multiple definition error on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
           environment:
             CGO_ENABLED: "1"
             PREFIX: "aperture"
-            LDFLAGS: "-s -w"
+            LDFLAGS: "-s -w -extldflags \"-Wl,--allow-multiple-definition\""
       - run:
           name: Install nFPM
           command: |


### PR DESCRIPTION
### Description of change
Added `--allow-multiple-definition` flag for fixing the `multiple definition` error.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/923)
<!-- Reviewable:end -->
