### PR TITLE
Fixed the hyphen issue in rpm package name

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -670,6 +670,8 @@ jobs:
           name: Package
           command: |
             mkdir -p dist/packages/
+            vless_version="${VERSION##v}"
+            export VERSION=${vless_version//[-]/\~}
             nfpm package --packager deb --target dist/packages/
             nfpm package --packager rpm --target dist/packages/
             ls -l dist/packages/
@@ -686,7 +688,10 @@ jobs:
                   for package in "deb" "rpm"
                   do
                     gcloud config set artifacts/repository aperture-${package}-packages
-                    gcloud artifacts apt upload aperture-${package}-packages --source="$(ls dist/packages/*.${package})" --project=${GOOGLE_PROJECT_ID}
+                    case "${package}" in
+                      deb) gcloud artifacts apt upload aperture-${package}-packages --source="$(ls dist/packages/*.${package})" --project=${GOOGLE_PROJECT_ID};;
+                      rpm) gcloud artifacts yum upload aperture-${package}-packages --source="$(ls dist/packages/*.${package})" --project=${GOOGLE_PROJECT_ID};;
+                    esac
                   done
       - save_cache:
           name: Save go cache

--- a/packaging/aperture-agent.yaml
+++ b/packaging/aperture-agent.yaml
@@ -1,4 +1,4 @@
-## The address of promethus instance connected with the Aperture Controller
+## The address of prometheus instance connected with the Aperture Controller
 # prometheus:
 #   address: http://myprometheus:9090
 


### PR DESCRIPTION
### Description of change

RPM is not allowing `-` in package name and nfpm is only replacing the first `-` in version with `~` so replaced it manually for both.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1057)
<!-- Reviewable:end -->
