### PR TITLE
Move aperture-java publishing jobs to SDK

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -588,31 +588,6 @@ jobs:
             cd <<parameters.path>>
             gradle test
 
-  publish-aperture-java-release:
-    parameters:
-      path:
-        type: string
-        description: Path to aperture-java
-        default: sdks/aperture-java
-    docker:
-      - image: cimg/openjdk:11.0
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - gradle-v1-{{ checksum "<<parameters.path>>/build.gradle.kts" }}
-            - gradle-v1-
-      # See https://discuss.circleci.com/t/gpg-keys-as-environment-variables/28641
-      - run:
-          name: Publish to Sonatype
-          command: |
-            cd <<parameters.path>>
-            GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) gradle assemble publishToSonatype
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: gradle-v1-{{ checksum "<<parameters.path>>/build.gradle.kts" }}
-
 workflows:
   version: 2
 
@@ -700,16 +675,6 @@ workflows:
           docker-image: aperture-java-example
           remote-repo: fluxninja/aperture-java
           remote-repo-fingerprint: "14:8a:b9:90:ba:48:a4:f0:27:b0:70:d7:95:17:16:1e"
-
-  publish-aperture-java-snapshot:
-    when:
-      and:
-        - equal: [main, << pipeline.git.branch >>]
-        - << pipeline.parameters.updated-aperture-java >>
-    jobs:
-      - publish-aperture-java-release:
-          path: sdks/aperture-java
-          context: sonatype
 
   aperture-operator:
     when: << pipeline.parameters.updated-aperture-operator >>

--- a/sdks/aperture-java/.circleci/config.yml
+++ b/sdks/aperture-java/.circleci/config.yml
@@ -1,0 +1,74 @@
+version: 2.1
+
+# this allows to use CircleCI's dynamic configuration feature
+setup: true
+
+orbs:
+  path-filtering: circleci/path-filtering@0.1.3
+  continuation: circleci/continuation@0.3.1
+
+jobs:
+  publish-release:
+    docker:
+      - image: cimg/openjdk:11.0
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-v1-{{ checksum "build.gradle.kts" }}
+            - gradle-v1-
+      # See https://discuss.circleci.com/t/gpg-keys-as-environment-variables/28641
+      - run: GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) gradle assemble publishToSonatype
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-v1-{{ checksum "build.gradle.kts" }}
+
+workflows:
+  version: 2
+  filter-paths-main:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - not:
+            matches:
+              &is_not_empty_tag {
+                value: << pipeline.git.tag >>,
+                pattern: "^.+$",
+              }
+        - not: &scheduled
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+    jobs:
+      - path-filtering/filter: &path_filtering_job
+          base-revision: << pipeline.git.base_revision >>
+          config-path: .circleci/continue-workflows.yml
+          mapping: |
+            (src/main/java/com/fluxninja/aperture/.*|.*gradle.kts) updated-sdk true
+
+  filter-paths-pr:
+    when:
+      and:
+        - not:
+            equal: [main, << pipeline.git.branch >>]
+        - not:
+            matches: *is_not_empty_tag
+        - not: *scheduled
+    jobs:
+      - path-filtering/filter:
+          <<: *path_filtering_job
+          base-revision: main
+
+  publish-release:
+    when:
+      matches:
+        { value: << pipeline.git.tag >>, pattern: "^releases/.*$" }
+    jobs:
+      - publish-release:
+          context: sonatype
+          # both this and workflow's when is needed
+          filters:
+            branches:
+              ignore: /.+/
+            tags:
+              only: /^releases\/.*$/

--- a/sdks/aperture-java/.circleci/continue-workflows.yml
+++ b/sdks/aperture-java/.circleci/continue-workflows.yml
@@ -1,0 +1,39 @@
+version: 2.1
+
+parameters:
+  updated-sdk:
+    type: boolean
+    default: false
+
+jobs:
+  publish-release:
+    docker:
+      - image: cimg/openjdk:11.0
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-v1-{{ checksum "build.gradle.kts" }}
+            - gradle-v1-
+      # See https://discuss.circleci.com/t/gpg-keys-as-environment-variables/28641
+      - run:
+          name: Publish to Sonatype
+          command: |
+            GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) gradle assemble publishToSonatype
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-v1-{{ checksum "build.gradle.kts" }}
+
+workflows:
+  version: 2
+
+  publish-snapshot:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - << pipeline.parameters.updated-sdk >>
+    jobs:
+      - publish-release:
+          context: sonatype


### PR DESCRIPTION
### Description of change
This is required to maintain separate releasing process for `aperture-java` and `aperture`.
In such setup all the publishing is done from the `aperture-java` repository and we can have separate tags.

Closes: GH-926

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/935)
<!-- Reviewable:end -->
