### PR TITLE
Bump Aperture Java SDK to 0.13.0

### DIFF
--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
   // Library name and version can be used by the user to create a resource that
   // connects to telemetry export.
   public static final String LIBRARY_NAME = "aperture-java";
-  public static final String LIBRARY_VERSION = "0.1.0";
+  public static final String LIBRARY_VERSION = "0.13.0";
 
   // Config defaults.
   public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "0.5.0"
+  var ver = "0.13.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change
As we are moving in lockstep, to avoid confusion, the Aperture Java SDK will follow the same versioning as Aperture main repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1001)
<!-- Reviewable:end -->
