### PR TITLE
Bump Golang to 1.20 (#1260

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -13,7 +13,7 @@ executors:
       - image: cimg/base:2022.07
   go-cimg-executor:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
         user: root
   python-cimg-executor:
     docker:

--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -453,7 +453,12 @@ jobs:
       - run:
           name: Run SDK Validator
           command: |
-            go run cmd/sdk-validator/main.go -sdk-docker-image=<<parameters.registry>>/<<parameters.docker-image>>:<<parameters.tag>> -port=<<parameters.port>> -requests=<<parameters.requests>> -rejects=<<parameters.rejects>> -sdk-port=<<parameters.sdk-port>>
+            go run cmd/sdk-validator/main.go \
+              -sdk-docker-image=<<parameters.registry>>/<<parameters.docker-image>>:<<parameters.tag>> \
+              -port=<<parameters.port>> \
+              -requests=<<parameters.requests>> \
+              -rejects=<<parameters.rejects>> \
+              -sdk-port=<<parameters.sdk-port>>
       - when:
           condition:
             equal: [main, << pipeline.git.branch >>]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,7 @@ run:
   modules-download-mode: readonly
   allow-parallel-runners: true
   allow-serial-runners: true
-  go: "1.19"
+  go: "1.20"
 linters-settings:
   goimports:
     local-prefixes: github.com/fluxninja

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
       - id: go-generate
       - id: go-mod-tidy-repo
         args:
-          - -compat=1.19
+          - -compat=1.20
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 pre-commit 2.20.0
 bats 1.7.0
 gcloud 395.0.0
-golang 1.19.2
+golang 1.20
 golangci-lint 1.50.1
 grpcurl 1.8.7
 mockery 2.14.0

--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19-buster AS base
+FROM golang:1.20-bullseye AS base
 
 WORKDIR /src
 COPY --link . .
@@ -43,10 +43,8 @@ RUN --mount=type=cache,target=/go/pkg/ \
   '
 
 # Final image
-FROM alpine:3.15.0
-# Needed for linker to be compatible
-RUN apk add --no-cache libc6-compat
-RUN apk add --no-cache curl
+FROM debian:bullseye-slim
+
 # Ensure config dirs exists, even if not mounted
 RUN mkdir -p /etc/aperture/aperture-agent/flowcontrol /etc/aperture/aperture-agent/classifiers /opt/aperture/aperture-agent/plugins
 COPY --link --from=builder /aperture-agent /aperture-agent

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19-buster AS base
+FROM golang:1.20-bullseye AS base
 
 WORKDIR /src
 COPY --link . .
@@ -42,10 +42,9 @@ RUN --mount=type=cache,target=/go/pkg/ \
   '
 
 # Final image
-FROM alpine:3.15.0
-# Needed for linker to be compatible
-RUN apk add --no-cache libc6-compat
-RUN apk add --no-cache curl
+FROM debian:bullseye-slim
+
+# Ensure config dirs exists, even if not mounted
 RUN mkdir -p /etc/aperture/aperture-controller/classifiers /etc/aperture/aperture-controller/policies /opt/aperture/aperture-controller/plugins
 COPY --link --from=builder /aperture-controller /aperture-controller
 COPY --link --from=plugins-builder /plugins /opt/aperture/aperture-controller/plugins

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxninja/aperture
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Henry-Sarabia/sliceconv v1.0.2

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19-buster as builder
+FROM golang:1.20-bullseye AS builder
 
 WORKDIR /src
 COPY --link . .

--- a/playground/demo_app/Dockerfile
+++ b/playground/demo_app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19-buster AS builder
+FROM golang:1.20-bullseye AS builder
 
 WORKDIR /src
 
@@ -13,6 +13,6 @@ RUN --mount=type=cache,target=/go/pkg/ \
 EOF
 
 # Final image
-FROM alpine:3.15.0
+FROM debian:bullseye-slim
 COPY --link --from=builder /demo_app /demo_app
 ENTRYPOINT ["/demo_app"]

--- a/playground/demo_app/go.mod
+++ b/playground/demo_app/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxninja/aperture/playground/demo_app
 
-go 1.19
+go 1.20
 
 require (
 	github.com/fluxninja/aperture v0.11.0

--- a/playground/graphql_demo_app/Dockerfile
+++ b/playground/graphql_demo_app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19-buster AS builder
+FROM golang:1.20-bullseye AS builder
 
 WORKDIR /src
 
@@ -13,6 +13,6 @@ RUN --mount=type=cache,target=/go/pkg/ \
 EOF
 
 # Final image
-FROM alpine:3.15.0
+FROM debian:bullseye-slim
 COPY --link --from=builder /graphql_demo_app /graphql_demo_app
 ENTRYPOINT ["/graphql_demo_app"]

--- a/playground/graphql_demo_app/go.mod
+++ b/playground/graphql_demo_app/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxninja/aperture/playground/graphql_demo_app
 
-go 1.19
+go 1.20
 
 require (
 	github.com/99designs/gqlgen v0.17.20

--- a/sdks/aperture-go/Dockerfile
+++ b/sdks/aperture-go/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1
-
-FROM golang:1.19-alpine3.16 AS builder
+FROM golang:1.20-bullseye AS builder
 
 WORKDIR /src
 COPY --link . .
@@ -8,7 +7,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "aperture-go-example" "./example"
 
 # Final image
-FROM alpine:3.16
+FROM debian:bullseye-slim
 
 COPY --from=builder /src/aperture-go-example /local/bin/aperture-go-example
 

--- a/sdks/aperture-go/Dockerfile
+++ b/sdks/aperture-go/Dockerfile
@@ -11,6 +11,10 @@ FROM debian:bullseye-slim
 
 COPY --from=builder /src/aperture-go-example /local/bin/aperture-go-example
 
+RUN apt-get update && apt-get install -y \
+    wget \
+ && rm -rf /var/lib/apt/lists/*
+
 HEALTHCHECK --interval=5s --timeout=60s --retries=3 --start-period=5s \
     CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8080/health || exit 1
 

--- a/sdks/aperture-go/go.mod
+++ b/sdks/aperture-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxninja/aperture-go
 
-go 1.19
+go 1.20
 
 require (
 	go.opentelemetry.io/otel v1.10.0

--- a/tools/go/go.mod
+++ b/tools/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxninja/aperture/tools/go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dmarkham/enumer v1.5.7


### PR DESCRIPTION
### Description of change
This bumps Golang to the latest 1.20 version.

Also, it unifies all Docker builder images to `golang:1.20-bullseye` and final images from `alpine` to `debian:bullseye-slim` (except for operator, as it is recommended to use `distroless` there). This should remove any `glibc` and `musl` compatibility issues.

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1260)
<!-- Reviewable:end -->
