### PR TITLE
Make logs less noisy

### DIFF
--- a/pkg/distcache/logwriter.go
+++ b/pkg/distcache/logwriter.go
@@ -15,11 +15,11 @@ type OlricLogWriter struct {
 func (ol *OlricLogWriter) Write(message []byte) (int, error) {
 	message = bytes.TrimSpace(message)
 	if len(message) < 2 {
-		ol.Logger.Info().Msg(string(message))
+		ol.Logger.Debug().Msg(string(message))
 	} else {
 		switch message[1] {
 		case 'I':
-			ol.Logger.Info().Msg(string(message[7:]))
+			ol.Logger.Debug().Msg(string(message[7:]))
 		case 'W':
 			ol.Logger.Warn().Msg(string(message[7:]))
 		case 'E':
@@ -27,7 +27,7 @@ func (ol *OlricLogWriter) Write(message []byte) (int, error) {
 		case 'D':
 			ol.Logger.Debug().Msg(string(message[8:]))
 		default:
-			ol.Logger.Info().Msg(string(message))
+			ol.Logger.Debug().Msg(string(message))
 		}
 	}
 	return len(message), nil

--- a/pkg/log/samplers.go
+++ b/pkg/log/samplers.go
@@ -26,7 +26,7 @@ import (
 func NewRatelimitingSampler() zerolog.Sampler {
 	return &zerolog.BurstSampler{
 		Burst:  1,
-		Period: 5 * time.Second,
+		Period: 5 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
### Description of change
* Move all Info logs from Olric to Debug, as they are too noisy.
* Make sampled logs appear once per 5 minutes instead of once per 5 seconds.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1000)
<!-- Reviewable:end -->
