### PR TITLE
Make SDK validator reject Check requests from feature control points

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ workflows:
             sdks/aperture-go/.* updated-aperture-go true
             sdks/aperture-js/.* updated-aperture-js true
             sdks/aperture-java/.* updated-aperture-java true
+            cmd/sdk-validator/.* updated-sdk-validator true
 
   filter-paths-pr:
     when:

--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -57,6 +57,9 @@ parameters:
   updated-aperture-java:
     type: boolean
     default: false
+  updated-sdk-validator:
+    type: boolean
+    default: false
 
 jobs:
   build-push-add-tag:
@@ -829,7 +832,10 @@ workflows:
           work_dir: .
 
   aperture-go:
-    when: << pipeline.parameters.updated-aperture-go >>
+    when:
+      or:
+        - << pipeline.parameters.updated-aperture-go >>
+        - << pipeline.parameters.updated-sdk-validator >>
     jobs:
       - validate-publish-sdk:
           name: validate-publish-aperture-go
@@ -841,7 +847,10 @@ workflows:
           remote-repo-fingerprint: "eb:80:c9:44:c7:53:0f:ae:b7:4e:86:0f:62:60:6f:76"
 
   aperture-js:
-    when: << pipeline.parameters.updated-aperture-js >>
+    when:
+      or:
+        - << pipeline.parameters.updated-aperture-js >>
+        - << pipeline.parameters.updated-sdk-validator >>
     jobs:
       - validate-publish-sdk:
           name: validate-publish-aperture-js
@@ -853,7 +862,10 @@ workflows:
           remote-repo-fingerprint: "00:5e:cf:81:48:2d:e9:b8:34:74:8b:46:cc:ad:2f:ce"
 
   aperture-java:
-    when: << pipeline.parameters.updated-aperture-java >>
+    when:
+      or:
+        - << pipeline.parameters.updated-aperture-java >>
+        - << pipeline.parameters.updated-sdk-validator >>
     jobs:
       - build-aperture-java:
           name: Build with OpenJDK 8

--- a/cmd/sdk-validator/validator/common.go
+++ b/cmd/sdk-validator/validator/common.go
@@ -20,13 +20,16 @@ type CommonHandler struct {
 	Rejected int64
 }
 
+const targetLabelMissing = "UNKNOWN"
+
 // CheckWithValues is a dummy function for creating *flowcontrolv1.CheckResponse from given parameters.
 func (c *CommonHandler) CheckWithValues(ctx context.Context, services []string, controlPoint string, labels map[string]string) *flowcontrolv1.CheckResponse {
 	var path string
 	var found bool
 	if path, found = labels["http.target"]; !found {
-		log.Warn().Msg("Missing request path label")
-		path = "UNKNOWN"
+		// traffic control points will have this label set
+		log.Trace().Msg("Missing request path label")
+		path = targetLabelMissing
 	}
 	log.Trace().Msgf("Received FlowControl Check request from path %v", path)
 
@@ -49,5 +52,9 @@ func (c *CommonHandler) CheckWithValues(ctx context.Context, services []string, 
 }
 
 func shouldBeTested(path string) bool {
+	if path == targetLabelMissing {
+		// handle feature control points
+		return true
+	}
 	return strings.Contains(path, "super")
 }


### PR DESCRIPTION
### Description of change

SDK validator updates expected `http.target` label to be present and so only worked for traffic control points.
This change makes it work for feature control points with no labels set.

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1208)
<!-- Reviewable:end -->
