### PR TITLE
Add metrics for IP-to-services lookups

### DIFF
--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -68,6 +68,9 @@ const (
 	// TokenBucketAvailableMetricName - a gauge that tracks the number of tokens available in token bucket.
 	TokenBucketAvailableMetricName = "token_bucket_available_tokens_total"
 
+	// ServiceLookupsMetricName - counter for IP to services lookups.
+	ServiceLookupsMetricName = "service_lookups_total"
+
 	// FlowControlRequestsMetricName - counter for Check requests for flowcontrol.
 	FlowControlRequestsMetricName = "flowcontrol_requests_total"
 	// FlowControlDecisionsMetricName - counter for Check requests per decision type.
@@ -115,6 +118,12 @@ const (
 	MethodLabel = "http_method"
 	// HandlerName - name of the http handler. Defaults to 'default'.
 	HandlerName = "handler_name"
+	// ServiceLookupsStatusLabel - status for ServiceLookupsMetricName.
+	ServiceLookupsStatusLabel = "status"
+	// ServiceLookupsStatusOK - service lookup status OK.
+	ServiceLookupsStatusOK = FlowStatusOK
+	// ServiceLookupsStatusError - service lookup status Error.
+	ServiceLookupsStatusError = FlowStatusError
 	// FlowStatusLabel - flow status.
 	FlowStatusLabel = "flow_status"
 	// FlowStatusOK - flow status OK.

--- a/pkg/policies/flowcontrol/provide.go
+++ b/pkg/policies/flowcontrol/provide.go
@@ -17,8 +17,8 @@ func Module() fx.Option {
 		fluxmeter.Module(),
 		classifier.Module(),
 		service.Module(),
+		servicegetter.Module,
 		fx.Provide(
-			servicegetter.ProvideFromEntityCache,
 			NewEngine,
 		),
 	)

--- a/pkg/policies/flowcontrol/servicegetter/metrics.go
+++ b/pkg/policies/flowcontrol/servicegetter/metrics.go
@@ -1,0 +1,43 @@
+package servicegetter
+
+import (
+	"github.com/fluxninja/aperture/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metrics is used for collecting metrics about servicegetter
+//
+// nil value of Metrics should be always usable.
+type Metrics struct {
+	okTotal     prometheus.Counter
+	errorsTotal prometheus.Counter
+}
+
+// NewMetrics creates new Metrics, registering counters in given registry.
+func NewMetrics(registry *prometheus.Registry) (*Metrics, error) {
+	total := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: metrics.ServiceLookupsMetricName,
+			Help: "Number of IP to services lookups",
+		},
+		[]string{metrics.ServiceLookupsStatusLabel},
+	)
+	if err := registry.Register(total); err != nil {
+		return nil, err
+	}
+	return &Metrics{
+		okTotal:     total.WithLabelValues(metrics.ServiceLookupsStatusOK),
+		errorsTotal: total.WithLabelValues(metrics.ServiceLookupsStatusError),
+	}, nil
+}
+
+func (m *Metrics) inc(ok bool) {
+	if m == nil {
+		return
+	}
+	if ok {
+		m.okTotal.Inc()
+	} else {
+		m.errorsTotal.Inc()
+	}
+}

--- a/pkg/policies/flowcontrol/servicegetter/provide.go
+++ b/pkg/policies/flowcontrol/servicegetter/provide.go
@@ -1,0 +1,9 @@
+package servicegetter
+
+import "go.uber.org/fx"
+
+// Module is a set of default providers for servicegetter components.
+var Module = fx.Options(
+	fx.Provide(ProvideFromEntityCache),
+	fx.Provide(NewMetrics),
+)


### PR DESCRIPTION
### Description of change

Adds a `service_lookups_total` metric which tracks IP-to-services lookups (via
entity cache). To differentiate between successful and failed lookups,
status=OK/Error label can be used.


Resolves #882

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/997)
<!-- Reviewable:end -->
