### PR TITLE
Add basic unit-test framework for testing circuits

### DIFF
--- a/pkg/policies/controlplane/components/constant.go
+++ b/pkg/policies/controlplane/components/constant.go
@@ -22,12 +22,12 @@ func (*Constant) Name() string { return "Constant" }
 // Type implements runtime.Component.
 func (*Constant) Type() runtime.ComponentType { return runtime.ComponentTypeSource }
 
-// NewConstantAndOptions creates constant setpoint and its fx options.
+// NewConstant creates a constant component with a given value.
+func NewConstant(value float64) runtime.Component { return &Constant{value: value} }
+
+// NewConstantAndOptions creates a constant components and its fx options.
 func NewConstantAndOptions(constant *policylangv1.Constant, componentIndex int, policyReadAPI iface.Policy) (runtime.Component, fx.Option, error) {
-	con := Constant{
-		value: constant.Value,
-	}
-	return &con, fx.Options(), nil
+	return NewConstant(constant.Value), fx.Options(), nil
 }
 
 // Execute implements runtime.Component.Execute.

--- a/pkg/policies/controlplane/policy.go
+++ b/pkg/policies/controlplane/policy.go
@@ -64,11 +64,7 @@ func newPolicyOptions(
 	))
 
 	// Create circuit
-	circuit, circuitOption := runtime.NewCircuitAndOptions(
-		compiledCircuit.Components(),
-		policy,
-		registry,
-	)
+	circuit, circuitOption := runtime.NewCircuitAndOptions(compiledCircuit.Components(), policy)
 	policyOptions = append(policyOptions, circuitOption)
 
 	policyOptions = append(policyOptions, circuitfactory.FactoryModuleForPolicyApp(circuit))

--- a/pkg/policies/controlplane/runtime/circuit_test.go
+++ b/pkg/policies/controlplane/runtime/circuit_test.go
@@ -1,0 +1,41 @@
+package runtime_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	rt "github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
+	"github.com/fluxninja/aperture/pkg/policies/controlplane/sim"
+)
+
+var _ = Describe("Circuit", func() {
+	It("handles loops by using value from previous iteration", func() {
+		circuit, err := sim.NewCircuitFromYaml(
+			`
+			components:
+			- first_valid:
+				in_ports:
+					inputs:
+						- { signal_name: SUM }
+						- { constant_value: 0.0 }
+				out_ports:
+					output: { signal_name: SUM_OR_ZERO }
+			- arithmetic_combinator:
+				operator: add
+				in_ports:
+					lhs: { signal_name: SUM_OR_ZERO }
+					rhs: { constant_value: 1.0 }
+				out_ports:
+					output: { signal_name: SUM }
+			`,
+			sim.Inputs(nil),
+			sim.OutputSignals{"SUM"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(circuit.Run(3)).To(Equal(
+			map[string][]rt.Reading{
+				"SUM": sim.NewReadings([]float64{1.0, 2.0, 3.0}),
+			},
+		))
+	})
+})

--- a/pkg/policies/controlplane/sim/circuit.go
+++ b/pkg/policies/controlplane/sim/circuit.go
@@ -1,0 +1,213 @@
+package sim
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	policylangv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/language/v1"
+	"github.com/fluxninja/aperture/pkg/config"
+	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/policies/controlplane/circuitfactory"
+	rt "github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
+	"github.com/fluxninja/aperture/pkg/status"
+)
+
+// Introducing some newtypes so that tests themselves are more readable.
+
+// Inputs map signal names to components that will emit test input.
+// Input components are required to emit an "output" signal, such as Input or
+// components.Constant. These can be created with NewInput and NewConstantInput.
+type Inputs map[string]rt.Component
+
+// OutputSignals is a list of signal names that comprise test output.
+type OutputSignals []string
+
+// Circuit is a simulated circuit intended to be used in tests.
+type Circuit struct {
+	meta    *simPolicyMeta
+	circuit *rt.Circuit
+	inputs  Inputs
+	outputs map[string]*output
+	tickNo  int
+	time    time.Time // virtual time of next tick
+}
+
+// NewCircuitFromYaml creates a new simulated Circuit based on yaml circuit description.
+//
+// Differences from real circuit:
+// * Fx options for components will be ignored.
+func NewCircuitFromYaml(
+	circuitYaml string,
+	inputs Inputs,
+	outputSignals OutputSignals,
+) (*Circuit, error) {
+	var err error
+	circuitYaml, err = SanitizeYaml(circuitYaml)
+	if err != nil {
+		return nil, err
+	}
+
+	var circuitProto policylangv1.Circuit
+
+	if err = config.UnmarshalYAML([]byte(circuitYaml), &circuitProto); err != nil {
+		return nil, err
+	}
+
+	policyMeta := newSimPolicyMeta(circuitProto.EvaluationInterval.AsDuration())
+
+	components, _, _, err := circuitfactory.CreateComponents(circuitProto.Components, policyMeta)
+	if err != nil {
+		return nil, err
+	}
+
+	return newCircuit(components, inputs, outputSignals, policyMeta)
+}
+
+// NewCircuit creates a new simulated Circuit.
+func NewCircuit(
+	components []rt.ConfiguredComponent,
+	inputs Inputs,
+	outputSignals OutputSignals,
+) (*Circuit, error) {
+	return newCircuit(components, inputs, outputSignals, newSimPolicyMeta(500*time.Millisecond))
+}
+
+func newCircuit(
+	components []rt.ConfiguredComponent,
+	inputs Inputs,
+	outputSignals OutputSignals,
+	policyMeta *simPolicyMeta,
+) (*Circuit, error) {
+	for inputSignal, input := range inputs {
+		components = append(components, ConfigureInputComponent(input, inputSignal))
+	}
+
+	outputs := make(map[string]*output, len(outputSignals))
+
+	for _, outputSignal := range outputSignals {
+		output := &output{}
+		components = append(components, ConfigureOutputComponent(outputSignal, output))
+		outputs[outputSignal] = output
+	}
+
+	compiledCircuit, err := rt.Compile(components, policyMeta.Registry.GetLogger())
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeCircuit, _ := rt.NewCircuitAndOptions(compiledCircuit, policyMeta)
+	if runtimeCircuit == nil {
+		return nil, errors.New("cannot create circuit")
+	}
+
+	return &Circuit{
+		meta:    policyMeta,
+		circuit: runtimeCircuit,
+		inputs:  inputs,
+		outputs: outputs,
+		time:    time.Now(),
+		tickNo:  0,
+	}, nil
+}
+
+// Step runs one tick of circuit execution and returns values of output signals.
+func (s *Circuit) Step() map[string]rt.Reading {
+	s.execStep()
+
+	outputs := make(map[string]rt.Reading, len(s.outputs))
+	for outputSignal, output := range s.outputs {
+		readings := output.TakeReadings()
+		if len(readings) != 1 {
+			panic("unexpected output readings len")
+		}
+		outputs[outputSignal] = readings[0]
+	}
+	return outputs
+}
+
+// Run runs given number of tick of circuit execution and returns values of output signals.
+func (s *Circuit) Run(steps int) map[string][]rt.Reading {
+	for iStep := 0; iStep < steps; iStep++ {
+		s.execStep()
+	}
+
+	outputs := make(map[string][]rt.Reading, len(s.outputs))
+	for outputSignal, output := range s.outputs {
+		outputs[outputSignal] = output.TakeReadings()
+	}
+	return outputs
+}
+
+// RunDrainInputs runs the circuit for as long as inputs are defined.
+//
+// Returns values of output signals.
+// There must be at least one input of type Input defined and all of them must
+// have same lengths.
+func (s *Circuit) RunDrainInputs() map[string][]rt.Reading {
+	return s.Run(s.inputLen())
+}
+
+func (s *Circuit) inputLen() int {
+	steps := -1
+	for _, input := range s.inputs {
+		if input, ok := input.(*Input); ok {
+			if steps != -1 && steps != len(*input) {
+				panic("input len mismatch")
+			}
+			steps = len(*input)
+		}
+	}
+	if steps == -1 {
+		panic("no Inputs")
+	}
+	return steps
+}
+
+func (s *Circuit) execStep() {
+	err := s.circuit.Execute(
+		rt.NewTickInfo(
+			s.time,
+			s.time.Add(s.meta.EvaluationInterval),
+			s.tickNo,
+			s.meta.EvaluationInterval,
+		),
+	)
+	s.tickNo += 1
+	s.time = s.time.Add(s.meta.EvaluationInterval)
+	if err != nil {
+		// Note: Assuming circuit execution will usually be infallible and thus
+		// all methods on CircuitSim are infallible. If a need will occur to
+		// test a execution when component is expected to fail, consider
+		// introducing new fallible methods, like TryStep, TryRun, etc.
+		panic(fmt.Errorf("circuit.Execute errored: %w", err))
+	}
+}
+
+// simPolicyMeta implements Policy interface for usage in simulated circuits.
+type simPolicyMeta struct {
+	EvaluationInterval time.Duration
+	Registry           status.Registry
+}
+
+func newSimPolicyMeta(evaluationInternal time.Duration) *simPolicyMeta {
+	logger := log.NewLogger(io.Discard, "panic")
+	registry := status.NewRegistry(logger)
+	return &simPolicyMeta{
+		Registry:           registry,
+		EvaluationInterval: evaluationInternal,
+	}
+}
+
+// GetPolicyName implements PolicyReadAPI.
+func (p *simPolicyMeta) GetPolicyName() string { return "test-policy" }
+
+// GetPolicyHash implements PolicyReadAPI.
+func (p *simPolicyMeta) GetPolicyHash() string { return "test-policy-hash" }
+
+// GetEvaluationInterval implements PolicyReadAPI.
+func (p *simPolicyMeta) GetEvaluationInterval() time.Duration { return p.EvaluationInterval }
+
+// GetStatusRegistry implements PolicyReadAPI.
+func (p *simPolicyMeta) GetStatusRegistry() status.Registry { return p.Registry }

--- a/pkg/policies/controlplane/sim/circuit_test.go
+++ b/pkg/policies/controlplane/sim/circuit_test.go
@@ -1,0 +1,128 @@
+package sim_test
+
+import (
+	"math"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/fluxninja/aperture/pkg/policies/controlplane/components"
+	rt "github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
+	"github.com/fluxninja/aperture/pkg/policies/controlplane/sim"
+)
+
+var _ = Describe("Circuit", func() {
+	It("can simulate empty circuit", func() {
+		circuit, err := sim.NewCircuit(nil, nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(circuit.Step()).To(BeEmpty())
+	})
+
+	It("can use constant output", func() {
+		circuit, err := sim.NewCircuit(
+			nil,
+			sim.Inputs{
+				"X": components.NewConstant(42.0),
+			},
+			sim.OutputSignals{"X"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(circuit.Step()).To(Equal(
+			map[string]rt.Reading{
+				"X": rt.NewReading(42.0),
+			},
+		))
+	})
+
+	It("can use array-input", func() {
+		circuit, err := sim.NewCircuit(
+			nil,
+			sim.Inputs{
+				"XX": sim.NewInput([]float64{42.0, 43.0}),
+			},
+			sim.OutputSignals{"XX"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(circuit.RunDrainInputs()).To(Equal(
+			map[string][]rt.Reading{
+				"XX": sim.NewReadings([]float64{42.0, 43.0}),
+			},
+		))
+	})
+
+	It("can simulate a single-component circuit", func() {
+		circuit, err := sim.NewCircuitFromYaml(
+			`
+			components:
+			- sqrt:
+				scale: 1.0 # FIXME, for some reason default doesn't load
+				in_ports:
+					input: { signal_name: INPUT }
+				out_ports:
+					output: { signal_name: SQRT }
+			`,
+			sim.Inputs{
+				"INPUT": sim.NewInput([]float64{4.0, 9.0}),
+			},
+			sim.OutputSignals{"SQRT"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(circuit.RunDrainInputs()).To(Equal(
+			map[string][]rt.Reading{
+				// FIXME: Add some helpers to handle floating-point inaccuracies.
+				// (Here we are lucky to have an exactly-representable answer)
+				"SQRT": sim.NewReadings([]float64{2.0, 3.0}),
+			},
+		))
+	})
+
+	It("can simulate a multi-component circuit", func() {
+		circuit, err := sim.NewCircuitFromYaml(
+			`
+			components:
+			- sqrt:
+				scale: 1.0 # FIXME, for some reason default doesn't load
+				in_ports:
+					input: { signal_name: INPUT }
+				out_ports:
+					output: { signal_name: SQRT }
+			- min:
+				in_ports:
+					inputs:
+						- { signal_name: SQRT }
+						- { signal_name: CAP }
+				out_ports:
+					output: { signal_name: SQRT-CAPPED }
+			`,
+			sim.Inputs{
+				"INPUT": sim.NewInput([]float64{4.0, 9.0}),
+				"CAP":   sim.NewConstantInput(2.5),
+			},
+			sim.OutputSignals{"SQRT-CAPPED"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(circuit.RunDrainInputs()).To(Equal(
+			map[string][]rt.Reading{
+				"SQRT-CAPPED": sim.NewReadings([]float64{2.0, 2.5}),
+			},
+		))
+	})
+
+	It("can handle invalid readings in tests", func() {
+		Skip("FIXME: Figure out how to nicely compare equality of invalid readings, especially in arrays")
+		circuit, err := sim.NewCircuit(
+			nil,
+			sim.Inputs{"NAN": sim.NewConstantInput(math.NaN())},
+			sim.OutputSignals{"NAN"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(circuit.Step()).To(Equal(
+			map[string]rt.Reading{
+				"NAN": rt.InvalidReading(),
+			},
+		))
+	})
+
+	// NOTE: This test file test a sanity of circuit simulator itself. Please
+	// put tests of actual components in appropriate packages.
+})

--- a/pkg/policies/controlplane/sim/components.go
+++ b/pkg/policies/controlplane/sim/components.go
@@ -1,0 +1,106 @@
+package sim
+
+import (
+	"github.com/fluxninja/aperture/pkg/config"
+	"github.com/fluxninja/aperture/pkg/notifiers"
+	"github.com/fluxninja/aperture/pkg/policies/controlplane/components"
+	rt "github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
+)
+
+// Input is a component that will emit signal from the given array – one
+// Reading per tick. On subsequent ticks, it will emit Invalid readings.
+type Input []rt.Reading
+
+// NewInput creates an input from an array of floats.
+func NewInput(values []float64) *Input {
+	input := Input(NewReadings(values))
+	return &input
+}
+
+// NewConstantInput creates a constant-value input.
+func NewConstantInput(value float64) rt.Component {
+	return components.NewConstant(value)
+}
+
+// Name implements runtime.Component.
+func (i *Input) Name() string { return "TestInput" }
+
+// Type implements runtime.Component.
+func (i *Input) Type() rt.ComponentType { return rt.ComponentTypeSource }
+
+// Execute implements runtime.Component.
+func (i *Input) Execute(_ rt.PortToValue, _ rt.TickInfo) (rt.PortToValue, error) {
+	return rt.PortToValue{
+		"output": []rt.Reading{i.execute()},
+	}, nil
+}
+
+func (i *Input) execute() rt.Reading {
+	if len(*i) == 0 {
+		return rt.InvalidReading()
+	}
+	reading := (*i)[0]
+	*i = (*i)[1:]
+	return reading
+}
+
+// DynamicConfigUpdate implements runtime.Component.
+func (i *Input) DynamicConfigUpdate(_ notifiers.Event, _ config.Unmarshaller) {}
+
+// Output is a sink component to capture signal within a test.
+type output struct {
+	Readings []rt.Reading
+}
+
+// Name implements runtime.Component.
+func (o *output) Name() string { return "TestOutput" }
+
+// Type implements runtime.Component.
+func (o *output) Type() rt.ComponentType { return rt.ComponentTypeSink }
+
+// TakeReadings returns the list of readings since previous TakeReadings() call
+// (or since start).
+func (o *output) TakeReadings() []rt.Reading {
+	readings := o.Readings
+	o.Readings = nil
+	return readings
+}
+
+// Execute implements runtime.Component.
+func (o *output) Execute(ins rt.PortToValue, _ rt.TickInfo) (rt.PortToValue, error) {
+	o.Readings = append(o.Readings, ins.ReadSingleValuePort("input"))
+	return nil, nil
+}
+
+// DynamicConfigUpdate implements runtime.Component.
+func (o *output) DynamicConfigUpdate(_ notifiers.Event, _ config.Unmarshaller) {}
+
+/******** helpers ***********/
+
+// ConfigureInputComponent takes an input component and creates a
+// ConfiguredComponent which outputs signal with given name on its "output"
+// port.
+func ConfigureInputComponent(comp rt.Component, signal string) rt.ConfiguredComponent {
+	return rt.ConfiguredComponent{
+		Component: comp,
+		PortMapping: rt.PortMapping{
+			Outs: map[string][]rt.Port{
+				"output": {{SignalName: &signal}},
+			},
+		},
+	}
+}
+
+// ConfigureOutputComponent takes an output component and creates a
+// ConfiguredComponent which reads signal with a given name on its "input"
+// port.
+func ConfigureOutputComponent(signal string, comp rt.Component) rt.ConfiguredComponent {
+	return rt.ConfiguredComponent{
+		Component: comp,
+		PortMapping: rt.PortMapping{
+			Ins: map[string][]rt.Port{
+				"input": {{SignalName: &signal}},
+			},
+		},
+	}
+}

--- a/pkg/policies/controlplane/sim/helpers.go
+++ b/pkg/policies/controlplane/sim/helpers.go
@@ -1,0 +1,52 @@
+package sim
+
+import (
+	"errors"
+	"strings"
+
+	rt "github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
+	"github.com/lithammer/dedent"
+)
+
+// NewReadings creates a slice of readings from a slice of floats.
+func NewReadings(values []float64) []rt.Reading {
+	readings := make([]rt.Reading, 0, len(values))
+	for _, value := range values {
+		readings = append(readings, rt.NewReading(value))
+	}
+	return readings
+}
+
+// SanitizeYaml cleans up indentation of multiline string literal with yaml.
+//
+// This is needed as yaml parsing will otherwise fail on tabs.
+func SanitizeYaml(source string) (string, error) {
+	// Get rid of leadings tabs that are likely to happen within multiline string literals.
+	source = dedent.Dedent(source)
+
+	// Accept either space-indented yaml or tab-indented yaml. In the latter
+	// case, tabs need to be converted to spaces before parsing.
+	spaces := false
+	tabs := false
+	for _, line := range strings.Split(source, "\n") {
+	loop:
+		for _, c := range line {
+			switch c {
+			case ' ':
+				spaces = true
+			case '\t':
+				tabs = true
+			default:
+				break loop
+			}
+		}
+	}
+	if spaces && tabs {
+		return "", errors.New("mixed tabs and spaces in yaml")
+	}
+	if tabs {
+		source = strings.ReplaceAll(source, "\t", "    ")
+	}
+
+	return source, nil
+}

--- a/pkg/policies/controlplane/sim/sim_suite_test.go
+++ b/pkg/policies/controlplane/sim/sim_suite_test.go
@@ -1,0 +1,29 @@
+package sim_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/utils"
+)
+
+func TestRuntime(t *testing.T) {
+	log.SetGlobalLevel(log.WarnLevel)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sim Suite")
+}
+
+var l *utils.GoLeakDetector
+
+var _ = BeforeSuite(func() {
+	l = utils.NewGoLeakDetector()
+})
+
+var _ = AfterSuite(func() {
+	err := l.FindLeaks()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
### Description of change

Added sim.Circuit which can be used to simulate a circuit using given Inputs, capturing listed output signals. Circuit can be defined as list of ConfiguredComponents or parsed from yaml.

Drive-by: Simplify circuit.NewCircuitWithOptions

Resolves #649 

##### Checklist

- [x] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1019)
<!-- Reviewable:end -->
