### PR TITLE
Improve OLAP telemetry rollup

### DIFF
--- a/cmd/aperture-agent/agent/otel-component.go
+++ b/cmd/aperture-agent/agent/otel-component.go
@@ -110,7 +110,7 @@ func AgentOTELComponents(
 		batchprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),
 		enrichmentprocessor.NewFactory(cache),
-		rollupprocessor.NewFactory(),
+		rollupprocessor.NewFactory(promRegistry),
 		metricsprocessor.NewFactory(promRegistry, engine, clasEng, controlPointCache),
 		attributesprocessor.NewFactory(),
 		tracestologsprocessor.NewFactory(),

--- a/docs/content/references/configuration/agent.md
+++ b/docs/content/references/configuration/agent.md
@@ -637,7 +637,7 @@ into smaller units.
 <dt>timeout</dt>
 <dd>
 
-(string, `gt=0`, default: `1s`) Timeout sets the time after which a batch will be sent regardless of size.
+(string, `gt=0`, default: `10s`) Timeout sets the time after which a batch will be sent regardless of size.
 
 </dd>
 </dl>

--- a/docs/content/references/configuration/controller.md
+++ b/docs/content/references/configuration/controller.md
@@ -534,7 +534,7 @@ into smaller units.
 <dt>timeout</dt>
 <dd>
 
-(string, `gt=0`, default: `1s`) Timeout sets the time after which a batch will be sent regardless of size.
+(string, `gt=0`, default: `10s`) Timeout sets the time after which a batch will be sent regardless of size.
 
 </dd>
 </dl>

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -192,7 +192,7 @@ definitions:
           of size.
         format: string
         type: string
-        x-go-default: 1s
+        x-go-default: 10s
         x-go-name: Timeout
         x-go-validate: gt=0
     title: BatchPrerollupConfig defines configuration for OTEL batch processor.

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -178,7 +178,7 @@ definitions:
           of size.
         format: string
         type: string
-        x-go-default: 1s
+        x-go-default: 10s
         x-go-name: Timeout
         x-go-validate: gt=0
     title: BatchPrerollupConfig defines configuration for OTEL batch processor.

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -78,6 +78,11 @@ const (
 	// FlowControlRejectReasonsMetricName - metric for reject reason on FCS Check requests.
 	FlowControlRejectReasonsMetricName = "flowcontrol_reject_reasons_total"
 
+	// OTEL metrics.
+
+	// RollupMetricName - logs rollup histogram.
+	RollupMetricName = "rollup"
+
 	// PROMETHEUS LABELS.
 
 	// InstanceLabel used to identify the host name on which an Aperture process is running.

--- a/pkg/otelcollector/config.go
+++ b/pkg/otelcollector/config.go
@@ -267,7 +267,7 @@ type PortsConfig struct {
 // +kubebuilder:object:generate=true
 type BatchPrerollupConfig struct {
 	// Timeout sets the time after which a batch will be sent regardless of size.
-	Timeout config.Duration `json:"timeout" validate:"gt=0" default:"1s"`
+	Timeout config.Duration `json:"timeout" validate:"gt=0" default:"10s"`
 
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 	SendBatchSize uint32 `json:"send_batch_size" validate:"gt=0" default:"10000"`

--- a/pkg/otelcollector/rollupprocessor/config.go
+++ b/pkg/otelcollector/rollupprocessor/config.go
@@ -1,6 +1,7 @@
 package rollupprocessor
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 )
@@ -9,6 +10,9 @@ import (
 type Config struct {
 	config.ProcessorSettings  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 	AttributeCardinalityLimit int                      `mapstructure:"attribute_cardinality_limit"`
+	RollupBuckets             []float64                `mapstructure:"rollup_buckets"`
+
+	promRegistry *prometheus.Registry
 }
 
 var _ component.ProcessorConfig = (*Config)(nil)

--- a/pkg/otelcollector/rollupprocessor/processor.go
+++ b/pkg/otelcollector/rollupprocessor/processor.go
@@ -13,8 +13,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/metrics"
 	"github.com/fluxninja/aperture/pkg/otelcollector"
 	"github.com/fluxninja/datasketches-go/sketches"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var rollupTypes = []RollupType{
@@ -82,6 +84,7 @@ type rollupProcessor struct {
 	cfg *Config
 
 	logsNextConsumer consumer.Logs
+	rollupHistogram  *prometheus.HistogramVec
 }
 
 const (
@@ -105,8 +108,22 @@ var (
 )
 
 func newRollupProcessor(set component.ProcessorCreateSettings, cfg *Config) (*rollupProcessor, error) {
+	rollupHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    metrics.RollupMetricName,
+		Help:    "Latency of the requests processed by the server",
+		Buckets: cfg.RollupBuckets,
+	}, []string{})
+	err := cfg.promRegistry.Register(rollupHistogram)
+	if err != nil {
+		// Ignore already registered error, as this is not harmful. Metrics may
+		// be registered by other running processor.
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			return nil, fmt.Errorf("couldn't register prometheus metrics: %w", err)
+		}
+	}
 	return &rollupProcessor{
-		cfg: cfg,
+		cfg:             cfg,
+		rollupHistogram: rollupHistogram,
 	}, nil
 }
 
@@ -132,6 +149,7 @@ func (rp *rollupProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) error 
 	rollupData := make(map[string]pcommon.Map)
 	datasketches := make(map[string]map[string]*sketches.HeapDoublesSketch)
 
+	log.Trace().Int("count", ld.LogRecordCount()).Msg("Before rollup")
 	otelcollector.IterateLogRecords(ld, func(logRecord plog.LogRecord) otelcollector.IterAction {
 		attributes := logRecord.Attributes()
 		key := rp.key(attributes, rollupsLog)
@@ -290,7 +308,15 @@ func (rp *rollupProcessor) exportLogs(ctx context.Context, rollupData map[string
 		// TODO tgill: need to get timestamp from v
 		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Now().UTC()))
 		v.CopyTo(logRecord.Attributes())
+		rawCount, _ := v.Get(RollupCountKey)
+		hist, err := rp.rollupHistogram.GetMetricWith(nil)
+		if err != nil {
+			log.Debug().Msgf("Could not extract rollup histogram metric from registry: %v", err)
+		} else {
+			hist.Observe(float64(rawCount.Int()))
+		}
 	}
+	log.Trace().Int("count", ld.LogRecordCount()).Msg("After rollup")
 	return rp.logsNextConsumer.ConsumeLogs(ctx, ld)
 }
 

--- a/pkg/otelcollector/rollupprocessor/processor.go
+++ b/pkg/otelcollector/rollupprocessor/processor.go
@@ -85,7 +85,7 @@ type rollupProcessor struct {
 }
 
 const (
-	defaultAttributeCardinalityLimit = 250
+	defaultAttributeCardinalityLimit = 10
 	// RedactedAttributeValue is a value that replaces actual attribute value
 	// in case it exceeds cardinality limit.
 	RedactedAttributeValue = "REDACTED_VIA_CARDINALITY_LIMIT"

--- a/pkg/otelcollector/rollupprocessor/processor_test.go
+++ b/pkg/otelcollector/rollupprocessor/processor_test.go
@@ -1,4 +1,4 @@
-package rollupprocessor_test
+package rollupprocessor
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"github.com/fluxninja/datasketches-go/sketches"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -16,7 +17,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/fluxninja/aperture/pkg/otelcollector"
-	. "github.com/fluxninja/aperture/pkg/otelcollector/rollupprocessor"
 )
 
 var _ = Describe("Rollup processor", func() {
@@ -28,6 +28,8 @@ var _ = Describe("Rollup processor", func() {
 	BeforeEach(func() {
 		config = &Config{
 			AttributeCardinalityLimit: 10,
+			RollupBuckets:             []float64{10, 20, 30},
+			promRegistry:              prometheus.NewRegistry(),
 		}
 		testConsumer = &fakeConsumer{
 			receivedLogs:    []plog.Logs{},

--- a/pkg/otelcollector/rollupprocessor/rollupprocessor_suite_test.go
+++ b/pkg/otelcollector/rollupprocessor/rollupprocessor_suite_test.go
@@ -1,4 +1,4 @@
-package rollupprocessor_test
+package rollupprocessor
 
 import (
 	"testing"

--- a/pkg/policies/flowcontrol/engine.go
+++ b/pkg/policies/flowcontrol/engine.go
@@ -3,6 +3,7 @@ package flowcontrol
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"golang.org/x/exp/maps"
@@ -65,9 +66,11 @@ func (e *Engine) ProcessRequest(
 	serviceIDs []string,
 	labels map[string]string,
 ) (response *flowcontrolv1.CheckResponse) {
+	labelKeys := maps.Keys(labels)
+	sort.Strings(labelKeys)
 	response = &flowcontrolv1.CheckResponse{
 		DecisionType:  flowcontrolv1.CheckResponse_DECISION_TYPE_ACCEPTED,
-		FlowLabelKeys: maps.Keys(labels),
+		FlowLabelKeys: labelKeys,
 		Services:      serviceIDs,
 		ControlPoint:  controlPoint,
 	}


### PR DESCRIPTION
### Description of change
#### 1. Sort flow label keys in Check() response  
Without flow label keys sorted, the rollup was not working properly, as
different order of items was treated as different rollup key.

#### 2. Change pre-rollup default timeout to 10s
This changes granularity of data going to FN Cloud from 1 to 10 seconds.

#### 3. Change cardinality limit to 10 per field per package.
This is needed to have some meaningful rollups.

#### 4. Add `rollup` histogram metric
For better observability in the future.


##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added
- [x] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1027)
<!-- Reviewable:end -->
