### PR TITLE
Simplify circuit unit-tests by avoiding SignalID

### DIFF
--- a/pkg/policies/controlplane/components/holder_test.go
+++ b/pkg/policies/controlplane/components/holder_test.go
@@ -1,7 +1,6 @@
 package components_test
 
 import (
-	"github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/sim"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,14 +20,14 @@ var _ = Describe("Holder", func() {
 					output: { signal_name: HOLDER }
 			`,
 			sim.Inputs{
-				runtime.MakeRootSignalID("INPUT"): sim.NewInput([]float64{1, nan, 3, nan, nan}),
+				"INPUT": sim.NewInput([]float64{1, nan, 3, nan, nan}),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("HOLDER")},
+			sim.OutputSignals{"HOLDER"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("HOLDER"): sim.NewReadings([]float64{1, 1, 1, 1, nan}),
+				"HOLDER": sim.NewReadings([]float64{1, 1, 1, 1, nan}),
 			},
 		))
 	})
@@ -46,14 +45,14 @@ var _ = Describe("Holder", func() {
 					output: { signal_name: HOLDER }
 			`,
 			sim.Inputs{
-				runtime.MakeRootSignalID("INPUT"): sim.NewInput([]float64{1, 2, 3, 4, 6, 7, 8}),
+				"INPUT": sim.NewInput([]float64{1, 2, 3, 4, 6, 7, 8}),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("HOLDER")},
+			sim.OutputSignals{"HOLDER"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("HOLDER"): sim.NewReadings([]float64{1, 1, 1, 1, 6, 6, 6}),
+				"HOLDER": sim.NewReadings([]float64{1, 1, 1, 1, 6, 6, 6}),
 			},
 		))
 	})

--- a/pkg/policies/controlplane/components/logical_test.go
+++ b/pkg/policies/controlplane/components/logical_test.go
@@ -3,7 +3,6 @@ package components_test
 import (
 	"math"
 
-	"github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/sim"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,14 +20,14 @@ var _ = Describe("Not component", func() {
 					output: { signal_name: NOT }
 			`,
 			sim.Inputs{
-				runtime.MakeRootSignalID("INPUT"): sim.NewInput([]float64{nan, 0.0, 1.0, 2.0, -1.}),
+				"INPUT": sim.NewInput([]float64{nan, 0.0, 1.0, 2.0, -1.}),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("NOT")},
+			sim.OutputSignals{"NOT"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("NOT"): sim.NewReadings([]float64{nan, 1.0, 0.0, 0.0, 0.0}),
+				"NOT": sim.NewReadings([]float64{nan, 1.0, 0.0, 0.0, 0.0}),
 			},
 		))
 	})
@@ -57,17 +56,17 @@ var _ = Describe("And and Or component", func() {
 					output: { signal_name: OR }
 			`,
 			sim.Inputs{
-				runtime.MakeRootSignalID("INPUTX"): sim.NewInput([]float64{nan, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, -1.}),
-				runtime.MakeRootSignalID("INPUTY"): sim.NewInput([]float64{nan, nan, nan, 0.0, 0.0, 1.0, 2.0, -2.}),
-				runtime.MakeRootSignalID("INPUTZ"): sim.NewInput([]float64{nan, 0.0, 1.0, 0.0, 1.0, 1.0, 3.0, 3.0}),
+				"INPUTX": sim.NewInput([]float64{nan, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, -1.}),
+				"INPUTY": sim.NewInput([]float64{nan, nan, nan, 0.0, 0.0, 1.0, 2.0, -2.}),
+				"INPUTZ": sim.NewInput([]float64{nan, 0.0, 1.0, 0.0, 1.0, 1.0, 3.0, 3.0}),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("AND"), runtime.MakeRootSignalID("OR")},
+			sim.OutputSignals{"AND", "OR"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("AND"): sim.NewReadings([]float64{nan, 0.0, nan, 0.0, 0.0, 1.0, 1.0, 1.0}),
-				runtime.MakeRootSignalID("OR"):  sim.NewReadings([]float64{nan, nan, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0}),
+				"AND": sim.NewReadings([]float64{nan, 0.0, nan, 0.0, 0.0, 1.0, 1.0, 1.0}),
+				"OR":  sim.NewReadings([]float64{nan, nan, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0}),
 			},
 		))
 	})
@@ -81,12 +80,12 @@ var _ = Describe("And and Or component", func() {
 					output: { signal_name: AND }
 			`,
 			nil,
-			sim.OutputSignals{runtime.MakeRootSignalID("AND")},
+			sim.OutputSignals{"AND"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Step()).To(Equal(
-			map[runtime.SignalID]sim.Reading{
-				runtime.MakeRootSignalID("AND"): sim.NewReading(1.0),
+			sim.StepOutputs{
+				"AND": sim.NewReading(1.0),
 			},
 		))
 	})
@@ -100,12 +99,12 @@ var _ = Describe("And and Or component", func() {
 					output: { signal_name: OR }
 			`,
 			nil,
-			sim.OutputSignals{runtime.MakeRootSignalID("OR")},
+			sim.OutputSignals{"OR"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Step()).To(Equal(
-			map[runtime.SignalID]sim.Reading{
-				runtime.MakeRootSignalID("OR"): sim.NewReading(0.0),
+			sim.StepOutputs{
+				"OR": sim.NewReading(0.0),
 			},
 		))
 	})

--- a/pkg/policies/controlplane/components/pulse-generator_test.go
+++ b/pkg/policies/controlplane/components/pulse-generator_test.go
@@ -1,7 +1,6 @@
 package components_test
 
 import (
-	"github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/sim"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,12 +19,12 @@ var _ = Describe("PulseGenerator", func() {
 					output: { signal_name: PULSE }
 			`,
 			nil,
-			sim.OutputSignals{runtime.MakeRootSignalID("PULSE")},
+			sim.OutputSignals{"PULSE"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Run(10)).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("PULSE"): sim.NewReadings([]float64{1, 1, 1, 0, 0, 1, 1, 1, 0, 0}),
+				"PULSE": sim.NewReadings([]float64{1, 1, 1, 0, 0, 1, 1, 1, 0, 0}),
 			},
 		))
 	})
@@ -42,12 +41,12 @@ var _ = Describe("PulseGenerator", func() {
 					output: { signal_name: PULSE }
 			`,
 			nil,
-			sim.OutputSignals{runtime.MakeRootSignalID("PULSE")},
+			sim.OutputSignals{"PULSE"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Run(4)).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("PULSE"): sim.NewReadings([]float64{1, 0, 1, 0}),
+				"PULSE": sim.NewReadings([]float64{1, 0, 1, 0}),
 			},
 		))
 	})
@@ -62,12 +61,12 @@ var _ = Describe("PulseGenerator", func() {
 					output: { signal_name: PULSE }
 			`,
 			nil,
-			sim.OutputSignals{runtime.MakeRootSignalID("PULSE")},
+			sim.OutputSignals{"PULSE"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Run(11)).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("PULSE"): sim.NewReadings([]float64{1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1}),
+				"PULSE": sim.NewReadings([]float64{1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1}),
 			},
 		))
 	})

--- a/pkg/policies/controlplane/runtime/circuit_test.go
+++ b/pkg/policies/controlplane/runtime/circuit_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/sim"
 )
 
@@ -31,12 +30,12 @@ var _ = Describe("Circuit", func() {
 					output: { signal_name: SUM }
 			`,
 			sim.Inputs(nil),
-			sim.OutputSignals{runtime.MakeRootSignalID("SUM")},
+			sim.OutputSignals{"SUM"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Run(3)).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("SUM"): sim.NewReadings([]float64{1.0, 2.0, 3.0}),
+				"SUM": sim.NewReadings([]float64{1.0, 2.0, 3.0}),
 			},
 		))
 	})
@@ -71,20 +70,15 @@ var _ = Describe("Circuit", func() {
 					output: { signal_name: VAR4 }
 			`,
 			sim.Inputs(nil),
-			sim.OutputSignals{
-				runtime.MakeRootSignalID("VAR"),
-				runtime.MakeRootSignalID("VAR2"),
-				runtime.MakeRootSignalID("VAR3"),
-				runtime.MakeRootSignalID("VAR4"),
-			},
+			sim.OutputSignals{"VAR", "VAR2", "VAR3", "VAR4"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Step()).To(Equal(
-			map[runtime.SignalID]sim.Reading{
-				runtime.MakeRootSignalID("VAR"):  sim.NewReading(42),
-				runtime.MakeRootSignalID("VAR2"): sim.NewReading(math.NaN()),
-				runtime.MakeRootSignalID("VAR3"): sim.NewReading(math.Inf(1)),
-				runtime.MakeRootSignalID("VAR4"): sim.NewReading(math.Inf(-1)),
+			sim.StepOutputs{
+				"VAR":  sim.NewReading(42),
+				"VAR2": sim.NewReading(math.NaN()),
+				"VAR3": sim.NewReading(math.Inf(1)),
+				"VAR4": sim.NewReading(math.Inf(-1)),
 			},
 		))
 	})

--- a/pkg/policies/controlplane/sim/circuit_test.go
+++ b/pkg/policies/controlplane/sim/circuit_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/components"
-	"github.com/fluxninja/aperture/pkg/policies/controlplane/runtime"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/sim"
 )
 
@@ -22,14 +21,14 @@ var _ = Describe("Circuit", func() {
 		circuit, err := sim.NewCircuit(
 			nil,
 			sim.Inputs{
-				runtime.MakeRootSignalID("X"): components.NewConstantSignal(42.0),
+				"X": components.NewConstantSignal(42.0),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("X")},
+			sim.OutputSignals{"X"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Step()).To(Equal(
-			map[runtime.SignalID]sim.Reading{
-				runtime.MakeRootSignalID("X"): sim.NewReading(42.0),
+			sim.StepOutputs{
+				"X": sim.NewReading(42.0),
 			},
 		))
 	})
@@ -38,14 +37,14 @@ var _ = Describe("Circuit", func() {
 		circuit, err := sim.NewCircuit(
 			nil,
 			sim.Inputs{
-				runtime.MakeRootSignalID("XX"): sim.NewInput([]float64{42.0, 43.0}),
+				"XX": sim.NewInput([]float64{42.0, 43.0}),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("XX")},
+			sim.OutputSignals{"XX"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("XX"): sim.NewReadings([]float64{42.0, 43.0}),
+				"XX": sim.NewReadings([]float64{42.0, 43.0}),
 			},
 		))
 	})
@@ -62,16 +61,16 @@ var _ = Describe("Circuit", func() {
 					output: { signal_name: SQRT }
 			`,
 			sim.Inputs{
-				runtime.MakeRootSignalID("INPUT"): sim.NewInput([]float64{4.0, 9.0}),
+				"INPUT": sim.NewInput([]float64{4.0, 9.0}),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("SQRT")},
+			sim.OutputSignals{"SQRT"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
 				// FIXME: Add some helpers to handle floating-point inaccuracies.
 				// (Here we are lucky to have an exactly-representable answer)
-				runtime.MakeRootSignalID("SQRT"): sim.NewReadings([]float64{2.0, 3.0}),
+				"SQRT": sim.NewReadings([]float64{2.0, 3.0}),
 			},
 		))
 	})
@@ -95,15 +94,15 @@ var _ = Describe("Circuit", func() {
 					output: { signal_name: SQRT-CAPPED }
 			`,
 			sim.Inputs{
-				runtime.MakeRootSignalID("INPUT"): sim.NewInput([]float64{4.0, 9.0}),
-				runtime.MakeRootSignalID("CAP"):   sim.NewConstantInput(2.5),
+				"INPUT": sim.NewInput([]float64{4.0, 9.0}),
+				"CAP":   sim.NewConstantInput(2.5),
 			},
-			sim.OutputSignals{runtime.MakeRootSignalID("SQRT-CAPPED")},
+			sim.OutputSignals{"SQRT-CAPPED"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
-				runtime.MakeRootSignalID("SQRT-CAPPED"): sim.NewReadings([]float64{2.0, 2.5}),
+				"SQRT-CAPPED": sim.NewReadings([]float64{2.0, 2.5}),
 			},
 		))
 	})
@@ -111,13 +110,13 @@ var _ = Describe("Circuit", func() {
 	It("can handle invalid readings in tests", func() {
 		circuit, err := sim.NewCircuit(
 			nil,
-			sim.Inputs{runtime.MakeRootSignalID("NAN"): sim.NewConstantInput(math.NaN())},
-			sim.OutputSignals{runtime.MakeRootSignalID("NAN")},
+			sim.Inputs{"NAN": sim.NewConstantInput(math.NaN())},
+			sim.OutputSignals{"NAN"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.Step()).To(Equal(
-			map[runtime.SignalID]sim.Reading{
-				runtime.MakeRootSignalID("NAN"): sim.InvalidReading(),
+			sim.StepOutputs{
+				"NAN": sim.InvalidReading(),
 			},
 		))
 	})

--- a/pkg/policies/controlplane/sim/components.go
+++ b/pkg/policies/controlplane/sim/components.go
@@ -95,8 +95,7 @@ func ConfigureInputComponent(comp runtime.Component, signal runtime.SignalID) ru
 }
 
 // ConfigureOutputComponent takes an output component and creates a
-// Component which reads signal with a given name on its "input"
-// poruntime.
+// Component which reads signal with a given name on its "input" port.
 func ConfigureOutputComponent(signal runtime.SignalID, comp runtime.Component) runtime.ConfiguredComponent {
 	return runtime.ConfiguredComponent{
 		Component: comp,


### PR DESCRIPTION
### Description of change

Circuit sim is doing blackbox-testing of components, thus all signal it
cares about are root-signals. Therefore, signal names in tests can be
just strings (internally translated to root SignalIDs). This make
circuit sim-based tests less verbose.

cc #1177, #1209

##### Checklist

- [x] Tests and/or benchmarks are included
