### PR TITLE
Fix Control Point Cache provide

### DIFF
--- a/pkg/discovery/kubernetes/provide.go
+++ b/pkg/discovery/kubernetes/provide.go
@@ -39,9 +39,11 @@ type KubernetesDiscoveryConfig struct {
 func Module() fx.Option {
 	return fx.Options(
 		notifiers.TrackersConstructor{Name: FxTagBase}.Annotate(),
+		fx.Provide(
+			ProvideControlPointCache,
+		),
 		fx.Invoke(
 			InvokeServiceDiscovery,
-			ProvideControlPointCache,
 		),
 	)
 }

--- a/plugins/service/aperture-plugin-fluxninja/heartbeats/heartbeats.go
+++ b/plugins/service/aperture-plugin-fluxninja/heartbeats/heartbeats.go
@@ -240,10 +240,13 @@ func (h *Heartbeats) newHeartbeat(
 		})
 	}
 
-	kubernetesControlPointObjects := h.kubernetesControlPointCache.Keys()
-	kubernetesControlPoints := make([]*controlpointcachev1.KubernetesControlPoint, 0, len(serviceControlPointObjects))
-	for _, cp := range kubernetesControlPointObjects {
-		kubernetesControlPoints = append(kubernetesControlPoints, cp.ToProto())
+	var kubernetesControlPoints []*controlpointcachev1.KubernetesControlPoint
+	if h.kubernetesControlPointCache != nil {
+		kubernetesControlPointObjects := h.kubernetesControlPointCache.Keys()
+		kubernetesControlPoints = make([]*controlpointcachev1.KubernetesControlPoint, 0, len(kubernetesControlPointObjects))
+		for _, cp := range kubernetesControlPointObjects {
+			kubernetesControlPoints = append(kubernetesControlPoints, cp.ToProto())
+		}
 	}
 
 	return &heartbeatv1.ReportRequest{

--- a/plugins/service/aperture-plugin-fluxninja/heartbeats/provide.go
+++ b/plugins/service/aperture-plugin-fluxninja/heartbeats/provide.go
@@ -56,7 +56,7 @@ type ConstructorIn struct {
 	EtcdClient                  *etcdclient.Client
 	PolicyFactory               *controlplane.PolicyFactory            `optional:"true"`
 	ServiceControlPointCache    *cache.Cache[selectors.ControlPointID] `optional:"true"`
-	KubernetesControlPointCache kubernetes.ControlPointCache
+	KubernetesControlPointCache kubernetes.ControlPointCache           `optional:"true"`
 }
 
 // Provide provides a new instance of Heartbeats.


### PR DESCRIPTION
### Description of change
* Move `ProvideControlPointCache` from `Invoke` to `Provide`.
* Make `ControlPointCache` dependency optional in FN plugin, as Controller won't use it.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Breaking changes
