### PR TITLE
Added the functionality to check for the minimum supported kubernetes version

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -2,3 +2,4 @@ inport
 outport
 flowcontrolv1
 Fatalf
+AtLeast

--- a/.codespellignore
+++ b/.codespellignore
@@ -2,4 +2,4 @@ inport
 outport
 flowcontrolv1
 Fatalf
-AtLeast
+atleast

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -32,7 +32,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/strings/slices"
@@ -170,9 +169,9 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	// Checking if the Minimum kubernetes version condition is satisfied.
-	if len(instance.Status.Resources) == 0 && apimachineryversion.CompareKubeAwareVersionStrings(controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion) == 1 {
+	if len(instance.Status.Resources) == 0 && !controllers.MinimumKubernetesVersionBool {
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "MinimumKubernetesVersionFail",
-			fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
+			fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above.", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
 	}
 
 	instance.Status.Resources = "creating"

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -32,10 +32,10 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/strings/slices"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -172,7 +172,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// Checking if the Minimum kubernetes version condition is satisfied.
 	if len(instance.Status.Resources) == 0 && apimachineryversion.CompareKubeAwareVersionStrings(controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion) == 1 {
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "MinimumKubernetesVersionFail",
-		fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
+			fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
 	}
 
 	instance.Status.Resources = "creating"

--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -22,10 +22,10 @@ import (
 
 	agentv1alpha1 "github.com/fluxninja/aperture/operator/api/agent/v1alpha1"
 	controllerv1alpha1 "github.com/fluxninja/aperture/operator/api/controller/v1alpha1"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
 
 const (

--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -105,7 +105,7 @@ const (
 	OtelPprofPort = "otel-pprof"
 	// OtelZpagesPort string.
 	OtelZpagesPort = "otel-zpages"
-	//  MinimumKubernetesVersion defines minimum kubernetes version required by Aperture
+	// MinimumKubernetesVersion defines minimum kubernetes version required by Aperture.
 	MinimumKubernetesVersion = "v1.23.0"
 )
 
@@ -145,6 +145,6 @@ var (
 	CertDir = filepath.Join(".", "certs")
 	// PoliciesDir defines policies directory for tests.
 	PoliciesDir = filepath.Join(".", "policies")
-	// Stores current kubernetes version
+	// CurrentKubernetesVersion defines local kubernetes version.
 	CurrentKubernetesVersion *apimachineryversion.Info
 )

--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -22,7 +22,7 @@ import (
 
 	agentv1alpha1 "github.com/fluxninja/aperture/operator/api/agent/v1alpha1"
 	controllerv1alpha1 "github.com/fluxninja/aperture/operator/api/controller/v1alpha1"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -145,6 +145,8 @@ var (
 	CertDir = filepath.Join(".", "certs")
 	// PoliciesDir defines policies directory for tests.
 	PoliciesDir = filepath.Join(".", "policies")
-	// CurrentKubernetesVersion defines local kubernetes version.
-	CurrentKubernetesVersion *apimachineryversion.Info
+	// CurrentKubernetesVersion is pointer of type `apimachineryversion.Version`, which defines local kubernetes version.
+	CurrentKubernetesVersion *apimachineryversion.Version
+	// MinimumKubernetesVersionBool defines if minimum kubernetes version required by Aperture is met.
+	MinimumKubernetesVersionBool bool
 )

--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
 
 const (
@@ -104,6 +105,8 @@ const (
 	OtelPprofPort = "otel-pprof"
 	// OtelZpagesPort string.
 	OtelZpagesPort = "otel-zpages"
+	//  MinimumKubernetesVersion defines minimum kubernetes version required by Aperture
+	MinimumKubernetesVersion = "v1.23.0"
 )
 
 var (
@@ -142,4 +145,6 @@ var (
 	CertDir = filepath.Join(".", "certs")
 	// PoliciesDir defines policies directory for tests.
 	PoliciesDir = filepath.Join(".", "policies")
+	// Stores current kubernetes version
+	CurrentKubernetesVersion *apimachineryversion.Info
 )

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -31,7 +31,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -178,9 +177,9 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Checking if the Minimum kubernetes version condition is satisfied.
-	if len(instance.Status.Resources) == 0 && apimachineryversion.CompareKubeAwareVersionStrings(controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion) == 1 {
+	if len(instance.Status.Resources) == 0 && !controllers.MinimumKubernetesVersionBool {
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "MinimumKubernetesVersionFail",
-			fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
+			fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above.", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
 	}
 
 	instance.Status.Resources = "creating"

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -31,10 +31,10 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -180,7 +180,7 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Checking if the Minimum kubernetes version condition is satisfied.
 	if len(instance.Status.Resources) == 0 && apimachineryversion.CompareKubeAwareVersionStrings(controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion) == 1 {
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "MinimumKubernetesVersionFail",
-		fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
+			fmt.Sprintf("Kubernetes version %v is not supported. Please use a kubernetes cluster with version %v or above", controllers.CurrentKubernetesVersion.String(), controllers.MinimumKubernetesVersion))
 	}
 
 	instance.Status.Resources = "creating"

--- a/operator/main.go
+++ b/operator/main.go
@@ -23,9 +23,9 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/discovery"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/operator/main.go
+++ b/operator/main.go
@@ -25,6 +25,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	"k8s.io/client-go/dynamic"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/discovery"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -112,6 +113,20 @@ func main() {
 	dynamicClient, err := dynamic.NewForConfig(ctrl.GetConfigOrDie())
 	if err != nil {
 		setupLog.Error(err, "unable to create Dynamic Client")
+		os.Exit(1)
+	}
+
+	// Creating the discovery client
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(ctrl.GetConfigOrDie())
+	if err != nil {
+		setupLog.Error(err, "unable to create Discovery Client")
+		os.Exit(1)
+	}
+
+	// Querying the local kubernetes version
+	controllers.CurrentKubernetesVersion, err = discoveryClient.ServerVersion()
+	if err != nil {
+		setupLog.Error(err, "unable to get the local kubernetes version")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

### Description of change

Fixes: https://github.com/fluxninja/aperture/issues/883

Created an event to be generated by the Agent and Controller if in case the minimum Kubernetes version is not satisfied.

To grab the current Kubernetes version followed the same method as kubectl: https://github.com/kubernetes/kubectl/blob/393c40f5c4acbe48edbc70f8c8696bb623744b76/pkg/cmd/version/version.go#L139

aperture-agent-manager log:

```
1.6685863398395433e+09	DEBUG	events	Kubernetes version v1.25.0 is not supported. Please use a kubernetes cluster with version v1.27.0 or above	{"type": "Warning", "object": {"kind":"Agent","namespace":"aperture-agent","name":"agent","uid":"ffe0db7d-fcf5-4685-84b2-da04ae7534f6","apiVersion":"fluxninja.com/v1alpha1","resourceVersion":"14668896"}, "reason": "MinimumKubernetesVersionFail"}
```

aperture-controller-manager log:

```
1.6685863398325784e+09	DEBUG	events	Kubernetes version v1.25.0 is not supported. Please use a kubernetes cluster with version v1.27.0 or above	{"type": "Warning", "object": {"kind":"Controller","namespace":"aperture-controller","name":"controller","uid":"26df4d5c-56af-453e-be98-68a1e1ecf63b","apiVersion":"fluxninja.com/v1alpha1","resourceVersion":"14668895"}, "reason": "MinimumKubernetesVersionFail"}
```

The minimum version was kept `1.27.0` for testing purposes

##### Checklist

- [x] Tested in playground or other setup
- [ ] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/933)
<!-- Reviewable:end -->
