### PR TITLE
Update Java SDK badge

### DIFF
--- a/sdks/aperture-java/README.md
+++ b/sdks/aperture-java/README.md
@@ -10,8 +10,8 @@
   <a href="https://dl.circleci.com/status-badge/img/gh/fluxninja/aperture-java/tree/main.svg?style=svg&circle-token=cf4312657fbc2f4833fee89328a3f27ab5f39c10">
     <img alt="Build Status" src="https://img.shields.io/circleci/build/github/fluxninja/aperture-java/main?token=cf4312657fbc2f4833fee89328a3f27ab5f39c10&style=for-the-badge&logo=circleci">
   </a>
-  <a href="https://maven-badges.herokuapp.com/maven-central/com.fluxninja.aperture/aperture-java/">
-    <img alt="Maven Central" src="https://maven-badges.herokuapp.com/maven-central/com.fluxninja.aperture/aperture-java/badge.svg?style=for-the-badge">
+  <a href="https://maven-badges.herokuapp.com/maven-central/com.fluxninja.aperture/aperture-java-core/">
+    <img alt="Maven Central" src="https://maven-badges.herokuapp.com/maven-central/com.fluxninja.aperture/aperture-java-core/badge.svg?style=for-the-badge">
   </a>
 </p>
 


### PR DESCRIPTION
### Description of change

Update Java SDK badge to point to `com.fluxninja.aperture/aperture-java-core` instead of obsolete `com.fluxninja.aperture/aperture-java`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1003)
<!-- Reviewable:end -->
