### PR TITLE
Corrected resource dependency in tilt file when only controller is started

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -946,7 +946,7 @@ def declare_resources(resources, dep_tree, inv_dep_tree):
             },
         )
 
-    if "demo-app" in resources:
+    if "controller" in resources:
         readiness_probe=probe(initial_delay_secs=5, exec=exec_action(['kubectl', 'get', "svc", "aperture-controller", "-n", APERTURE_CONTROLLER_NS])) # Treat as success if service is available
         local_resource(
             name="controller-service",


### PR DESCRIPTION
### Description of change

The condition for creating `controller-service` resource in tilt was incorrect and due to that policy was not getting created when only `aperture-controller` is started on tilt.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1121)
<!-- Reviewable:end -->
