### PR TITLE
Fix baremetal package building

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -627,10 +627,10 @@ jobs:
             GIT_BRANCH="$(git branch --show-current)"
             GIT_COMMIT_HASH="$(git log -n1 --format=%H)"
             GOOS="$(go env GOOS)"
-            component=aperture-controller
+            component=aperture-agent
             tag_matcher="releases/${component}/*"
             current_branch="$(git branch --show-current)"
-            tag="$(git tag -l --sort="-version:refname" "${tag_matcher}" | head -n1 | cut -d/ -f 3)"
+            tag="$(git tag -l --sort="-version:refname" "${tag_matcher}" | head -n1)"
             commits="$(git rev-list "${tag}"..HEAD --count)"
             VERSION="${tag##*/}-b.${commits}"
             mkdir -p $HOME/go


### PR DESCRIPTION
### Description of change

There is a race between component tag being created, and compund tag being created.
Since we only need the former,
we now get the commit count since latest aperture-agent component tag.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1063)
<!-- Reviewable:end -->
