### PR TITLE
Added support for changing agent installation mode without re-creation of CR

### DIFF
--- a/docs/content/get-started/installation/agent/kubernetes/sidecar.md
+++ b/docs/content/get-started/installation/agent/kubernetes/sidecar.md
@@ -380,7 +380,7 @@ chart installed above:
    kubectl rollout restart deployment <DEPLOYMENT_NAME> -n <NAMESPACE>
    ```
 
-6. If pods are running as part of a Kubernetes Daemonset:
+6. If pods are running as part of a Kubernetes DaemonSet:
 
    ```bash
    kubectl rollout restart daemonset <DAEMONSET_NAME> -n <NAMESPACE>

--- a/operator/controllers/agent/daemonset.go
+++ b/operator/controllers/agent/daemonset.go
@@ -35,7 +35,7 @@ import (
 	agentv1alpha1 "github.com/fluxninja/aperture/operator/api/agent/v1alpha1"
 )
 
-// daemonsetForAgent prepares the Daemonset object for the Agent.
+// daemonsetForAgent prepares the DaemonSet object for the Agent.
 func daemonsetForAgent(instance *agentv1alpha1.Agent, log logr.Logger, scheme *runtime.Scheme) (*appsv1.DaemonSet, error) {
 	spec := instance.Spec
 

--- a/operator/controllers/agent/daemonset_test.go
+++ b/operator/controllers/agent/daemonset_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/otelcollector"
 )
 
-var _ = Describe("Agent Daemonset", func() {
+var _ = Describe("Agent DaemonSet", func() {
 	var (
 		probe = common.Probe{
 			Enabled:             true,
@@ -620,7 +620,7 @@ var _ = Describe("Agent Daemonset", func() {
 	})
 })
 
-var _ = Describe("Test Daemonset Mutate", func() {
+var _ = Describe("Test DaemonSet Mutate", func() {
 	It("Mutate should update required fields only", func() {
 		expected := &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{},

--- a/operator/controllers/agent/old_hook_test.tpl
+++ b/operator/controllers/agent/old_hook_test.tpl
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "fluxninja.com/v1alpha1",
+  "kind": "Agent",
+  "metadata": {
+    "name": "agent-sample"
+  },
+  "spec": {
+    "config": {
+      "etcd": {
+        "endpoints": [
+          "test.com"
+        ]
+      },
+      "prometheus": {
+        "address": "test.com"
+      }
+    },
+    "sidecar": {
+      "enabled": true
+    }
+  }
+}

--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -91,6 +91,8 @@ const (
 	ApertureFluxNinjaPlugin = "aperture-plugin-fluxninja"
 	// DefaulterAnnotationKey defines annotation key for set defaults.
 	DefaulterAnnotationKey = "fluxninja.com/set-defaults"
+	// AgentModeChangeAnnotationKey defines annotation key for change in Agent installation mode.
+	AgentModeChangeAnnotationKey = "fluxninja.com/installation-mode-change"
 	// FailedStatus string.
 	FailedStatus = "failed"
 	// PolicyValidatingWebhookName defines Validating Webhook name for Policy.


### PR DESCRIPTION
### Description of change

User has to uninstall and recreate the Agent CR currently to change the installation mode to Sidecar.
With this change, they can just modify the existing CR to change the installation mode and operator will handle the rest.
Restarting all the pods on changing the installation is not feasible so added event in the CR to indicate the same.

Fixes #896 

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added
- [x] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1089)
<!-- Reviewable:end -->
