### PR TITLE
rollupprocessor: Prepare for multiple stages of rollup

### DIFF
--- a/pkg/otelcollector/rollupprocessor/config.go
+++ b/pkg/otelcollector/rollupprocessor/config.go
@@ -11,8 +11,20 @@ type Config struct {
 	config.ProcessorSettings  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 	AttributeCardinalityLimit int                      `mapstructure:"attribute_cardinality_limit"`
 	RollupBuckets             []float64                `mapstructure:"rollup_buckets"`
+	Stage                     Stage                    `mapstructure:"stage"`
 
 	promRegistry *prometheus.Registry
 }
+
+// Stage defines whether this is initial or aggregating rollup.
+type Stage string
+
+const (
+	// InitialStage is rollup made directly from individual logs.
+	InitialStage Stage = "initial"
+
+	// Aggregation is rollup of rollup results.
+	Aggregation Stage = "aggregation"
+)
 
 var _ component.ProcessorConfig = (*Config)(nil)

--- a/pkg/otelcollector/rollupprocessor/factory.go
+++ b/pkg/otelcollector/rollupprocessor/factory.go
@@ -29,6 +29,7 @@ func createDefaultConfig(promRegistry *prometheus.Registry) func() component.Pro
 		return &Config{
 			ProcessorSettings:         config.NewProcessorSettings(component.NewID(typeStr)),
 			AttributeCardinalityLimit: defaultAttributeCardinalityLimit,
+			Stage:                     InitialStage,
 			RollupBuckets:             defaultRollupBuckets,
 			promRegistry:              promRegistry,
 		}

--- a/pkg/otelcollector/rollupprocessor/processor_test.go
+++ b/pkg/otelcollector/rollupprocessor/processor_test.go
@@ -28,6 +28,7 @@ var _ = Describe("Rollup processor", func() {
 	BeforeEach(func() {
 		config = &Config{
 			AttributeCardinalityLimit: 10,
+			Stage:                     InitialStage,
 			RollupBuckets:             []float64{10, 20, 30},
 			promRegistry:              prometheus.NewRegistry(),
 		}


### PR DESCRIPTION
### Description of change

Stage field in rollupprocessor config decides whether processor should perform
initial rollup from logs, or "rollup of rollups". Each Rollup now "knows" how
it should be aggregated.

Aggregate rollup is not enabled in any pipeline yet (and can't, as we need to
implement RollupDatasketchMerge).

---

Wanted to represent rollup of counts as RollupSum, but RollupSum operates on floats. We can either:
* special-case counts, don't try to treat it as regular Rollup,
* duplicate all float-attribute-related code to work on int-fields too,
* just accept that sum of counts won't be int.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1033)
<!-- Reviewable:end -->
