### PR TITLE
docs : Fix typo in the reference section for controller 

### DIFF
--- a/docs/content/references/configuration/controller.md
+++ b/docs/content/references/configuration/controller.md
@@ -8,7 +8,7 @@ sidebar_label: Controller
 See also [Aperture Controller installation](/get-started/installation/controller.md).
 :::
 
-List of all config parameters for Aperture Agent.
+List of all config parameters for Aperture Controller.
 
 <!---
 Generated File Starts


### PR DESCRIPTION
### Description of change
Typo in the `controller.md` file .
Needed `Controller` and Agent was written.
##### Checklist

- [ ] Tested in playground or other setup
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/952)
<!-- Reviewable:end -->
