### PR TITLE
Warn on unknown entity (take two)

### DIFF
--- a/cmd/aperture-agent/agent.go
+++ b/cmd/aperture-agent/agent.go
@@ -21,7 +21,6 @@ import (
 	"github.com/fluxninja/aperture/pkg/entitycache"
 	"github.com/fluxninja/aperture/pkg/k8s"
 	"github.com/fluxninja/aperture/pkg/log"
-	"github.com/fluxninja/aperture/pkg/notifiers"
 	"github.com/fluxninja/aperture/pkg/otelcollector"
 	"github.com/fluxninja/aperture/pkg/peers"
 	"github.com/fluxninja/aperture/pkg/platform"
@@ -32,7 +31,6 @@ import (
 func main() {
 	app := platform.New(
 		platform.Config{}.Module(),
-		notifiers.TrackersConstructor{Name: "entity_trackers"}.Annotate(),
 		prometheus.Module(),
 		k8s.Module(),
 		peers.Constructor{}.Module(),

--- a/cmd/sdk-validator/main.go
+++ b/cmd/sdk-validator/main.go
@@ -23,10 +23,10 @@ import (
 
 	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/check/v1"
 	"github.com/fluxninja/aperture/cmd/sdk-validator/validator"
-	"github.com/fluxninja/aperture/pkg/entitycache"
 	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/resources/classifier"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/service/envoy"
+	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/servicegetter"
 	"github.com/fluxninja/aperture/pkg/status"
 )
 
@@ -90,8 +90,11 @@ func main() {
 	flowcontrolv1.RegisterFlowControlServiceServer(grpcServer, flowcontrolHandler)
 
 	reg := status.NewRegistry(log.GetGlobalLogger())
-	entities := entitycache.NewEntityCache()
-	authzHandler := envoy.NewHandler(classifier.NewClassificationEngine(reg), entities, commonHandler)
+	authzHandler := envoy.NewHandler(
+		classifier.NewClassificationEngine(reg),
+		servicegetter.NewEmpty(),
+		commonHandler,
+	)
 	authv3.RegisterAuthorizationServer(grpcServer, authzHandler)
 
 	// initiate and register otel trace handler

--- a/pkg/discovery/kubernetes/provide.go
+++ b/pkg/discovery/kubernetes/provide.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/discovery/common"
+	"github.com/fluxninja/aperture/pkg/entitycache"
 	"github.com/fluxninja/aperture/pkg/k8s"
 	"github.com/fluxninja/aperture/pkg/log"
-	"github.com/fluxninja/aperture/pkg/notifiers"
 	"github.com/fluxninja/aperture/pkg/status"
 )
 
@@ -33,7 +33,7 @@ type FxIn struct {
 	Lifecycle        fx.Lifecycle
 	StatusRegistry   status.Registry
 	KubernetesClient k8s.K8sClient
-	EntityTrackers   notifiers.Trackers `name:"entity_trackers"`
+	EntityTrackers   *entitycache.EntityTrackers
 }
 
 // InvokeKubernetesServiceDiscovery creates a Kubernetes service discovery.
@@ -45,7 +45,8 @@ func InvokeKubernetesServiceDiscovery(in FxIn) error {
 	}
 
 	if cfg.DiscoveryEnabled {
-		kd, err := newKubernetesServiceDiscovery(in.EntityTrackers, cfg.NodeName, in.KubernetesClient)
+		entityEvents := in.EntityTrackers.RegisterServiceDiscovery(podTrackerPrefix)
+		kd, err := newKubernetesServiceDiscovery(entityEvents, cfg.NodeName, in.KubernetesClient)
 		if err != nil {
 			log.Info().Err(err).Msg("Failed to create Kubernetes discovery service")
 			return nil

--- a/pkg/discovery/static/provide.go
+++ b/pkg/discovery/static/provide.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/discovery/common"
+	"github.com/fluxninja/aperture/pkg/entitycache"
 	"github.com/fluxninja/aperture/pkg/log"
-	"github.com/fluxninja/aperture/pkg/notifiers"
 )
 
 const (
@@ -47,29 +47,27 @@ type StaticDiscoveryConfig struct {
 	Services []*ServiceConfig `json:"services"`
 }
 
-// FxIn describes parameters passed to k8s discovery constructor.
-type FxIn struct {
-	fx.In
-	Unmarshaller   config.Unmarshaller
-	Lifecycle      fx.Lifecycle
-	EntityTrackers notifiers.Trackers `name:"entity_trackers"`
-}
-
 // InvokeStaticServiceDiscovery causes statically configured services to be uploaded to the tracker.
-func InvokeStaticServiceDiscovery(in FxIn) error {
+func InvokeStaticServiceDiscovery(
+	unmarshaller config.Unmarshaller,
+	lifecycle fx.Lifecycle,
+	entityTrackers *entitycache.EntityTrackers,
+) error {
 	var cfg StaticDiscoveryConfig
-	if err := in.Unmarshaller.UnmarshalKey(configKey, &cfg); err != nil {
+	if err := unmarshaller.UnmarshalKey(configKey, &cfg); err != nil {
 		log.Error().Err(err).Msg("Unable to deserialize static services configuration!")
 		return err
 	}
 
-	sd, err := newStaticServiceDiscovery(in.EntityTrackers, cfg)
-	if err != nil {
-		log.Info().Err(err).Msg("Failed to create static discovery service")
+	if len(cfg.Services) == 0 {
+		log.Info().Msg("No services configured, disabling static service discovery")
 		return nil
 	}
 
-	in.Lifecycle.Append(fx.Hook{
+	entityEvents := entityTrackers.RegisterServiceDiscovery(staticEntityTrackerPrefix)
+	sd := newStaticServiceDiscovery(entityEvents, cfg)
+
+	lifecycle.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
 			return sd.start()
 		},

--- a/pkg/discovery/static/static_discovery_test.go
+++ b/pkg/discovery/static/static_discovery_test.go
@@ -2,7 +2,6 @@ package static
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -14,13 +13,13 @@ import (
 )
 
 var (
-	ctrl         *gomock.Controller
-	mockTrackers *mocks.MockTrackers
+	ctrl            *gomock.Controller
+	mockEventWriter *mocks.MockEventWriter
 )
 
 var _ = BeforeEach(func() {
 	ctrl = gomock.NewController(GinkgoT())
-	mockTrackers = mocks.NewMockTrackers(ctrl)
+	mockEventWriter = mocks.NewMockEventWriter(ctrl)
 })
 
 var _ = Describe("Static service discovery", func() {
@@ -67,7 +66,7 @@ var _ = Describe("Static service discovery", func() {
 				Name:      someName,
 			}
 
-			expectedEntityKey := notifiers.Key(fmt.Sprintf("%v.%v", staticEntityTrackerPrefix, someUID))
+			expectedEntityKey := notifiers.Key(someUID)
 			serializedExpectedEntity, err := json.Marshal(expectedEntity)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -148,7 +147,7 @@ var _ = Describe("Static service discovery", func() {
 				Name:      someName,
 			}
 
-			expectedEntityKey := notifiers.Key(fmt.Sprintf("%v.%v", staticEntityTrackerPrefix, someUID))
+			expectedEntityKey := notifiers.Key(someUID)
 			serializedExpectedEntity, err := json.Marshal(expectedEntity)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -162,8 +161,6 @@ var _ = Describe("Static service discovery", func() {
 	})
 })
 
-func CreateStaticDiscoveryWithFakeTracker(config StaticDiscoveryConfig) (*StaticDiscovery, *mocks.MockTrackers) {
-	sd, err := newStaticServiceDiscovery(mockTrackers, config)
-	Expect(err).NotTo(HaveOccurred())
-	return sd, mockTrackers
+func CreateStaticDiscoveryWithFakeTracker(config StaticDiscoveryConfig) (*StaticDiscovery, *mocks.MockEventWriter) {
+	return newStaticServiceDiscovery(mockEventWriter, config), mockEventWriter
 }

--- a/pkg/entitycache/entity_cache.go
+++ b/pkg/entitycache/entity_cache.go
@@ -17,6 +17,7 @@ import (
 // Module sets up EntityCache with Fx.
 func Module() fx.Option {
 	return fx.Options(
+		notifiers.TrackersConstructor{Name: "entity_trackers_private"}.Annotate(),
 		fx.Provide(provideEntityCache),
 		grpcgateway.RegisterHandler{Handler: entitycachev1.RegisterEntityCacheServiceHandlerFromEndpoint}.Annotate(),
 		fx.Invoke(RegisterEntityCacheService),
@@ -29,15 +30,40 @@ type EntityCache struct {
 	entities *entitycachev1.EntityCache
 }
 
+// EntityTrackers allows to register a service discovery for entity cache
+//
+// Intended to be used during FX initialization.
+type EntityTrackers struct {
+	trackers     notifiers.Trackers
+	hasDiscovery bool
+}
+
+// RegisterServiceDiscovery registers service discovery for entity cache and
+// returns an EventWriter to push discovery events into.
+//
+// Keys passed to EventWriter shouldn't be prefixed.
+//
+// Should be called at FX provide/invoke stage.
+func (et *EntityTrackers) RegisterServiceDiscovery(name string) notifiers.EventWriter {
+	et.hasDiscovery = true
+	return notifiers.NewPrefixedEventWriter(name+".", et.trackers)
+}
+
+// HasDiscovery returns whether RegisterServiceDiscovery was called before.
+func (et *EntityTrackers) HasDiscovery() bool { return et.hasDiscovery }
+
+// Watcher returns watcher that watches all events from registered service discoveries.
+func (et *EntityTrackers) Watcher() notifiers.Watcher { return et.trackers }
+
 // FxIn are the parameters for ProvideEntityCache.
 type FxIn struct {
 	fx.In
 	Lifecycle      fx.Lifecycle
-	EntityTrackers notifiers.Trackers `name:"entity_trackers"`
+	EntityTrackers notifiers.Trackers `name:"entity_trackers_private"`
 }
 
 // provideEntityCache creates Entity Cache.
-func provideEntityCache(in FxIn) (*EntityCache, error) {
+func provideEntityCache(in FxIn) (*EntityCache, *EntityTrackers) {
 	entityCache := NewEntityCache()
 
 	// create a ConfigPrefixNotifier
@@ -65,7 +91,7 @@ func provideEntityCache(in FxIn) (*EntityCache, error) {
 		},
 	})
 
-	return entityCache, nil
+	return entityCache, &EntityTrackers{trackers: in.EntityTrackers}
 }
 
 func (c *EntityCache) processUpdate(event notifiers.Event, unmarshaller config.Unmarshaller) {
@@ -124,9 +150,13 @@ func (c *EntityCache) GetByIP(entityIP string) (*entitycachev1.Entity, error) {
 	c.RLock()
 	defer c.RUnlock()
 
+	if len(c.entities.EntitiesByIpAddress.Entities) == 0 {
+		return nil, errNoEntities
+	}
+
 	v, ok := c.entities.EntitiesByIpAddress.Entities[entityIP]
 	if !ok {
-		return nil, errors.New("entity not found")
+		return nil, errNotFound
 	}
 	return v.DeepCopy(), nil
 }
@@ -136,12 +166,21 @@ func (c *EntityCache) GetByName(entityName string) (*entitycachev1.Entity, error
 	c.RLock()
 	defer c.RUnlock()
 
+	if len(c.entities.EntitiesByName.Entities) == 0 {
+		return nil, errNoEntities
+	}
+
 	v, ok := c.entities.EntitiesByName.Entities[entityName]
 	if !ok {
-		return nil, errors.New("entity not found")
+		return nil, errNotFound
 	}
 	return v.DeepCopy(), nil
 }
+
+var (
+	errNotFound   = errors.New("entity not found")
+	errNoEntities = errors.New("entity not found (empty cache)")
+)
 
 // Clear removes all entities from the cache.
 func (c *EntityCache) Clear() {

--- a/pkg/mocks/mock-trackers.go
+++ b/pkg/mocks/mock-trackers.go
@@ -11,6 +11,65 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
+// MockEventWriter is a mock of EventWriter interface.
+type MockEventWriter struct {
+	ctrl     *gomock.Controller
+	recorder *MockEventWriterMockRecorder
+}
+
+// MockEventWriterMockRecorder is the mock recorder for MockEventWriter.
+type MockEventWriterMockRecorder struct {
+	mock *MockEventWriter
+}
+
+// NewMockEventWriter creates a new mock instance.
+func NewMockEventWriter(ctrl *gomock.Controller) *MockEventWriter {
+	mock := &MockEventWriter{ctrl: ctrl}
+	mock.recorder = &MockEventWriterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockEventWriter) EXPECT() *MockEventWriterMockRecorder {
+	return m.recorder
+}
+
+// Purge mocks base method.
+func (m *MockEventWriter) Purge(prefix string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Purge", prefix)
+}
+
+// Purge indicates an expected call of Purge.
+func (mr *MockEventWriterMockRecorder) Purge(prefix interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Purge", reflect.TypeOf((*MockEventWriter)(nil).Purge), prefix)
+}
+
+// RemoveEvent mocks base method.
+func (m *MockEventWriter) RemoveEvent(key notifiers.Key) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveEvent", key)
+}
+
+// RemoveEvent indicates an expected call of RemoveEvent.
+func (mr *MockEventWriterMockRecorder) RemoveEvent(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEvent", reflect.TypeOf((*MockEventWriter)(nil).RemoveEvent), key)
+}
+
+// WriteEvent mocks base method.
+func (m *MockEventWriter) WriteEvent(key notifiers.Key, value []byte) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "WriteEvent", key, value)
+}
+
+// WriteEvent indicates an expected call of WriteEvent.
+func (mr *MockEventWriterMockRecorder) WriteEvent(key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteEvent", reflect.TypeOf((*MockEventWriter)(nil).WriteEvent), key, value)
+}
+
 // MockTrackers is a mock of Trackers interface.
 type MockTrackers struct {
 	ctrl     *gomock.Controller

--- a/pkg/policies/flowcontrol/provide.go
+++ b/pkg/policies/flowcontrol/provide.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/resources/classifier"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/resources/fluxmeter"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/service"
+	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/servicegetter"
 )
 
 // Module returns the fx options for dataplane side pieces of policy.
@@ -17,6 +18,7 @@ func Module() fx.Option {
 		classifier.Module(),
 		service.Module(),
 		fx.Provide(
+			servicegetter.ProvideFromEntityCache,
 			NewEngine,
 		),
 	)

--- a/pkg/policies/flowcontrol/service/check/check_test.go
+++ b/pkg/policies/flowcontrol/service/check/check_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/platform"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/service/check"
+	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/servicegetter"
 )
 
 var (
@@ -48,6 +49,7 @@ var _ = BeforeEach(func() {
 		}.Module(),
 		fx.Provide(agentinfo.ProvideAgentInfo),
 		fx.Supply(entities),
+		fx.Provide(servicegetter.FromEntityCache),
 		fx.Provide(check.ProvideNopMetrics),
 		fx.Provide(check.ProvideHandler),
 		fx.Provide(flowcontrol.NewEngine),

--- a/pkg/policies/flowcontrol/service/check/provide.go
+++ b/pkg/policies/flowcontrol/service/check/provide.go
@@ -10,9 +10,9 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	flowcontrolv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/flowcontrol/check/v1"
-	"github.com/fluxninja/aperture/pkg/entitycache"
 	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/iface"
+	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/servicegetter"
 )
 
 // Module is a set of default providers for flowcontrol components
@@ -33,14 +33,16 @@ func Module() fx.Option {
 type ConstructorIn struct {
 	fx.In
 
-	EntityCache *entitycache.EntityCache
-	Metrics     Metrics
-	EngineAPI   iface.Engine
+	ServiceGetter servicegetter.ServiceGetter
+	Metrics       Metrics
+	EngineAPI     iface.Engine
 }
 
 // ProvideHandler provides a Flow Control Handler.
-func ProvideHandler(in ConstructorIn) (flowcontrolv1.FlowControlServiceServer, HandlerWithValues, error) {
-	h := NewHandler(in.EntityCache, in.Metrics, in.EngineAPI)
+func ProvideHandler(
+	in ConstructorIn,
+) (flowcontrolv1.FlowControlServiceServer, HandlerWithValues, error) {
+	h := NewHandler(in.ServiceGetter, in.Metrics, in.EngineAPI)
 
 	// Note: Returning the same handler twice as different interfaces – once as
 	// a handler to be registered on grpc server and once for consumption by

--- a/pkg/policies/flowcontrol/service/envoy/authz_test.go
+++ b/pkg/policies/flowcontrol/service/envoy/authz_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/log"
 	classification "github.com/fluxninja/aperture/pkg/policies/flowcontrol/resources/classifier"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/service/envoy"
+	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/servicegetter"
 	"github.com/fluxninja/aperture/pkg/status"
 )
 
@@ -67,7 +68,11 @@ var _ = Describe("Authorization handler", func() {
 				IpAddress: "1.2.3.4",
 				Services:  []string{service1Selector.ServiceSelector.Service},
 			})
-			handler = envoy.NewHandler(classifier, entities, &AcceptingHandler{})
+			handler = envoy.NewHandler(
+				classifier,
+				servicegetter.FromEntityCache(entities),
+				&AcceptingHandler{},
+			)
 		})
 		It("returns ok response", func() {
 			ctxWithIp := peer.NewContext(ctx, newFakeRpcPeer("1.2.3.4"))

--- a/pkg/policies/flowcontrol/service/provide.go
+++ b/pkg/policies/flowcontrol/service/provide.go
@@ -6,10 +6,7 @@ import (
 	"go.uber.org/fx"
 )
 
-// Module is a set of default providers for flowcontrol components
-//
-// Note that the handler needs to be Registered for flowcontrol to be available
-// externally.
+// Module is a set of default providers for flowcontrol components.
 func Module() fx.Option {
 	return fx.Options(
 		check.Module(),

--- a/pkg/policies/flowcontrol/servicegetter/servicegetter.go
+++ b/pkg/policies/flowcontrol/servicegetter/servicegetter.go
@@ -1,0 +1,93 @@
+package servicegetter
+
+import (
+	"context"
+	"net"
+
+	"go.uber.org/fx"
+	"google.golang.org/grpc/peer"
+
+	"github.com/fluxninja/aperture/pkg/entitycache"
+	"github.com/fluxninja/aperture/pkg/log"
+)
+
+// ServiceGetter can be used to query services based on client context.
+type ServiceGetter interface {
+	ServicesFromContext(ctx context.Context) []string
+}
+
+// FromEntityCache creates a new EntityCache-powered ServiceGetter.
+func FromEntityCache(ec *entitycache.EntityCache) ServiceGetter {
+	return &ecServiceGetter{entityCache: ec}
+}
+
+// NewEmpty creates a new ServiceGetter that always returns nil.
+func NewEmpty() ServiceGetter { return emptyServiceGetter{} }
+
+type ecServiceGetter struct {
+	entityCache    *entitycache.EntityCache
+	ecHasDiscovery bool
+}
+
+// ServicesFromContext returns list of services associated with IP extracted from context
+//
+// The returned list of services depends only on state of entityCache.
+// However, emitted warnings will depend on whether service discovery is enabled or not.
+func (sg *ecServiceGetter) ServicesFromContext(ctx context.Context) []string {
+	rpcPeer, peerExists := peer.FromContext(ctx)
+	if !peerExists {
+		if sg.ecHasDiscovery {
+			log.Bug().Msg("cannot get client info from context")
+		}
+		return nil
+	}
+
+	tcpAddr, isTCPAddr := rpcPeer.Addr.(*net.TCPAddr)
+	if !isTCPAddr {
+		if sg.ecHasDiscovery {
+			log.Bug().Msg("client addr is not TCP")
+		}
+		return nil
+
+	}
+
+	clientIP := tcpAddr.IP.String()
+	entity, err := sg.entityCache.GetByIP(clientIP)
+	if err != nil {
+		if sg.ecHasDiscovery {
+			log.Sample(noEntitySampler).Warn().Err(err).Str("clientIP", clientIP).
+				Msg("cannot get services")
+		}
+		return nil
+	}
+
+	return entity.Services
+}
+
+var noEntitySampler = log.NewRatelimitingSampler()
+
+// ProvideFromEntityCache provides an EntityCache-powered ServiceGetter.
+func ProvideFromEntityCache(
+	entityCache *entitycache.EntityCache,
+	entityTrackers *entitycache.EntityTrackers,
+	lc fx.Lifecycle,
+) ServiceGetter {
+	sg := &ecServiceGetter{entityCache: entityCache}
+
+	lc.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			// Checking this flag on OnStart so that all registrations done in
+			// provide/invoke stage would be visible.
+			sg.ecHasDiscovery = entityTrackers.HasDiscovery()
+			return nil
+		},
+		OnStop: func(context.Context) error { return nil },
+	})
+
+	return sg
+}
+
+type emptyServiceGetter struct{}
+
+// ServicesFromContext implements ServiceGetter interface.
+func (sg emptyServiceGetter) ServicesFromContext(ctx context.Context) []string { return nil }

--- a/test/aperture_suite_test.go
+++ b/test/aperture_suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/resources/classifier"
 	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/service"
+	"github.com/fluxninja/aperture/pkg/policies/flowcontrol/servicegetter"
 	"github.com/fluxninja/aperture/pkg/status"
 	"github.com/fluxninja/aperture/pkg/utils"
 	"github.com/fluxninja/aperture/test/harness"
@@ -152,6 +153,7 @@ var _ = BeforeSuite(func() {
 				fx.ParamTags(alerts.AlertsFxTag),
 			),
 			entitycache.NewEntityCache,
+			servicegetter.NewEmpty,
 			agentinfo.ProvideAgentInfo,
 			flowcontrol.NewEngine,
 			controlpointcache.Provide,


### PR DESCRIPTION
Previous attempt (#943) was partially reverted as it was overeager. This time
it's emitting only a warning. (and only in some cases)

### Description of change

Start warning on failed IP to entity lookup, but only when service
discovery is actually enabled (when service discovery is disabled,
failure to do entity lookup is normal condition and glob-policies can
still work).

This required making service discovery registration "more formal".
Previously, service discovery simply wrote to Trackers, which made it
impossible to differentiate between discovery not-working vs being
disabled. This commit introduces EntityTrackers, which manages service
discoveries and hands out EventWriters.

Also:
* Extracted EventWriter interface from Trackers.
* Extracted shared "IP to services" logic to ServiceGetter.
* Fixed obtaining client IP from peer context for IPv6 (noticed
  that on sidecar mode peer IP can be [::1]).

This PR is a step towards #882.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/991)
<!-- Reviewable:end -->
