### PR TITLE
Change error on removing metrics to warn

### DIFF
--- a/pkg/policies/flowcontrol/actuators/concurrency/concurrency-limiter.go
+++ b/pkg/policies/flowcontrol/actuators/concurrency/concurrency-limiter.go
@@ -450,11 +450,11 @@ func (conLimiter *concurrencyLimiter) setup(lifecycle fx.Lifecycle) error {
 			}
 			deletedCount := conLimiter.concurrencyLimiterFactory.workloadLatencySummaryVec.DeletePartialMatch(metricLabels)
 			if deletedCount == 0 {
-				errMulti = multierr.Append(errMulti, errors.New("failed to delete workload_latency_ms summary from its metric vector"))
+				log.Warn().Msg("Could not delete workload_latency_ms summary from its metric vector. No traffic to generate metrics?")
 			}
 			deletedCount = conLimiter.concurrencyLimiterFactory.workloadCounterVec.DeletePartialMatch(metricLabels)
 			if deletedCount == 0 {
-				errMulti = multierr.Append(errMulti, errors.New("failed to delete workload_requests_total counter from its metric vector"))
+				log.Warn().Msg("Could not delete workload_requests_total counter from its metric vector. No traffic to generate metrics?")
 			}
 
 			conLimiter.registry.SetStatus(status.NewStatus(nil, errMulti))

--- a/pkg/policies/flowcontrol/actuators/rate/rate-limiter.go
+++ b/pkg/policies/flowcontrol/actuators/rate/rate-limiter.go
@@ -2,7 +2,6 @@ package rate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"strconv"
@@ -319,7 +318,7 @@ func (rateLimiter *rateLimiter) setup(lifecycle fx.Lifecycle) error {
 			var merr, err error
 			deleted := rateCounterVec.DeletePartialMatch(metricLabels)
 			if deleted == 0 {
-				merr = multierr.Append(merr, errors.New("failed to delete rate limiter counter from its metric vector"))
+				logger.Warn().Msg("Could not delete rate limiter counter from its metric vector. No traffic to generate metrics?")
 			}
 			// remove from data engine
 			err = rateLimiter.rateLimiterFactory.engineAPI.UnregisterRateLimiter(rateLimiter)


### PR DESCRIPTION
### Description of change
When `DeletePartialMatch` returns 0 it does not have to mean there was an error. We could have empty metrics.
Changed Errors to Warnings for clarity.

Closes: GH-1090

##### Checklist

- [x] Tested in playground or other setup