### PR TITLE
Fix linker in `make go-test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,12 @@ go-test:
 	@echo Running go tests
 	@{ \
 		export KUBEBUILDER_ASSETS=$(shell make operator-setup_envtest -s); \
-		gotestsum --format=pkgname; \
+		PKGS=$$(go list ./...); \
+		gotestsum \
+			--format=pkgname \
+			--packages="$${PKGS}" \
+			-- \
+				-ldflags='-extldflags "-Wl,--allow-multiple-definition"'; \
 	}
 
 go-lint:


### PR DESCRIPTION
### Description of change
Using github.com/alecthomas/participle as a dependency causes `multiple definition` error in linker. This fix allows such multiple definitions when linking.

##### Checklist

- [ ] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1039)
<!-- Reviewable:end -->
