### PR TITLE
Fix alerts channel marshall & add resolve timeout helpers

### DIFF
--- a/blueprints/examples/latency-gradient/example.jsonnet
+++ b/blueprints/examples/latency-gradient/example.jsonnet
@@ -12,7 +12,6 @@ local flowSelector = aperture.spec.v1.FlowSelector;
 local serviceSelector = aperture.spec.v1.ServiceSelector;
 local flowMatcher = aperture.spec.v1.FlowMatcher;
 local controlPoint = aperture.spec.v1.ControlPoint;
-local staticBuckets = aperture.spec.v1.FluxMeterStaticBuckets;
 
 local svcSelector = flowSelector.new()
                     + flowSelector.withServiceSelector(

--- a/pkg/alerts/alert.go
+++ b/pkg/alerts/alert.go
@@ -48,7 +48,6 @@ var specialLabels = map[string]struct{}{
 	otelcollector.AlertNameLabel:         {},
 	otelcollector.AlertSeverityLabel:     {},
 	otelcollector.AlertGeneratorURLLabel: {},
-	otelcollector.AlertChannelsLabel:     {},
 }
 
 // AlertOption is a type for constructor options.

--- a/pkg/alerts/alert.go
+++ b/pkg/alerts/alert.go
@@ -183,6 +183,18 @@ func WithGeneratorURL(value string) AlertOption {
 	}
 }
 
+// SetResolveTimeout sets a resolve timeout which says when given alert becomes resolved.
+func (a *Alert) SetResolveTimeout(t time.Duration) {
+	a.postableAlert.EndsAt = strfmt.DateTime(time.Time(a.postableAlert.StartsAt).Add(t))
+}
+
+// WithResolveTimeout is an option function for constructor.
+func WithResolveTimeout(t time.Duration) AlertOption {
+	return func(a *Alert) {
+		a.SetResolveTimeout(t)
+	}
+}
+
 // AlertsFromLogs gets slice of alerts from OTEL Logs.
 func AlertsFromLogs(ld plog.Logs) []*Alert {
 	// We can't preallocate size, as we don't know how many of those log records
@@ -206,6 +218,7 @@ func AlertsFromLogs(ld plog.Logs) []*Alert {
 				logRecord := logsSlice.At(logsIt)
 				a := &Alert{}
 				a.postableAlert.StartsAt = strfmt.DateTime(logRecord.Timestamp().AsTime())
+				a.postableAlert.EndsAt = strfmt.DateTime(logRecord.ObservedTimestamp().AsTime())
 				a.postableAlert.GeneratorURL = strfmt.URI(generatorURL.AsString())
 				a.postableAlert.Labels = models.LabelSet(mapFromAttributes(resourceAttributes, specialLabels))
 				a.SetSeverity(ParseSeverity(logRecord.SeverityText()))
@@ -232,6 +245,7 @@ func (a *Alert) AsLogs() plog.Logs {
 
 	logRecord := resource.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 	logRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Time(a.postableAlert.StartsAt)))
+	logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Time(a.postableAlert.EndsAt)))
 	logRecord.SetSeverityText(a.Severity().String())
 	pcommon.NewValueStr(a.Name()).CopyTo(logRecord.Body())
 

--- a/pkg/alerts/alert_test.go
+++ b/pkg/alerts/alert_test.go
@@ -1,6 +1,8 @@
 package alerts_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -16,6 +18,7 @@ var _ = Describe("Alert", func() {
 			alerts.WithName("buzz"),
 			alerts.WithSeverity(alerts.SeverityCrit),
 			alerts.WithAlertChannels([]string{"one", "two", "three"}),
+			alerts.WithResolveTimeout(50*time.Second),
 		)
 		finalAlert := alert
 		finalAlert.SetLabel("is_alert", "true")

--- a/pkg/alerts/alert_test.go
+++ b/pkg/alerts/alert_test.go
@@ -15,6 +15,7 @@ var _ = Describe("Alert", func() {
 			alerts.WithAnnotation("two", "twelve"),
 			alerts.WithName("buzz"),
 			alerts.WithSeverity(alerts.SeverityCrit),
+			alerts.WithAlertChannels([]string{"one", "two", "three"}),
 		)
 		finalAlert := alert
 		finalAlert.SetLabel("is_alert", "true")

--- a/pkg/otelcollector/alertsexporter/exporter.go
+++ b/pkg/otelcollector/alertsexporter/exporter.go
@@ -45,6 +45,7 @@ func (ex *alertsExporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	alerts := alerts.AlertsFromLogs(ld)
 
 	for _, amClient := range ex.cfg.alertMgr.Clients {
+		log.Trace().Int("alerts", ld.LogRecordCount()).Str("client", amClient.GetName()).Msg("Exporting alerts")
 		err := amClient.SendAlerts(ctx, alerts)
 		if err != nil {
 			log.Warn().Err(err).Msgf("could not send alerts for client: %+v", amClient.GetName())

--- a/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
+++ b/pkg/policies/controlplane/components/actuators/concurrency/load-actuator.go
@@ -216,7 +216,7 @@ func (la *LoadActuator) createAlert() *alerts.Alert {
 	if evalTimeout > timeout {
 		timeout = evalTimeout
 	}
-	newAlert.SetAnnotation("resolve_timeout", timeout.String())
+	newAlert.SetResolveTimeout(timeout)
 
 	return newAlert
 }

--- a/pkg/policies/controlplane/components/alerter.go
+++ b/pkg/policies/controlplane/components/alerter.go
@@ -78,7 +78,7 @@ func (a *Alerter) createAlert() *alerts.Alert {
 		alerts.WithAlertChannels(a.alertChannels),
 		alerts.WithLabel("policy_name", a.policyReadAPI.GetPolicyName()),
 		alerts.WithLabel("type", "alerter"),
-		alerts.WithAnnotation("resolve_timeout", a.resolveTimeout.String()),
+		alerts.WithResolveTimeout(a.resolveTimeout),
 		alerts.WithGeneratorURL(
 			fmt.Sprintf("http://%s/%s/%s", info.GetHostInfo().Hostname, a.policyReadAPI.GetPolicyName(), a.name),
 		),


### PR DESCRIPTION
### Description of change
* Properly marshal `alert_channels` alert label to OTEL logs
* Drive-By: remove unused jsonnet import
* Add trace logging to Alertmanager exporter
* Add resolve timeout helpers to Alerts

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1034)
<!-- Reviewable:end -->
