### PR TITLE
Update aperture on customer demo cluster when changes merged to main

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -593,6 +593,52 @@ jobs:
             cd <<parameters.path>>
             gradle test
 
+  update-environment:
+    parameters:
+      job-root:
+        type: string
+        default: "/home/circleci"
+        description: The root folder of the job where all repositories will be cloned to
+      manifests-repo:
+        type: string
+        default: git@github.com:fluxninja/argo-manifests.git
+        description: ArgoCD manifests repository to update
+      manifests-branch:
+        type: string
+        default: tests
+        description: Branch to use when pushing deployment changes
+      environment-path:
+        type: string
+        description: Path to the environment to update
+      component:
+        type: string
+        default: ""
+        description: Application component to update image and deployment code for
+      update:
+        type: string
+        default: everything
+        description: Whether to update 'images', 'deployment-code' or 'everything'
+    executor: python-cimg-executor
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "f9:49:04:10:b1:77:16:b0:0e:c0:ba:21:0e:9d:fd:40"  # argo-manifests R/W
+            - "2a:af:6f:d5:b9:d4:dd:95:df:18:47:e9:0b:4a:c7:82"  # deployment R/W
+            - "10:d1:92:4e:2a:55:81:c9:82:c2:74:ce:6d:0e:e8:a8"   #cloud keys
+      - checkout
+      - gcp-gcr/gcr-auth
+      - run: *install_opsninja
+      - run:
+          name: Update application in the deployment
+          environment:
+            JOB_ROOT: << parameters.job-root >>
+            UPDATE: << parameters.update >>
+            MANIFESTS_BRANCH: << parameters.manifests-branch >>
+            MANIFESTS_REPO: << parameters.manifests-repo >>
+            COMPONENT: << parameters.component >>
+            ENVIRONMENT_PATH: << parameters.environment-path >>
+          command: .circleci/scripts/update_environment.sh
+
   package-agent:
     parameters:
       workspace-name:
@@ -741,6 +787,18 @@ workflows:
           docker-context: .
           dockerfile: cmd/aperture-agent/Dockerfile
           use-docker-layer-caching: true
+      - update-environment:
+          filters:
+            branches:
+              only:
+                - main
+          name: aperture-agent-update-environment
+          requires:
+            - image-build-aperture-agent
+          environment-path: environments/customer-demo/
+          component: aperture-agent
+          update: images
+
       - build-push-add-tag:
           name: image-build-aperture-controller
           dockerhub-image: fluxninja/aperture-controller
@@ -749,6 +807,18 @@ workflows:
           docker-context: .
           dockerfile: cmd/aperture-controller/Dockerfile
           use-docker-layer-caching: true
+      - update-environment:
+          filters:
+            branches:
+              only:
+                - main
+          name: aperture-controller-update-environment
+          requires:
+            - image-build-aperture-controller
+          environment-path: environments/customer-demo/
+          component: aperture-controller
+          update: images
+
       - go-test-coverage:
           name: go-test-coverage-aperture
           work_dir: .
@@ -824,6 +894,17 @@ workflows:
           docker-context: .
           dockerfile: ./operator/Dockerfile
           use-docker-layer-caching: true
+      - update-environment:
+          filters:
+            branches:
+              only:
+                - main
+          name: aperture-operator-update-environment
+          requires:
+            - image-build-aperture-operator
+          environment-path: environments/customer-demo/
+          component: aperture-operator
+          update: images
 
   demo-app:
     when: << pipeline.parameters.updated-demo-app >>
@@ -837,7 +918,17 @@ workflows:
           dockerfile: ./playground/demo_app/Dockerfile
           use-docker-layer-caching: true
           push-to-dockerhub: false
-
+      - update-environment:
+          filters:
+            branches:
+              only:
+                - main
+          name: demo-app-update-environment
+          requires:
+            - image-demo-app
+          environment-path: environments/customer-demo/
+          component: demo-app
+          update: images
   pre-commit:
     jobs:
       - pre-commit
@@ -875,6 +966,16 @@ workflows:
       - publish-deployment-code: &push_deployment_code_job
           name: push-deployment-changes
           task-name: Push deployment code changes to fluxninja/deployment.git
+      - update-environment:
+          filters:
+            branches:
+              only:
+                - main
+          name: push-deployment-changes-update-environment
+          requires:
+            - push-deployment-changes
+          update: deployment-code
+          environment-path: environments/customer-demo/
 
   preview-deployment-changes:
     when:

--- a/.circleci/post-release.yaml
+++ b/.circleci/post-release.yaml
@@ -288,14 +288,14 @@ commands:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "8d:43:0f:09:ed:86:44:23:4f:43:88:29:71:bf:92:e7" # fluxninja/cloud R/O
+            - "10:d1:92:4e:2a:55:81:c9:82:c2:74:ce:6d:0e:e8:a8" # fluxninja/cloud R/O
       - run:
           name: Install opsninja and its dependencies
           command: |
             # We need R/O access to cloud repository to be able to fetch opsninja library
             # FIXME: make "releases" of opsninja library somehow, even as a separate repository
             # to limit exposure.
-            export CLOUD_RO_KEY_FINGERPRINT="8d:43:0f:09:ed:86:44:23:4f:43:88:29:71:bf:92:e7"
+            export CLOUD_RO_KEY_FINGERPRINT="10:d1:92:4e:2a:55:81:c9:82:c2:74:ce:6d:0e:e8:a8"
             export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa_$(echo "${CLOUD_RO_KEY_FINGERPRINT}" | tr -d ':')"
             export SSH_AUTH_SOCK=""
             # Bust asdf cache as our opsninja version is always 0.0.0

--- a/.circleci/scripts/update_environment.sh
+++ b/.circleci/scripts/update_environment.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LOGURU_LEVEL=TRACE
+export GIT_SSH_COMMAND="fn circleci ssh -o IdentitiesOnly=yes -o IdentityAgent=none"
+
+commit_author=$(git show --format="%aN <%aE>" --quiet)
+
+args=(
+    --author "${commit_author}"
+    --update "${UPDATE}"
+    --release-train "latest"
+    --push
+)
+
+if [ -n "${COMPONENT}" ]; then
+    args+=(--component "${COMPONENT}")
+fi
+
+retry_counter=10
+errcode=1
+while true; do
+    (( retry_counter-- )) || break
+
+    set +e
+    if fn --config-path "${JOB_ROOT}"/project/.opsninja.yaml \
+          manifests update "${args[@]}" "${ENVIRONMENT_PATH}"; then
+        errcode=0
+        break
+    else
+        errcode="${?}"
+    fi
+    set -e
+    sleep 1
+done
+
+exit $errcode

--- a/.opsninja.yaml
+++ b/.opsninja.yaml
@@ -1,0 +1,53 @@
+metadata:
+  repository: git@github.com:fluxninja/aperture.git
+
+repositories:
+  ssh://git@github.com/fluxninja/aperture:
+    identities:
+    - "75:2f:7a:fe:d3:a1:5e:81:a8:d2:cc:3a:21:59:b7:2c"  # CircleCI fluxninja/aperture standard pipeline R/O
+
+bundles:
+  aperture:
+    components:
+      - charts/aperture-agent
+      - applications/aperture-agent
+
+charts:
+  aperture-agent:
+    path: manifests/charts/aperture-agent/
+  aperture-controller:
+    path: manifests/charts/aperture-controller/
+  istioconfig:
+    path: manifests/charts/istioconfig/
+
+
+applications:
+  aperture-operator:
+    image:
+      name: aperture-operator
+      docker_context: operator
+      dockerfile: operator/Dockerfile
+  aperture-agent:
+    image:
+      name: aperture-agent
+      docker_context: cmd/aperture-agent
+      dockerfile: cmd/aperture-agent/Dockerfile
+    deployment:
+      manifests/charts/aperture-agent/.+: charts/aperture/aperture-agent/
+  aperture-controller:
+    image:
+      name: aperture-controller
+      docker_context: cmd/aperture-controller
+      dockerfile: cmd/aperture-controller/Dockerfile
+    deployment:
+      manifests/charts/aperture-controller/.+: charts/aperture/aperture-controller/
+  demo-app:
+    image:
+      name: demo-app
+      docker_context: playground/demo_app
+      dockerfile: playground/demo_app/Dockerfile
+    deployment:
+      playground/tanka/charts/demo-app/.+: charts/aperture/demo-app/
+  istioconfig:
+    deployment:
+      manifests/charts/istioconfig/.+: charts/aperture/istioconfig/


### PR DESCRIPTION
### Description of change

Currently whenever new changes are merged to cloud main . Demo cluster is update. Similarly this PR will do the update on  `customer demo cluster` whenever new changes are merged to aperture main

The PR has been tested by making minor changes to the files to run the CI . 
Can confirm that it is updating the hash on [argo-manfiests](https://github.com/fluxninja/argo-manifests/commit/dd66e330a58d6b415ad0efd1f2e48d8b000cb119) repo. 

Closes https://github.com/fluxninja/cloud/issues/7810


##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1103)
<!-- Reviewable:end -->
