### PR TITLE
Start warning on entity lookup failure in authz and flowcontrol

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -280,7 +280,7 @@ func Sample(sampler zerolog.Sampler) *Logger {
 // The "auto" part has a slight runtime cost though, so the full should be
 // preferred for cases where performance matters, like on datapath.
 func (lg *Logger) Autosample() *Logger {
-	return lg.Sample(getAutosampler())
+	return lg.Sample(GetAutosampler())
 }
 
 // Autosample returns the global logger with sampler based on caller location.
@@ -289,7 +289,7 @@ func (lg *Logger) Autosample() *Logger {
 func Autosample() *Logger {
 	// Note: not calling global.Autosample() as it might mess up with caller
 	// depth in getAutosampler().
-	return Sample(getAutosampler())
+	return Sample(GetAutosampler())
 }
 
 // Bug starts a new message with "bug" level
@@ -310,7 +310,7 @@ func Autosample() *Logger {
 //
 // You must call Msg on the returned event in order to send the event.
 func (lg *Logger) Bug() *zerolog.Event {
-	return bugWithSampler(lg, getAutosampler())
+	return BugWithSampler(lg, GetAutosampler())
 }
 
 // Bug starts a new message with "bug" level
@@ -321,7 +321,7 @@ func (lg *Logger) Bug() *zerolog.Event {
 func Bug() *zerolog.Event {
 	// Note: not calling global.Bug() as it might mess up with caller depth in
 	// getAutosampler().
-	return bugWithSampler(global, getAutosampler())
+	return BugWithSampler(global, GetAutosampler())
 }
 
 // Hook returns the current logger with the h hook.

--- a/pkg/net/grpc/helpers.go
+++ b/pkg/net/grpc/helpers.go
@@ -1,0 +1,147 @@
+package grpc
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/fluxninja/aperture/pkg/log"
+)
+
+// LogEvent wraps *zerolog.Event, so that sending an event also returns an grpc
+// error
+//
+// LogEvent also forwards _some_ builder-functions (like Str()) to the
+// underlying zerolog.Event. This is just a sugar, as you can always use
+// WithEvent on the whole chain.
+type LogEvent struct {
+	e    *zerolog.Event
+	code codes.Code
+}
+
+// LoggedError wraps zerolog.Event so that sending an event will also return a
+// grpc error.
+//
+// GRPC error code should be provided using Code(), otherwise, the error will
+// use codes.Unknown.
+//
+// Example:
+//
+//	return nil, grpc.LoggedError(log.Autosample().Warn()).
+//	    Code(codes.InvalidArgument).
+//	    Msg("missing frobnicator")
+func LoggedError(e *zerolog.Event) LogEvent {
+	return LogEvent{
+		e:    e,
+		code: codes.Unknown,
+	}
+}
+
+// Bug is equivalent to WithLogEvent(log.Bug()).Code(codes.Internal)
+//
+// Example: return nil, grpc.Bug().Msg("impossible happened").
+func Bug() LogEvent {
+	// Note: not forwarding to log.Bug() as it might mess up with caller depth
+	// in GetAutosampler()
+	return LogEvent{
+		e:    log.BugWithSampler(log.GetGlobalLogger(), log.GetAutosampler()),
+		code: codes.Internal,
+	}
+}
+
+// BugWithLogger is equivalent to WithLogEvent(logger.Bug()).Code(codes.Internal).
+func BugWithLogger(lg *log.Logger) LogEvent {
+	// Note: not forwarding to lg.Bug() as it might mess up with caller depth
+	// in GetAutosampler()
+	return LogEvent{
+		e:    log.BugWithSampler(lg, log.GetAutosampler()),
+		code: codes.Internal,
+	}
+}
+
+// Code sets the gRPC code to be used in error returned via Msg() or Send()
+//
+// Additionally, it adds the code field to the event.
+func (e LogEvent) Code(code codes.Code) LogEvent {
+	e.e.Stringer("code", code)
+	e.code = code
+	return e
+}
+
+// Msg sends the *Event with msg added as the message field if not empty.
+//
+// Msg returns grpc error using given msg as message and code previously set
+// with Code
+//
+// NOTICE: once this method is called, the LogEvent should be disposed.
+// Calling Msg twice can have unexpected result.
+func (e LogEvent) Msg(msg string) error {
+	e.e.Msg(msg)
+	return status.Error(e.code, msg)
+}
+
+// Send is equivalent to calling Msg("").
+func (e LogEvent) Send() error {
+	e.e.Msg("")
+	return status.Error(e.code, "")
+}
+
+// *** forwarded builders ***
+
+// Str adds the field key with val as a string to the *Event context.
+func (e LogEvent) Str(key, val string) LogEvent {
+	e.e.Str(key, val)
+	return e
+}
+
+// Stringer adds the field key with val.String() (or null if val is nil)
+// to the *Event context.
+func (e LogEvent) Stringer(key string, val fmt.Stringer) LogEvent {
+	e.e.Stringer(key, val)
+	return e
+}
+
+// Err adds the field "error" with serialized err to the *Event context.
+// If err is nil, no field is added.
+//
+// To customize the key name, change zerolog.ErrorFieldName.
+//
+// If Stack() has been called before and zerolog.ErrorStackMarshaler is defined,
+// the err is passed to ErrorStackMarshaler and the result is appended to the
+// zerolog.ErrorStackFieldName.
+func (e LogEvent) Err(err error) LogEvent {
+	e.e.Err(err)
+	return e
+}
+
+// Bool adds the field key with val as a bool to the *Event context.
+func (e LogEvent) Bool(key string, b bool) LogEvent {
+	e.e.Bool(key, b)
+	return e
+}
+
+// Int adds the field key with i as a int to the *Event context.
+func (e LogEvent) Int(key string, i int) LogEvent {
+	e.e.Int(key, i)
+	return e
+}
+
+// Float32 adds the field key with f as a float32 to the *Event context.
+func (e LogEvent) Float32(key string, f float32) LogEvent {
+	e.e.Float32(key, f)
+	return e
+}
+
+// Float64 adds the field key with f as a float64 to the *Event context.
+func (e LogEvent) Float64(key string, f float64) LogEvent {
+	e.e.Float64(key, f)
+	return e
+}
+
+// Interface adds the field key with i marshaled using reflection.
+func (e LogEvent) Interface(key string, i interface{}) LogEvent {
+	e.e.Interface(key, i)
+	return e
+}


### PR DESCRIPTION
### Description of change

Added warnings on client IP retrieval failure and entity lookup failure.
Also, converted these failures to fail-early, so they're more
dicsoverable. We might lose some things (like stats) by not processing
such request further, but since we don't have any metadata about
services, such information was not too helpful.

This is a step forward to #882.

Drive-by:
* Ripped out comments suggesting that on nil EntityCache we do some sort of fallback service detection via Host – this logic is long gone now.
* Entity cache is assumed to be non-nil.
* Added helpers in grpc package to simplify "log and return grpc error reusing the same message".
* Refactored if-else to switch-case in authz Check, as `DecisionType != REJECTED` was weird to read.
* Removed Eventually() in authz tests, it's no longer needed from some time.

##### Checklist

- [x] Tested in playground or other setup
- [x] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/943)
<!-- Reviewable:end -->
