### PR TITLE
Make Gradle build java SDK compatible with JDK 1.8

### DIFF
--- a/sdks/aperture-java/build.gradle.kts
+++ b/sdks/aperture-java/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
 
 // Publishing
 java {
+    setSourceCompatibility("1.8")
+    setTargetCompatibility("1.8")
     withJavadocJar()
     withSourcesJar()
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/931)
<!-- Reviewable:end -->
