### PR TITLE
Add channel and severity helpers to alerts

### DIFF
--- a/pkg/alerts/alert.go
+++ b/pkg/alerts/alert.go
@@ -1,6 +1,7 @@
 package alerts
 
 import (
+	"strings"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -17,6 +18,7 @@ var specialLabels = map[string]struct{}{
 	otelcollector.AlertNameLabel:         {},
 	otelcollector.AlertSeverityLabel:     {},
 	otelcollector.AlertGeneratorURLLabel: {},
+	otelcollector.AlertChannelsLabel:     {},
 }
 
 // AlertOption is a type for constructor options.
@@ -65,7 +67,7 @@ func (a *Alert) SetName(name string) {
 // WithName is an option function for constructor.
 func WithName(name string) AlertOption {
 	return func(a *Alert) {
-		a.postableAlert.Labels[otelcollector.AlertNameLabel] = name
+		a.SetName(name)
 	}
 }
 
@@ -79,16 +81,37 @@ func (a *Alert) SetSeverity(severity string) {
 	a.postableAlert.Labels[otelcollector.AlertSeverityLabel] = severity
 }
 
-// PostableAlert returns the underlying PostableAlert struct.
-func (a *Alert) PostableAlert() models.PostableAlert {
-	return a.postableAlert
-}
-
 // WithSeverity is an option function for constructor.
 func WithSeverity(severity string) AlertOption {
 	return func(a *Alert) {
-		a.postableAlert.Labels[otelcollector.AlertSeverityLabel] = severity
+		a.SetSeverity(severity)
 	}
+}
+
+// AlertChannels gets the alert channels from labels. Returns empty slice if label not found.
+func (a *Alert) AlertChannels() []string {
+	channels, ok := a.postableAlert.Labels[otelcollector.AlertChannelsLabel]
+	if !ok {
+		return []string{}
+	}
+	return strings.Split(channels, ",")
+}
+
+// SetAlertChannels sets the alert channels in labels. Overwrites previous value if exists.
+func (a *Alert) SetAlertChannels(alertChannels []string) {
+	a.postableAlert.Labels[otelcollector.AlertChannelsLabel] = strings.Join(alertChannels, ",")
+}
+
+// WithAlertChannels is an option function for constructor.
+func WithAlertChannels(alertChannels []string) AlertOption {
+	return func(a *Alert) {
+		a.SetAlertChannels(alertChannels)
+	}
+}
+
+// PostableAlert returns the underlying PostableAlert struct.
+func (a *Alert) PostableAlert() models.PostableAlert {
+	return a.postableAlert
 }
 
 // SetAnnotation sets a single annotation. It overwrites the previous value if exists.
@@ -99,7 +122,7 @@ func (a *Alert) SetAnnotation(key, value string) {
 // WithAnnotation is an option function for constructor.
 func WithAnnotation(key, value string) AlertOption {
 	return func(a *Alert) {
-		a.postableAlert.Annotations[key] = value
+		a.SetAnnotation(key, value)
 	}
 }
 
@@ -111,7 +134,7 @@ func (a *Alert) SetLabel(key, value string) {
 // WithLabel is an option function for constructor.
 func WithLabel(key, value string) AlertOption {
 	return func(a *Alert) {
-		a.postableAlert.Labels[key] = value
+		a.SetLabel(key, value)
 	}
 }
 
@@ -123,7 +146,7 @@ func (a *Alert) SetGeneratorURL(value string) {
 // WithGeneratorURL is an option function for constructor.
 func WithGeneratorURL(value string) AlertOption {
 	return func(a *Alert) {
-		a.postableAlert.GeneratorURL = strfmt.URI(value)
+		a.SetGeneratorURL(value)
 	}
 }
 

--- a/pkg/alerts/alert_test.go
+++ b/pkg/alerts/alert_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Alert", func() {
 			alerts.WithAnnotation("one", "eleven"),
 			alerts.WithAnnotation("two", "twelve"),
 			alerts.WithName("buzz"),
-			alerts.WithSeverity("error"),
+			alerts.WithSeverity(alerts.SeverityCrit),
 		)
 		finalAlert := alert
 		finalAlert.SetLabel("is_alert", "true")

--- a/pkg/otelcollector/consts.go
+++ b/pkg/otelcollector/consts.go
@@ -165,6 +165,8 @@ const (
 	AlertNameLabel = "alertname"
 	// AlertSeverityLabel also known as log level. Human readable string.
 	AlertSeverityLabel = "severity"
+	// AlertChannelsLabel is a comma-separated list of channels to which alert is assigned.
+	AlertChannelsLabel = "alert_channels"
 	// IsAlertLabel helps to differentiate normal logs from alert logs.
 	IsAlertLabel = "is_alert"
 )

--- a/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
+++ b/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
@@ -200,7 +200,7 @@ func (la *LoadActuator) publishDecision(tickInfo runtime.TickInfo, loadMultiplie
 func (la *LoadActuator) createAlert() *alerts.Alert {
 	newAlert := alerts.NewAlert(
 		alerts.WithName("Load Shed Event"),
-		alerts.WithSeverity(la.alerterConfig.Severity),
+		alerts.WithSeverity(alerts.ParseSeverity(la.alerterConfig.Severity)),
 		alerts.WithAlertChannels(la.alerterConfig.AlertChannels),
 		alerts.WithLabel("policy_name", la.policyReadAPI.GetPolicyName()),
 		alerts.WithLabel("type", "concurrency_limiter"),

--- a/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
+++ b/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -202,11 +201,11 @@ func (la *LoadActuator) createAlert() *alerts.Alert {
 	newAlert := alerts.NewAlert(
 		alerts.WithName("Load Shed Event"),
 		alerts.WithSeverity(la.alerterConfig.Severity),
+		alerts.WithAlertChannels(la.alerterConfig.AlertChannels),
 		alerts.WithLabel("policy_name", la.policyReadAPI.GetPolicyName()),
 		alerts.WithLabel("type", "concurrency_limiter"),
 		alerts.WithLabel("agent_group", la.agentGroupName),
 		alerts.WithLabel("component_index", strconv.Itoa(la.componentIndex)),
-		alerts.WithAnnotation("alert_channels", strings.Join(la.alerterConfig.AlertChannels, ",")),
 		alerts.WithGeneratorURL(
 			fmt.Sprintf("http://%s/%s/%d", info.GetHostInfo().Hostname, la.policyReadAPI.GetPolicyName(), la.componentIndex),
 		),

--- a/pkg/policies/controlplane/components/alerter.go
+++ b/pkg/policies/controlplane/components/alerter.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"go.uber.org/fx"
@@ -76,9 +75,9 @@ func (a *Alerter) createAlert() *alerts.Alert {
 	newAlert := alerts.NewAlert(
 		alerts.WithName(a.name),
 		alerts.WithSeverity(a.severity),
+		alerts.WithAlertChannels(a.alertChannels),
 		alerts.WithLabel("policy_name", a.policyReadAPI.GetPolicyName()),
 		alerts.WithLabel("type", "alerter"),
-		alerts.WithAnnotation("alert_channels", strings.Join(a.alertChannels, ",")),
 		alerts.WithAnnotation("resolve_timeout", a.resolveTimeout.String()),
 		alerts.WithGeneratorURL(
 			fmt.Sprintf("http://%s/%s/%s", info.GetHostInfo().Hostname, a.policyReadAPI.GetPolicyName(), a.name),

--- a/pkg/policies/controlplane/components/alerter.go
+++ b/pkg/policies/controlplane/components/alerter.go
@@ -74,7 +74,7 @@ func (a *Alerter) DynamicConfigUpdate(event notifiers.Event, unmarshaller config
 func (a *Alerter) createAlert() *alerts.Alert {
 	newAlert := alerts.NewAlert(
 		alerts.WithName(a.name),
-		alerts.WithSeverity(a.severity),
+		alerts.WithSeverity(alerts.ParseSeverity(a.severity)),
 		alerts.WithAlertChannels(a.alertChannels),
 		alerts.WithLabel("policy_name", a.policyReadAPI.GetPolicyName()),
 		alerts.WithLabel("type", "alerter"),


### PR DESCRIPTION
### Description of change

* Add helpers for alert channels, so it is not set directly in alert labels.
* Make severity helpers typed, so severity values are unified.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1018)
<!-- Reviewable:end -->
