### PR TITLE
Added steps for exposing the etcd and prometheus outside of the cluster

### DIFF
--- a/manifests/charts/aperture-controller/README.md
+++ b/manifests/charts/aperture-controller/README.md
@@ -165,18 +165,28 @@
 | `controller.config.prometheus.address`                       | specifies the address of the Prometheus server. Example, "http://prometheus-server:80". This must not be empty when prometheus.enabled is set to false. | `nil`    |
 
 
+### Ingress
+
+| Name                  | Description                                  | Value   |
+| --------------------- | -------------------------------------------- | ------- |
+| `ingress.enabled`     | Enables Ingress for Etcd and Prometheus      | `false` |
+| `ingress.domain_name` | Domain Name to use for configuring the Paths | `nil`   |
+
+
 ### etcd
 
-| Name                                  | Description                                                                            | Value               |
-| ------------------------------------- | -------------------------------------------------------------------------------------- | ------------------- |
-| `etcd.enabled`                        | Whether to deploy a small etcd cluster as part of this chart                           | `true`              |
-| `etcd.auth.rbac.create`               | specifies whether to create the RBAC resources for Etcd                                | `false`             |
-| `etcd.auth.token.type`                | specifies the type of token to use                                                     | `simple`            |
-| `etcd.initContainer.enabled`          | Create init container to check the health of Etcd before starting Aperture Controller. | `true`              |
-| `etcd.initContainer.image.registry`   | Init container image registry.                                                         | `docker.io/bitnami` |
-| `etcd.initContainer.image.repository` | Init container image repository.                                                       | `etcd`              |
-| `etcd.initContainer.image.tag`        | Init container image tag.                                                              | `3.5`               |
-| `etcd.initContainer.image.pullPolicy` | Init container image pull policy.                                                      | `IfNotPresent`      |
+| Name                                  | Description                                                                               | Value               |
+| ------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------- |
+| `etcd.enabled`                        | Whether to deploy a small etcd cluster as part of this chart                              | `true`              |
+| `etcd.auth.rbac.create`               | specifies whether to create the RBAC resources for Etcd                                   | `false`             |
+| `etcd.auth.token.type`                | specifies the type of token to use                                                        | `simple`            |
+| `etcd.autoCompactionMode`             | Auto compaction mode, by default periodic. Valid values: "periodic", "revision".          | `periodic`          |
+| `etcd.autoCompactionRetention`        | Auto compaction retention for mvcc key value store in hour, by default 0, means disabled. | `24`                |
+| `etcd.initContainer.enabled`          | Create init container to check the health of Etcd before starting Aperture Controller.    | `true`              |
+| `etcd.initContainer.image.registry`   | Init container image registry.                                                            | `docker.io/bitnami` |
+| `etcd.initContainer.image.repository` | Init container image repository.                                                          | `etcd`              |
+| `etcd.initContainer.image.tag`        | Init container image tag.                                                                 | `3.5`               |
+| `etcd.initContainer.image.pullPolicy` | Init container image pull policy.                                                         | `IfNotPresent`      |
 
 
 ### prometheus

--- a/manifests/charts/aperture-controller/templates/_helpers.tpl
+++ b/manifests/charts/aperture-controller/templates/_helpers.tpl
@@ -96,3 +96,15 @@ Fetch the value of the API Key secret for Aperture Controller
     {{ print "" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Prepare the Host for configuring in the Ingress
+{{ include "controller.ingress-endpoint" ( dict "component" "component_name" "context" $.context $) }}
+*/}}
+{{- define "controller.ingress-endpoint" -}}
+{{- if .context.Values.ingress.domain_name -}}
+    {{- printf "%s.%s" .component .context.Values.ingress.domain_name -}}
+{{- else -}}
+    {{- fail "Value of .Values.ingress.domain_name cannot be empty when .Values.ingress.enabled is set to true." -}}
+{{- end -}}
+{{- end -}}

--- a/manifests/charts/aperture-controller/templates/ingress.yaml
+++ b/manifests/charts/aperture-controller/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ingress
+  namespace: {{ template "common.names.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: aperture-controller-ingress
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+  - host: {{ include "controller.ingress-endpoint" (dict "component" "etcd" "context" . $) | quote }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}-etcd
+            port:
+              number: {{ coalesce .Values.etcd.service.ports.client .Values.etcd.service.port 2379 }}
+        path: /
+        pathType: Prefix
+  - host: {{ include "controller.ingress-endpoint" (dict "component" "prometheus" "context" . $) | quote }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}-prometheus-server
+            port:
+              number: {{ coalesce .Values.prometheus.server.service.servicePort 80 }}
+        path: /
+        pathType: Prefix
+{{- end }}

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -529,10 +529,20 @@ controller:
     prometheus:
       address: ~
 
+## @section Ingress
+##
+ingress:
+  ## @param ingress.enabled Enables Ingress for Etcd and Prometheus
+  enabled: false
+  ## @param ingress.domain_name Domain Name to use for configuring the Paths
+  domain_name: ~
+
 ## @section etcd
 ## @param etcd.enabled Whether to deploy a small etcd cluster as part of this chart
 ## @param etcd.auth.rbac.create specifies whether to create the RBAC resources for Etcd
 ## @param etcd.auth.token.type specifies the type of token to use
+## @param etcd.autoCompactionMode Auto compaction mode, by default periodic. Valid values: "periodic", "revision".
+## @param etcd.autoCompactionRetention Auto compaction retention for mvcc key value store in hour, by default 0, means disabled.
 ## @param etcd.initContainer.enabled Create init container to check the health of Etcd before starting Aperture Controller.
 ## @param etcd.initContainer.image.registry Init container image registry.
 ## @param etcd.initContainer.image.repository Init container image repository.


### PR DESCRIPTION
### Description of change

Added support for Ingress to expose etcd and prometheus endpoints in the Controller chart and steps for the same.

##### Checklist

- [x] Documentation is changed or added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1051)
<!-- Reviewable:end -->
