### PR TITLE
Cleaned up RBAC permissions in operator for agent and controller

### DIFF
--- a/manifests/charts/aperture-agent/templates/rbac.yaml
+++ b/manifests/charts/aperture-agent/templates/rbac.yaml
@@ -22,7 +22,6 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
-  - validatingwebhookconfigurations
   - mutatingwebhookconfigurations
   verbs:
   - create
@@ -48,16 +47,7 @@ rules:
 - apiGroups:
   - fluxninja.com
   resources:
-  - controllers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - fluxninja.com
-  resources:
   - agents
-  - policies
   verbs:
   - create
   - delete
@@ -70,33 +60,23 @@ rules:
   - fluxninja.com
   resources:
   - agents/finalizers
-  - policies/finalizers
   verbs:
   - update
 - apiGroups:
   - fluxninja.com
   resources:
   - agents/status
-  - policies/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-- apiGroups:
   - ""
   resources:
-  - componentstatuses
   - configmaps
   - secrets
   - serviceaccounts
   - services
-  - namespaces
   verbs:
   - create
   - delete
@@ -108,21 +88,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - namespaces/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
   - nodes
+  - endpoints
+  - componentstatuses
   verbs:
   - get
   - list
@@ -155,6 +123,7 @@ rules:
   - ""
   resources:
   - pods
+  - namespaces
   verbs:
   - get
   - list
@@ -184,14 +153,6 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
@@ -204,25 +165,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-- apiGroups:
-  - quota.openshift.io
-  resources:
-  - clusterresourcequotas
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/aperture-controller/templates/rbac.yaml
+++ b/manifests/charts/aperture-controller/templates/rbac.yaml
@@ -13,12 +13,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 rules:
-- nonResourceURLs:
-  - /healthz
-  - /metrics
-  - /version
-  verbs:
-  - get
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -35,7 +29,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - daemonsets
   - deployments
   verbs:
   - create
@@ -44,14 +37,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - fluxninja.com
-  resources:
-  - agents
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - fluxninja.com
@@ -83,79 +68,15 @@ rules:
   - patch
   - update
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-- apiGroups:
   - ""
   resources:
-  - componentstatuses
   - configmaps
   - secrets
   - serviceaccounts
   - services
-  - namespaces
   verbs:
   - create
   - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - namespaces/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes/metrics
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - nodes/proxy
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - nodes/spec
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - nodes/stats
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
   - get
   - list
   - patch
@@ -184,14 +105,6 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
@@ -204,25 +117,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-- apiGroups:
-  - quota.openshift.io
-  resources:
-  - clusterresourcequotas
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -64,18 +64,20 @@ rules:
   resources:
   - leases
   verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - componentstatuses
-  verbs:
   - create
   - delete
   - get
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - componentstatuses
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -112,27 +114,11 @@ rules:
   resources:
   - namespaces
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - namespaces/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - ""
   resources:
@@ -290,19 +276,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-- apiGroups:
-  - quota.openshift.io
-  resources:
-  - clusterresourcequotas
-  verbs:
-  - get
-  - list
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
@@ -326,9 +299,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use

--- a/operator/controllers/agent/clusterrole.go
+++ b/operator/controllers/agent/clusterrole.go
@@ -33,16 +33,7 @@ var (
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
-			APIGroups: []string{"quota.openshift.io"},
-			Resources: []string{"clusterresourcequotas"},
-			Verbs:     []string{"get"},
-		},
-		{
-			NonResourceURLs: []string{"/version", "/healthz"},
-			Verbs:           []string{"get"},
-		},
-		{
-			NonResourceURLs: []string{"/metrics"},
+			NonResourceURLs: []string{"/version", "/healthz", "/metrics"},
 			Verbs:           []string{"get"},
 		},
 		{
@@ -51,53 +42,16 @@ var (
 			Verbs:     []string{"get"},
 		},
 		{
-			APIGroups:     []string{"policy"},
-			Resources:     []string{"podsecuritypolicies"},
-			Verbs:         []string{"use"},
-			ResourceNames: []string{controllers.AppName},
-		},
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"use"},
-			ResourceNames: []string{controllers.AppName},
-		},
-		{
-			APIGroups: []string{"coordination.k8s.io"},
-			Resources: []string{"leases"},
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-		},
-		{
-			APIGroups: []string{"admissionregistration.k8s.io"},
-			Resources: []string{"mutatingwebhookconfigurations"},
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-		},
-		{
-			APIGroups: []string{"fluxninja.com"},
-			Resources: []string{"policies"},
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-		},
-		{
 			APIGroups: []string{""},
 			Resources: []string{"events"},
 			Verbs:     []string{"create", "patch"},
-		},
-		{
-			APIGroups: []string{"fluxninja.com"},
-			Resources: []string{"policies/finalizers"},
-			Verbs:     []string{"update"},
-		},
-		{
-			APIGroups: []string{"fluxninja.com"},
-			Resources: []string{"policies/status"},
-			Verbs:     []string{"get", "patch", "update"},
 		},
 	}
 
 	roleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "ClusterRole",
-		Name:     controllers.AppName,
+		Name:     controllers.AgentServiceName,
 	}
 )
 
@@ -105,7 +59,7 @@ var (
 func clusterRoleForAgent(instance *agentv1alpha1.Agent) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.AppName,
+			Name:        controllers.AgentServiceName,
 			Labels:      controllers.CommonLabels(instance.Spec.Labels, instance.GetName(), controllers.OperatorName),
 			Annotations: controllers.AgentAnnotationsWithOwnerRef(instance),
 		},

--- a/operator/controllers/agent/clusterrole_test.go
+++ b/operator/controllers/agent/clusterrole_test.go
@@ -46,7 +46,7 @@ var _ = Describe("clusterRoleForAgent", func() {
 
 			expected := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: AppName,
+					Name: AgentServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   AppName,
@@ -65,16 +65,7 @@ var _ = Describe("clusterRoleForAgent", func() {
 						Verbs:     []string{"get", "list", "watch"},
 					},
 					{
-						APIGroups: []string{"quota.openshift.io"},
-						Resources: []string{"clusterresourcequotas"},
-						Verbs:     []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/version", "/healthz"},
-						Verbs:           []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/metrics"},
+						NonResourceURLs: []string{"/version", "/healthz", "/metrics"},
 						Verbs:           []string{"get"},
 					},
 					{
@@ -83,46 +74,9 @@ var _ = Describe("clusterRoleForAgent", func() {
 						Verbs:     []string{"get"},
 					},
 					{
-						APIGroups:     []string{"policy"},
-						Resources:     []string{"podsecuritypolicies"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups:     []string{"security.openshift.io"},
-						Resources:     []string{"securitycontextconstraints"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups: []string{"coordination.k8s.io"},
-						Resources: []string{"leases"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
-						APIGroups: []string{"admissionregistration.k8s.io"},
-						Resources: []string{"mutatingwebhookconfigurations"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
-						APIGroups: []string{"fluxninja.com"},
-						Resources: []string{"policies"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
 						APIGroups: []string{""},
 						Resources: []string{"events"},
 						Verbs:     []string{"create", "patch"},
-					},
-					{
-						APIGroups: []string{"fluxninja.com"},
-						Resources: []string{"policies/finalizers"},
-						Verbs:     []string{"update"},
-					},
-					{
-						APIGroups: []string{"fluxninja.com"},
-						Resources: []string{"policies/status"},
-						Verbs:     []string{"get", "patch", "update"},
 					},
 				},
 			}
@@ -153,7 +107,7 @@ var _ = Describe("clusterRoleForAgent", func() {
 
 			expected := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: AppName,
+					Name: AgentServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   AppName,
@@ -174,16 +128,7 @@ var _ = Describe("clusterRoleForAgent", func() {
 						Verbs:     []string{"get", "list", "watch"},
 					},
 					{
-						APIGroups: []string{"quota.openshift.io"},
-						Resources: []string{"clusterresourcequotas"},
-						Verbs:     []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/version", "/healthz"},
-						Verbs:           []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/metrics"},
+						NonResourceURLs: []string{"/version", "/healthz", "/metrics"},
 						Verbs:           []string{"get"},
 					},
 					{
@@ -192,46 +137,9 @@ var _ = Describe("clusterRoleForAgent", func() {
 						Verbs:     []string{"get"},
 					},
 					{
-						APIGroups:     []string{"policy"},
-						Resources:     []string{"podsecuritypolicies"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups:     []string{"security.openshift.io"},
-						Resources:     []string{"securitycontextconstraints"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups: []string{"coordination.k8s.io"},
-						Resources: []string{"leases"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
-						APIGroups: []string{"admissionregistration.k8s.io"},
-						Resources: []string{"mutatingwebhookconfigurations"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
-						APIGroups: []string{"fluxninja.com"},
-						Resources: []string{"policies"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
 						APIGroups: []string{""},
 						Resources: []string{"events"},
 						Verbs:     []string{"create", "patch"},
-					},
-					{
-						APIGroups: []string{"fluxninja.com"},
-						Resources: []string{"policies/finalizers"},
-						Verbs:     []string{"update"},
-					},
-					{
-						APIGroups: []string{"fluxninja.com"},
-						Resources: []string{"policies/status"},
-						Verbs:     []string{"get", "patch", "update"},
 					},
 				},
 			}
@@ -280,7 +188,7 @@ var _ = Describe("clusterRoleBindingForAgent", func() {
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
-				Name:     AppName,
+				Name:     AgentServiceName,
 			},
 			Subjects: []rbacv1.Subject{
 				{

--- a/operator/controllers/agent/config_test.tpl
+++ b/operator/controllers/agent/config_test.tpl
@@ -21,6 +21,9 @@ etcd:
     key_file: ""
     key_log_file: ""
   username: ""
+flow_control:
+  preview_service:
+    enabled: true
 fluxninja_plugin:
   api_key: ""
   client:

--- a/operator/controllers/agent/configmaps_test.go
+++ b/operator/controllers/agent/configmaps_test.go
@@ -148,7 +148,7 @@ var _ = Describe("ConfigMap for Agent", func() {
 			result, err := configMapForAgentConfig(instance.DeepCopy(), scheme.Scheme)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Data).To(Equal(expected.Data))
+			Expect(result.Data["aperture-agent.yaml"]).To(Equal(expected.Data["aperture-agent.yaml"]))
 		})
 	})
 })

--- a/operator/controllers/agent/reconciler_test.go
+++ b/operator/controllers/agent/reconciler_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			agentServiceKey := types.NamespacedName{Name: AgentServiceName, Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: AppName}
+			clusterRoleKey := types.NamespacedName{Name: AgentServiceName}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			clusterRoleBindingKey := types.NamespacedName{Name: AgentServiceName}
@@ -188,7 +188,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			agentServiceKey := types.NamespacedName{Name: AgentServiceName, Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: AppName}
+			clusterRoleKey := types.NamespacedName{Name: AgentServiceName}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			clusterRoleBindingKey := types.NamespacedName{Name: AgentServiceName}
@@ -313,7 +313,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			agentServiceKey := types.NamespacedName{Name: AgentServiceName, Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: AppName}
+			clusterRoleKey := types.NamespacedName{Name: AgentServiceName}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			clusterRoleBindingKey := types.NamespacedName{Name: AgentServiceName}

--- a/operator/controllers/controller/clusterrole.go
+++ b/operator/controllers/controller/clusterrole.go
@@ -28,51 +28,6 @@ import (
 var (
 	rules = []rbacv1.PolicyRule{
 		{
-			APIGroups: []string{""},
-			Resources: []string{"services", "events", "endpoints", "pods", "nodes", "namespaces", "componentstatuses"},
-			Verbs:     []string{"get", "list", "watch"},
-		},
-		{
-			APIGroups: []string{"quota.openshift.io"},
-			Resources: []string{"clusterresourcequotas"},
-			Verbs:     []string{"get"},
-		},
-		{
-			NonResourceURLs: []string{"/version", "/healthz"},
-			Verbs:           []string{"get"},
-		},
-		{
-			NonResourceURLs: []string{"/metrics"},
-			Verbs:           []string{"get"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"nodes/metrics", "nodes/spec", "nodes/proxy", "nodes/stats"},
-			Verbs:     []string{"get"},
-		},
-		{
-			APIGroups:     []string{"policy"},
-			Resources:     []string{"podsecuritypolicies"},
-			Verbs:         []string{"use"},
-			ResourceNames: []string{controllers.AppName},
-		},
-		{
-			APIGroups:     []string{"security.openshift.io"},
-			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"use"},
-			ResourceNames: []string{controllers.AppName},
-		},
-		{
-			APIGroups: []string{"coordination.k8s.io"},
-			Resources: []string{"leases"},
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-		},
-		{
-			APIGroups: []string{"admissionregistration.k8s.io"},
-			Resources: []string{"mutatingwebhookconfigurations"},
-			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-		},
-		{
 			APIGroups: []string{"fluxninja.com"},
 			Resources: []string{"policies"},
 			Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
@@ -97,7 +52,7 @@ var (
 	roleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "ClusterRole",
-		Name:     controllers.AppName,
+		Name:     controllers.ControllerServiceName,
 	}
 )
 
@@ -105,7 +60,7 @@ var (
 func clusterRoleForController(instance *controllerv1alpha1.Controller) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.AppName,
+			Name:        controllers.ControllerServiceName,
 			Labels:      controllers.CommonLabels(instance.Spec.Labels, instance.GetName(), controllers.OperatorName),
 			Annotations: controllers.ControllerAnnotationsWithOwnerRef(instance),
 		},

--- a/operator/controllers/controller/clusterrole_test.go
+++ b/operator/controllers/controller/clusterrole_test.go
@@ -46,7 +46,7 @@ var _ = Describe("clusterRoleForController", func() {
 
 			expected := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: AppName,
+					Name: ControllerServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   AppName,
@@ -59,51 +59,6 @@ var _ = Describe("clusterRoleForController", func() {
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
-					{
-						APIGroups: []string{""},
-						Resources: []string{"services", "events", "endpoints", "pods", "nodes", "namespaces", "componentstatuses"},
-						Verbs:     []string{"get", "list", "watch"},
-					},
-					{
-						APIGroups: []string{"quota.openshift.io"},
-						Resources: []string{"clusterresourcequotas"},
-						Verbs:     []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/version", "/healthz"},
-						Verbs:           []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/metrics"},
-						Verbs:           []string{"get"},
-					},
-					{
-						APIGroups: []string{""},
-						Resources: []string{"nodes/metrics", "nodes/spec", "nodes/proxy", "nodes/stats"},
-						Verbs:     []string{"get"},
-					},
-					{
-						APIGroups:     []string{"policy"},
-						Resources:     []string{"podsecuritypolicies"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups:     []string{"security.openshift.io"},
-						Resources:     []string{"securitycontextconstraints"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups: []string{"coordination.k8s.io"},
-						Resources: []string{"leases"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
-						APIGroups: []string{"admissionregistration.k8s.io"},
-						Resources: []string{"mutatingwebhookconfigurations"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
 					{
 						APIGroups: []string{"fluxninja.com"},
 						Resources: []string{"policies"},
@@ -153,7 +108,7 @@ var _ = Describe("clusterRoleForController", func() {
 
 			expected := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: AppName,
+					Name: ControllerServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   AppName,
@@ -168,51 +123,6 @@ var _ = Describe("clusterRoleForController", func() {
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
-					{
-						APIGroups: []string{""},
-						Resources: []string{"services", "events", "endpoints", "pods", "nodes", "namespaces", "componentstatuses"},
-						Verbs:     []string{"get", "list", "watch"},
-					},
-					{
-						APIGroups: []string{"quota.openshift.io"},
-						Resources: []string{"clusterresourcequotas"},
-						Verbs:     []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/version", "/healthz"},
-						Verbs:           []string{"get"},
-					},
-					{
-						NonResourceURLs: []string{"/metrics"},
-						Verbs:           []string{"get"},
-					},
-					{
-						APIGroups: []string{""},
-						Resources: []string{"nodes/metrics", "nodes/spec", "nodes/proxy", "nodes/stats"},
-						Verbs:     []string{"get"},
-					},
-					{
-						APIGroups:     []string{"policy"},
-						Resources:     []string{"podsecuritypolicies"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups:     []string{"security.openshift.io"},
-						Resources:     []string{"securitycontextconstraints"},
-						Verbs:         []string{"use"},
-						ResourceNames: []string{AppName},
-					},
-					{
-						APIGroups: []string{"coordination.k8s.io"},
-						Resources: []string{"leases"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-					{
-						APIGroups: []string{"admissionregistration.k8s.io"},
-						Resources: []string{"mutatingwebhookconfigurations"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
 					{
 						APIGroups: []string{"fluxninja.com"},
 						Resources: []string{"policies"},
@@ -280,7 +190,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
-				Name:     AppName,
+				Name:     ControllerServiceName,
 			},
 			Subjects: []rbacv1.Subject{
 				{

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/fluxninja/aperture/operator/api"
-	agentv1alpha1 "github.com/fluxninja/aperture/operator/api/agent/v1alpha1"
 	controllerv1alpha1 "github.com/fluxninja/aperture/operator/api/controller/v1alpha1"
 	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/net/tlsconfig"
@@ -65,37 +64,22 @@ var (
 )
 
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=fluxninja.com,resources=agents,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fluxninja.com,resources=controllers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fluxninja.com,resources=controllers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=fluxninja.com,resources=controllers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=fluxninja.com,resources=policies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fluxninja.com,resources=policies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=fluxninja.com,resources=policies/finalizers,verbs=update
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=componentstatuses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
-//+kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=core,resources=namespaces/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=nodes/metrics,verbs=get
-//+kubebuilder:rbac:groups=core,resources=nodes/spec,verbs=get
-//+kubebuilder:rbac:groups=core,resources=nodes/proxy,verbs=get
-//+kubebuilder:rbac:groups=core,resources=nodes/stats,verbs=get
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,verbs=use
-//+kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=get;list
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
-//+kubebuilder:rbac:urls=/version;/healthz;/metrics,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -265,22 +249,15 @@ func (r *ControllerReconciler) updateStatus(ctx context.Context, instance *contr
 
 // deleteResources deletes cluster-scoped resources for which owner-reference is not added.
 func (r *ControllerReconciler) deleteResources(ctx context.Context, log logr.Logger, instance *controllerv1alpha1.Controller) {
-	deleteClusterRole := true
-	instances := &agentv1alpha1.AgentList{}
-	err := r.List(ctx, instances)
-	if err != nil {
-		log.Error(err, "failed to list Agents")
-	} else if instances.Items != nil && len(instances.Items) != 0 {
-		for _, ins := range instances.Items {
-			if ins.Status.Resources == "created" {
-				deleteClusterRole = false
-			}
-		}
+	// Deleting old ClusterRole
+	cr := clusterRoleForController(instance)
+	cr.Name = controllers.AppName
+	if err := r.Delete(ctx, cr); err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "failed to delete object of ClusterRole")
 	}
-	if deleteClusterRole {
-		if err := r.Delete(ctx, clusterRoleForController(instance)); err != nil {
-			log.Error(err, "failed to delete object of ClusterRole")
-		}
+
+	if err := r.Delete(ctx, clusterRoleForController(instance)); err != nil {
+		log.Error(err, "failed to delete object of ClusterRole")
 	}
 
 	if err := r.Delete(ctx, clusterRoleBindingForController(instance)); err != nil {

--- a/operator/controllers/controller/reconciler_test.go
+++ b/operator/controllers/controller/reconciler_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			controllerServiceKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: AppName}
+			clusterRoleKey := types.NamespacedName{Name: ControllerServiceName}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			clusterRoleBindingKey := types.NamespacedName{Name: ControllerServiceName}
@@ -168,7 +168,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			controllerServiceKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: AppName}
+			clusterRoleKey := types.NamespacedName{Name: ControllerServiceName}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 			clusterRoleBindingKey := types.NamespacedName{Name: ControllerServiceName}


### PR DESCRIPTION
### Description of change

There were duplicate and non-required permissions present in the agent and controller ClusterRole via operator so removed them so that the agent and controller only gets the required permissions in Kubernetes.

##### Checklist

- [x] Tested in playground or other setup
- [x] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1088)
<!-- Reviewable:end -->
