### PR TITLE
docs: add links to introspection APIs for flowcontrol preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### ignore api docs (all mdx files) located at docs/content/references/api
+docs/content/references/api/**/*.mdx
+
 dist/
 build/
 .gradle/

--- a/docs/content/concepts/flow-control/flow-classifier.md
+++ b/docs/content/concepts/flow-control/flow-classifier.md
@@ -69,8 +69,9 @@ the classifier to particular paths.
 ## Live Previewing Requests
 
 You can discover the request attributes flowing through services and control
-points using the Introspection API on an `aperture-agent` local to the service
-instances (pods).
+points using the
+[Introspection API](references/api/agent/flow-preview-service-preview-http-requests.api.mdx)
+on an `aperture-agent` local to the service instances (pods).
 
 For example:
 

--- a/docs/content/concepts/flow-control/flow-label.md
+++ b/docs/content/concepts/flow-control/flow-label.md
@@ -70,8 +70,9 @@ also takes an explicit `labels` map in the `Check()` call.
 ## Live Previewing Flow Labels
 
 You can discover the labels flowing through services and control points using
-the Introspection API on an `aperture-agent` local to the service instances
-(pods).
+the
+[Introspection API](references/api/agent/flow-preview-service-preview-flow-labels.api.mdx)
+on an `aperture-agent` local to the service instances (pods).
 
 For example:
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [X] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1132)
<!-- Reviewable:end -->
