### PR TITLE
Improve visibility of sampled logs

### DIFF
--- a/pkg/alerts/alert.go
+++ b/pkg/alerts/alert.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/alertmanager/api/v2/models"
-	"github.com/rs/zerolog"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
@@ -90,7 +89,7 @@ func AlertsFromLogs(ld plog.Logs) []*Alert {
 		resourceAttributes := resourceLogs.Resource().Attributes()
 		generatorURL, exists := resourceAttributes.Get(otelcollector.AlertGeneratorURLLabel)
 		if !exists {
-			log.Sample(zerolog.Sometimes).Trace().
+			log.Trace().
 				Str("key", otelcollector.AlertGeneratorURLLabel).Msg("Key not found")
 			return nil
 		}

--- a/pkg/log/log_suite_test.go
+++ b/pkg/log/log_suite_test.go
@@ -1,0 +1,30 @@
+package log_test
+
+import (
+	"io"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/utils"
+)
+
+func TestLog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Log Suite")
+}
+
+var l *utils.GoLeakDetector
+
+var _ = BeforeSuite(func() {
+	l = utils.NewGoLeakDetector()
+	// This suite test the global logger via hooks, so hide its output.
+	log.SetGlobalLogger(log.NewLogger(io.Discard, "info"))
+})
+
+var _ = AfterSuite(func() {
+	err := l.FindLeaks()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/log/samplers.go
+++ b/pkg/log/samplers.go
@@ -1,0 +1,69 @@
+package log
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// NewRatelimitingSampler return a log sampler that allows max one log entry
+// per few seconds.
+//
+// Use to report cases when we want to warn for visibility, but the warning is
+// likely to reoccur, and we don't want to spam logs. Eg. Invalid arguments on
+// some intra-aperture RPC call.
+//
+// This should be preferred over log.Sample(zerolog.Sometimes), so that we can
+// be sure that one-off or low-frequency cases are always logged.
+// It's preferred to create a new Sampler for each kind of Msg you send.
+//
+// See also Logger.Autosample()
+//
+// Note: Return value should be persisted – do not pass directly to
+// log.Sample().
+func NewRatelimitingSampler() zerolog.Sampler {
+	return &zerolog.BurstSampler{
+		Burst:  1,
+		Period: 5 * time.Second,
+	}
+}
+
+func getAutosampler() zerolog.Sampler {
+	// We want separate sampler for every callsite of Autosample() and Bug().
+	// Usage of Caller has some runtime cost, but that's acceptable:
+	// * for Autosample() a more performant (and verbose) alternative exists,
+	// * Bug() in theory never happens, so we shouldn't care too much about perf.
+	callerPC, _, _, pcValid := runtime.Caller(2)
+	if !pcValid {
+		bugWithSampler(global, badCallerSampler).Msg("bug: Cannot get caller info")
+		callerPC = 0
+	}
+	if sampler := getExistingAutosampler(callerPC); sampler != nil {
+		return sampler
+	}
+	autoSamplersLock.Lock()
+	defer autoSamplersLock.Unlock()
+	// Note: Possible race with another getAutosampler() call, but that's a
+	// harmless race.
+	sampler := NewRatelimitingSampler()
+	autoSamplers[callerPC] = sampler
+	return sampler
+}
+
+func getExistingAutosampler(callerPC uintptr) zerolog.Sampler {
+	autoSamplersLock.RLock()
+	defer autoSamplersLock.RUnlock()
+	return autoSamplers[callerPC]
+}
+
+func bugWithSampler(lg *Logger, sampler zerolog.Sampler) *zerolog.Event {
+	return lg.Sample(sampler).Warn().Bool(bugKey, true)
+}
+
+var (
+	autoSamplers     map[uintptr]zerolog.Sampler = make(map[uintptr]zerolog.Sampler)
+	autoSamplersLock sync.RWMutex
+	badCallerSampler = NewRatelimitingSampler()
+)

--- a/pkg/log/samplers_test.go
+++ b/pkg/log/samplers_test.go
@@ -1,0 +1,93 @@
+package log_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+
+	"github.com/fluxninja/aperture/pkg/log"
+)
+
+var _ = Describe("Autosample", func() {
+	It("ratelimits repeated logs", func() {
+		var count Count
+		for i := 0; i < 5; i++ {
+			log.Autosample().Hook(&count).Info().Msg("a")
+		}
+		Expect(int(count)).To(Equal(1))
+	})
+
+	It("doesn't ratelimit unrelated logs", func() {
+		var count Count
+		log.Autosample().Hook(&count).Info().Msg("a")
+		log.Autosample().Hook(&count).Info().Msg("a")
+		log.Autosample().Hook(&count).Info().Msg("a")
+		log.Autosample().Hook(&count).Info().Msg("bb")
+		Expect(int(count)).To(Equal(4))
+	})
+})
+
+var _ = Describe("logger.Autosample", func() {
+	var logger *log.Logger
+	BeforeEach(func() {
+		logger = log.GetGlobalLogger()
+	})
+
+	It("ratelimits repeated logs", func() {
+		var count Count
+		for i := 0; i < 5; i++ {
+			logger.Autosample().Hook(&count).Info().Msg("a")
+		}
+		Expect(int(count)).To(Equal(1))
+	})
+
+	It("doesn't ratelimit unrelated logs", func() {
+		var count Count
+		logger.Autosample().Hook(&count).Info().Msg("a")
+		logger.Autosample().Hook(&count).Info().Msg("a")
+		logger.Autosample().Hook(&count).Info().Msg("a")
+		logger.Autosample().Hook(&count).Info().Msg("bb")
+		Expect(int(count)).To(Equal(4))
+	})
+})
+
+var _ = Describe("logger.Bug", func() {
+	var logger *log.Logger
+	BeforeEach(func() {
+		logger = log.GetGlobalLogger()
+	})
+
+	It("ratelimits repeated logs", func() {
+		var count Count
+		logger = logger.Hook(&count)
+		for i := 0; i < 5; i++ {
+			logger.Bug().Msg("a")
+		}
+		Expect(int(count)).To(Equal(1))
+	})
+
+	It("doesn't ratelimit unrelated logs", func() {
+		var count Count
+		logger = logger.Hook(&count)
+		logger.Bug().Msg("a")
+		logger.Bug().Msg("a")
+		logger.Bug().Msg("a")
+		logger.Bug().Msg("bb")
+		Expect(int(count)).To(Equal(4))
+	})
+
+	It("uses warn level", func() {
+		var lvl SaveLevel
+		logger = logger.Hook(&lvl)
+		logger.Bug().Msg("a")
+		Expect(lvl.last).To(Equal(zerolog.WarnLevel))
+	})
+})
+
+type SaveLevel struct{ last zerolog.Level }
+
+func (s *SaveLevel) Run(e *zerolog.Event, lvl zerolog.Level, msg string) { s.last = lvl }
+
+type Count int
+
+func (c *Count) Run(e *zerolog.Event, lvl zerolog.Level, msg string) { *c++ }

--- a/pkg/otelcollector/alertsreceiver/processor.go
+++ b/pkg/otelcollector/alertsreceiver/processor.go
@@ -3,7 +3,6 @@ package alertsreceiver
 import (
 	"context"
 
-	"github.com/rs/zerolog"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 
@@ -54,7 +53,7 @@ func (p *alertsReceiver) run(ctx context.Context) {
 		err := p.logsConsumer.ConsumeLogs(ctx, alert.AsLogs())
 		// We do not care much about those errors. Alerts can be dropped sometimes,
 		// they are sent all the time anyway.
-		log.Sample(zerolog.Sometimes).Debug().Err(err).Msg("ConsumeLogs failed")
+		log.Autosample().Debug().Err(err).Msg("ConsumeLogs failed")
 	case <-ctx.Done():
 		return
 	}

--- a/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
+++ b/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/iface"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
 	"github.com/fluxninja/aperture/pkg/policies/paths"
-	"github.com/rs/zerolog"
 )
 
 // LoadActuator struct.
@@ -98,13 +97,13 @@ func (la *LoadActuator) Execute(inPortReadings runtime.PortToValue, tickInfo run
 				}
 				return nil, la.publishDecision(tickInfo, lmValue, false)
 			} else {
-				logger.Sample(zerolog.Often).Info().Msg("Invalid load multiplier data")
+				logger.Autosample().Info().Msg("Invalid load multiplier data")
 			}
 		} else {
-			logger.Sample(zerolog.Often).Info().Msg("load_multiplier port has no reading")
+			logger.Autosample().Info().Msg("load_multiplier port has no reading")
 		}
 	} else {
-		logger.Sample(zerolog.Often).Info().Msg("load_multiplier port not found")
+		logger.Autosample().Info().Msg("load_multiplier port not found")
 	}
 	return nil, la.publishDefaultDecision(tickInfo)
 }
@@ -150,7 +149,7 @@ func (la *LoadActuator) publishDecision(tickInfo runtime.TickInfo, loadMultiplie
 		TickInfo:       tickInfo.Serialize(),
 	}
 	// Publish decision
-	logger.Sample(zerolog.Often).Debug().Float64("loadMultiplier", loadMultiplier).Bool("passThrough", passThrough).Msg("Publish load decision")
+	logger.Autosample().Debug().Float64("loadMultiplier", loadMultiplier).Bool("passThrough", passThrough).Msg("Publish load decision")
 	wrapper := &policysyncv1.LoadDecisionWrapper{
 		LoadDecision: decision,
 		CommonAttributes: &policysyncv1.CommonAttributes{

--- a/pkg/policies/flowcontrol/actuators/concurrency/load-actuator.go
+++ b/pkg/policies/flowcontrol/actuators/concurrency/load-actuator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/zerolog"
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
 
@@ -288,10 +287,10 @@ func (la *loadActuator) decisionUpdateCallback(event notifiers.Event, unmarshall
 	}
 
 	if loadDecision.PassThrough {
-		logger.Sample(zerolog.Often).Debug().Msg("Setting pass through mode")
+		logger.Autosample().Debug().Msg("Setting pass through mode")
 		la.tokenBucketLoadMultiplier.SetPassThrough(true)
 	} else {
-		logger.Sample(zerolog.Often).Debug().Float64("loadMultiplier", loadDecision.LoadMultiplier).Msg("Setting load multiplier")
+		logger.Autosample().Debug().Float64("loadMultiplier", loadDecision.LoadMultiplier).Msg("Setting load multiplier")
 		la.tokenBucketLoadMultiplier.SetLoadMultiplier(la.clock.Now(), loadDecision.LoadMultiplier)
 		la.tokenBucketLoadMultiplier.SetPassThrough(false)
 	}

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -10,7 +10,6 @@ import (
 	"runtime/debug"
 
 	"github.com/elastic/gosigar"
-	"github.com/rs/zerolog"
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
 	"google.golang.org/protobuf/proto"
@@ -179,7 +178,7 @@ func (w *watchdog) start() error {
 				if hp != nil {
 					details, e := hp.checkHeap()
 					if e != nil {
-						log.Sample(zerolog.Rarely).Error().Err(e).Msg("Heap check failed")
+						log.Autosample().Warn().Err(e).Msg("Heap check failed")
 					}
 					w.heapStatusRegistry.SetStatus(status.NewStatus(details, nil))
 				}
@@ -268,7 +267,7 @@ func (policy *systemWatermarks) Check(ctx context.Context) (proto.Message, error
 	log.Debug().Msg("System watermarks check triggered")
 	msg, err := check(policy, ctx, systemUsage)
 	if err != nil {
-		log.Sample(zerolog.Rarely).Error().Err(err).Msg("System watermarks check failed")
+		log.Autosample().Warn().Err(err).Msg("System watermarks check failed")
 	}
 	return msg, nil
 }
@@ -282,7 +281,7 @@ func (policy *systemAdaptive) Check(ctx context.Context) (proto.Message, error) 
 	log.Debug().Msg("System adaptive check triggered")
 	msg, err := check(policy, ctx, systemUsage)
 	if err != nil {
-		log.Sample(zerolog.Rarely).Error().Err(err).Msg("System adaptive check failed")
+		log.Autosample().Warn().Err(err).Msg("System adaptive check failed")
 	}
 	return msg, nil
 }


### PR DESCRIPTION
by using zerolog.BurstSampler instead of zerolog.RandomSampler. This
ensures that one-off and low-frequency events are always logged.

* Added log.NewRatelimitingSampler() helper that creates
  a zerolog.BurstSampler with sane defaults.
* Added log.Autosample() that automates creation of per-message
  BurstSampler variables (this is slightly less performant, so it's not
  used on datapath).

Also:
* Added log.Bug(), whic is like Panic() (intended for "impossible"
  cases), but for "continuable" errors. Currently it's just Autosample()
  Warn() + "bug" label, but in future we should add more visibility, like
  sentry reporting.

Drive-by:
* Downgraded various non-critical logs from Error to Warn.
* Removed sampling from Trace() logs, as it seems a bit contradictory.

##### Checklist

- [x] Tested in playground or other setup
- [x] Tests and/or benchmarks are included
- [x] Figure out how to handle changes in demoapp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/929)
<!-- Reviewable:end -->
