### PR TITLE
Update query for rate limit dashboard

### DIFF
--- a/blueprints/examples/static-rate-limiting/gen/dashboards/example.json
+++ b/blueprints/examples/static-rate-limiting/gen/dashboards/example.json
@@ -102,7 +102,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(rate_limiter_counter{policy_name=\"example\"}[$__rate_interval])",
+          "expr": "sum by(decision_type) (rate(rate_limiter_counter{policy_name=\"example\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",

--- a/blueprints/lib/1.0/blueprints/static-rate-limiting/dashboard.libsonnet
+++ b/blueprints/lib/1.0/blueprints/static-rate-limiting/dashboard.libsonnet
@@ -45,7 +45,7 @@ function(params) {
   local rateLimiterPanel =
     newTimeSeriesPanel('Rate Limiter',
                        ds,
-                       'rate(rate_limiter_counter{policy_name="%(policyName)s"}[$__rate_interval])' % { policyName: $._config.policyName },
+                       'sum by(decision_type) (rate(rate_limiter_counter{policy_name="%(policyName)s"}[$__rate_interval]))' % { policyName: $._config.policyName },
                        'Decisions',
                        'reqps'),
 


### PR DESCRIPTION
### Description of change

Updated query to use `sum by` to reduce the number of fields for the `Rate Limiter` panel.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1161)
<!-- Reviewable:end -->
