### PR TITLE
Add image and description to Introduction page

### DIFF
--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -1,7 +1,10 @@
 ---
 title: Introduction
 sidebar_position: 1
-description: Aperture Introduction
+description:
+  Introduction to FluxNinja Aperture, an open-source flow control and
+  reliability management platform for modern web applications.
+image: ./assets/img/aperture_logo.png
 keywords:
   - reliability
   - overload


### PR DESCRIPTION
The front matter fields are preferred and used by Docusaurus, e.g., `og:description`, `og:image`. These are the fields used in social media thumbnails.

Reference - https://docusaurus.io/docs/next/seo#:~:text=Docusaurus%20is%20a%20static%20site,discover%20your%20content%20more%20easily.

### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1049)
<!-- Reviewable:end -->
