### PR TITLE
Remove v so that links work on development docs

### DIFF
--- a/blueprints/scripts/generate_all.sh
+++ b/blueprints/scripts/generate_all.sh
@@ -44,7 +44,7 @@ $FIND "$blueprints_root"/lib -type f -name config.libsonnet | while read -r file
 	echo -e "\`\`\`" >>"$docs_file"
 	echo "## Blueprint Location" >>"$docs_file"
 	echo -e "\n" >>"$docs_file"
-	echo "GitHub: <a href={\`https://github.com/fluxninja/aperture/tree/v\${apertureVersion}/blueprints/lib/1.0/blueprints/$blueprint_name\`}>$blueprint_name</a>" >>"$docs_file"
+	echo "GitHub: <a href={\`https://github.com/fluxninja/aperture/tree/\${apertureVersion}/blueprints/lib/1.0/blueprints/$blueprint_name\`}>$blueprint_name</a>" >>"$docs_file"
 	echo -e "\n" >>"$docs_file"
 	echo "## Introduction" >>"$docs_file"
 	echo -e "\n" >>"$docs_file"

--- a/docs/content/apertureVersion.js
+++ b/docs/content/apertureVersion.js
@@ -1,1 +1,9 @@
 export const apertureVersion = "main";
+
+export var apertureVersionWithOutV;
+
+var apertureVersionWithOutV = apertureVersion;
+if (apertureVersionWithOutV != "main"){
+  var apertureVersionWithOutV = apertureVersionWithOutV.slice(1);
+}
+

--- a/docs/content/concepts/flow-control/flow-control.md
+++ b/docs/content/concepts/flow-control/flow-control.md
@@ -107,12 +107,12 @@ integrations that will communicate with the Aperture Agent.
   We provide integration instructions for [Istio/Envoy][istio]. The user can
   name the Control Point to identify a particular filter chain in Envoy. In case
   of insertion via Istio, the <a
-  href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/manifests/charts/istioconfig/templates/envoy_filter.yaml`}>default
+  href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/manifests/charts/istioconfig/templates/envoy_filter.yaml`}>default
   filter config</a>, assigns _ingress_ and _egress_ Control Points as
   [identified by Istio][istio-patch-context].
 
 - _Feature_ Control Points: We provide <a
-  href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/sdks/`}>Aperture
+  href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/sdks/`}>Aperture
   SDKs</a>[][aperture-go] for popular languages. Aperture SDK wraps any function
   call or code snippet inside the Service code as a Feature Control Point. Every
   invocation of the Feature is a Flow from the perspective of Aperture.

--- a/docs/content/get-started/flow-control/sdk/overview.md
+++ b/docs/content/get-started/flow-control/sdk/overview.md
@@ -23,7 +23,7 @@ A second way, one that allows for more customization, is to use Aperture SDK to
 set feature or traffic Control Points within services.
 
 We provide <a
-href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/sdks/`}>Aperture
+href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/sdks/`}>Aperture
 SDKs</a> for popular languages. Aperture SDK allows you to manually wrap any
 function call or code snippet inside the Service code as a Feature Control
 Point. Every invocation of the Feature is a Flow from the perspective of

--- a/docs/content/get-started/installation/agent/bare_metal.md
+++ b/docs/content/get-started/installation/agent/bare_metal.md
@@ -16,8 +16,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import {apertureVersion} from '../../../apertureVersion.js';
-apertureVersionWithOutV = apertureVersion.slice(1)
-
+export const apertureVersionWithOutV = apertureVersion.slice(1)
 ```
 
 The Aperture Agent can be installed as a system service on any Linux system

--- a/docs/content/get-started/installation/agent/bare_metal.md
+++ b/docs/content/get-started/installation/agent/bare_metal.md
@@ -15,11 +15,8 @@ sidebar_position: 3
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
-import {apertureVersion} from '../../../apertureVersion.js';
-var apertureVersionWithOutV = apertureVersion;
-if (apertureVersionWithOutV != "main"){
-  var apertureVersionWithOutV = apertureVersionWithOutV.slice(1);
-}
+import {apertureVersion,apertureVersionWithOutV} from '../../../apertureVersion.js';
+
 ```
 
 The Aperture Agent can be installed as a system service on any Linux system

--- a/docs/content/get-started/installation/agent/bare_metal.md
+++ b/docs/content/get-started/installation/agent/bare_metal.md
@@ -16,6 +16,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import {apertureVersion} from '../../../apertureVersion.js';
+apertureVersionWithOutV = apertureVersion.slice(1)
+
 ```
 
 The Aperture Agent can be installed as a system service on any Linux system
@@ -34,7 +36,7 @@ Alternatively download it using following script:
 ```mdx-code-block
 export const DownloadScript = ({children, packager, arch, archSeparator, versionSeparator}) => (
 <CodeBlock language="bash">
-{`VERSION="${apertureVersion}"
+{`VERSION="${apertureVersionWithOutV}"
 ARCH="${arch}"
 PACKAGER="${packager}"
 url="https://github.com/fluxninja/aperture/releases/download/v\${VERSION}/aperture-agent${versionSeparator}\${VERSION}${archSeparator}\${ARCH}.\${PACKAGER}"
@@ -57,10 +59,10 @@ curl --fail --location --remote-name "\${url}"
 
 <Tabs groupId="packageManager" queryString>
   <TabItem value="dpkg" label="dpkg">
-    <CodeBlock language="bash">{`sudo dpkg -i aperture-agent_${apertureVersion}*.deb`}</CodeBlock>
+    <CodeBlock language="bash">{`sudo dpkg -i aperture-agent_${apertureVersionWithOutV}*.deb`}</CodeBlock>
   </TabItem>
   <TabItem value="rpm" label="rpm">
-    <CodeBlock language="bash">{`sudo rpm -i aperture-agent-${apertureVersion}*.rpm`}</CodeBlock>
+    <CodeBlock language="bash">{`sudo rpm -i aperture-agent-${apertureVersionWithOutV}*.rpm`}</CodeBlock>
   </TabItem>
 </Tabs>
 

--- a/docs/content/get-started/installation/agent/bare_metal.md
+++ b/docs/content/get-started/installation/agent/bare_metal.md
@@ -16,7 +16,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 import {apertureVersion} from '../../../apertureVersion.js';
-export const apertureVersionWithOutV = apertureVersion.slice(1)
+var apertureVersionWithOutV = apertureVersion;
+if (apertureVersionWithOutV != "main"){
+  var apertureVersionWithOutV = apertureVersionWithOutV.slice(1);
+}
 ```
 
 The Aperture Agent can be installed as a system service on any Linux system

--- a/docs/content/get-started/policies/applying-policies.md
+++ b/docs/content/get-started/policies/applying-policies.md
@@ -43,7 +43,7 @@ Aperture Controller is running.
 1. Create the Aperture Policy by running the following command:
 
 <CodeBlock language="bash">
-{`kubectl --namespace=aperture-controller apply -f https://raw.githubusercontent.com/fluxninja/aperture/v${apertureVersion}/docs/content/tutorials/flow-control/assets/static-rate-limiting/static-rate-limiting.yaml`}
+{`kubectl --namespace=aperture-controller apply -f https://raw.githubusercontent.com/fluxninja/aperture/${apertureVersion}/docs/content/tutorials/flow-control/assets/static-rate-limiting/static-rate-limiting.yaml`}
 </CodeBlock>
 
 2. Run the following command to check if the Aperture Policy was created.

--- a/docs/content/get-started/policies/blueprints.md
+++ b/docs/content/get-started/policies/blueprints.md
@@ -36,7 +36,7 @@ In order to generate Blueprints please install the pre-requisites [`jb`][jb] and
 ## Generating Aperture Policies and Grafana Dashboards
 
 The available Aperture Blueprints can be found under <a
-href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/blueprints/lib/1.0/blueprints/`}>`blueprints/lib/1.0/blueprints`</a>.
+href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/blueprints/lib/1.0/blueprints/`}>`blueprints/lib/1.0/blueprints`</a>.
 In each blueprint, `bundle.libsonnet` can be used to generate the actual
 artifacts, and `config.libsonnet` comes with the default configuration for the
 given blueprint. This can be overridden by the `--config` option passed to the
@@ -49,11 +49,11 @@ objects can be merged by using `+:` operator. Check the `example` directory for
 more information.
 
 To generate files, the script <a
-href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/blueprints/scripts/generate-bundle.py`}>`blueprints/scripts/generate-bundle.py`</a>
+href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/blueprints/scripts/generate-bundle.py`}>`blueprints/scripts/generate-bundle.py`</a>
 can be used. This script takes arguments for the output directory path where
 files will be saved and a path to a config libsonnet file containing blueprint
 customization and configuration. Assuming you are at <a
-href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/`}>`Aperture root`</a>,
+href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/`}>`Aperture root`</a>,
 run the following commands to generate an example config:
 
 ```sh

--- a/docs/content/references/bundled-blueprints/latency-gradient-concurrency-limiting.md
+++ b/docs/content/references/bundled-blueprints/latency-gradient-concurrency-limiting.md
@@ -9,7 +9,7 @@ import {apertureVersion} from '../../apertureVersion.js';
 ## Blueprint Location
 
 GitHub: <a
-href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/blueprints/lib/1.0/blueprints/latency-gradient-concurrency-limiting`}>latency-gradient-concurrency-limiting</a>
+href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/blueprints/lib/1.0/blueprints/latency-gradient-concurrency-limiting`}>latency-gradient-concurrency-limiting</a>
 
 ## Introduction
 

--- a/docs/content/references/bundled-blueprints/signals-dashboard.md
+++ b/docs/content/references/bundled-blueprints/signals-dashboard.md
@@ -9,7 +9,7 @@ import {apertureVersion} from '../../apertureVersion.js';
 ## Blueprint Location
 
 GitHub: <a
-href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/blueprints/lib/1.0/blueprints/signals-dashboard`}>signals-dashboard</a>
+href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/blueprints/lib/1.0/blueprints/signals-dashboard`}>signals-dashboard</a>
 
 ## Introduction
 

--- a/docs/content/references/bundled-blueprints/static-rate-limiting.md
+++ b/docs/content/references/bundled-blueprints/static-rate-limiting.md
@@ -9,7 +9,7 @@ import {apertureVersion} from '../../apertureVersion.js';
 ## Blueprint Location
 
 GitHub: <a
-href={`https://github.com/fluxninja/aperture/tree/v${apertureVersion}/blueprints/lib/1.0/blueprints/static-rate-limiting`}>static-rate-limiting</a>
+href={`https://github.com/fluxninja/aperture/tree/${apertureVersion}/blueprints/lib/1.0/blueprints/static-rate-limiting`}>static-rate-limiting</a>
 
 ## Introduction
 


### PR DESCRIPTION
### Description of change
Remove `v` so that links work on development docs. After pushing this [PR](https://github.com/fluxninja/aperture/pull/1160). Links on development docs are failing . Now the `v` has been handled in the version.js script itself.

Refer this PR for more info https://github.com/fluxninja/aperture-tech-docs/pull/146

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1169)
<!-- Reviewable:end -->
