### PR TITLE
Do not overwrite OTEL extensions in FN plugin (#1252

### DIFF
--- a/plugins/service/aperture-plugin-fluxninja/otel/provide.go
+++ b/plugins/service/aperture-plugin-fluxninja/otel/provide.go
@@ -63,6 +63,8 @@ func provideOtelConfig(baseConfig *otelconfig.OTELConfig,
 
 	config := otelconfig.NewOTELConfig()
 	addFluxNinjaExporter(config, &pluginConfig, grpcClientConfig, httpClientConfig)
+	// This is to prevent overwriting extensions with empty config.
+	config.Extensions = baseConfig.Extensions
 
 	lifecycle.Append(fx.Hook{
 		OnStart: func(context.Context) error {


### PR DESCRIPTION
### Description of change
This prevents overwriting extensions configured in base OTEL config, with the configuration in FN plugin.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1252)
<!-- Reviewable:end -->
