### PR TITLE
Make `build.sh` work with `sh`

### DIFF
--- a/pkg/info/build.sh
+++ b/pkg/info/build.sh
@@ -23,7 +23,7 @@ LDFLAGS="\
     -X 'github.com/fluxninja/aperture/pkg/info.GitCommitHash=${GIT_COMMIT_HASH}' \
     -X 'github.com/fluxninja/aperture/pkg/info.Prefix=${PREFIX}' \
 "
-if [[ -z "${RACE}" ]]; then
+if [ -z "${RACE:-}" ]; then
     go build --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"
 else
     go build --race --ldflags "${LDFLAGS}" -o "${TARGET}" "${SOURCE}"


### PR DESCRIPTION
### Description of change
In some places we use the `build.sh` script with `sh` not `bash`. This change updates the if condition to work in both environments.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1157)
<!-- Reviewable:end -->
