### PR TITLE
Add missing root certs to images (#1266

### DIFF
--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -45,6 +45,11 @@ RUN --mount=type=cache,target=/go/pkg/ \
 # Final image
 FROM debian:bullseye-slim
 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # Ensure config dirs exists, even if not mounted
 RUN mkdir -p /etc/aperture/aperture-agent/flowcontrol /etc/aperture/aperture-agent/classifiers /opt/aperture/aperture-agent/plugins
 COPY --link --from=builder /aperture-agent /aperture-agent

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -44,6 +44,11 @@ RUN --mount=type=cache,target=/go/pkg/ \
 # Final image
 FROM debian:bullseye-slim
 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # Ensure config dirs exists, even if not mounted
 RUN mkdir -p /etc/aperture/aperture-controller/classifiers /etc/aperture/aperture-controller/policies /opt/aperture/aperture-controller/plugins
 COPY --link --from=builder /aperture-controller /aperture-controller

--- a/pkg/policies/controlplane/circuitfactory/graph.go
+++ b/pkg/policies/controlplane/circuitfactory/graph.go
@@ -102,10 +102,7 @@ func (circuit *Circuit) ToGraphView() ([]*policymonitoringv1.ComponentView, []*p
 
 func convertPortViews(ports []*policymonitoringv1.PortView) []*policymonitoringv1.PortView {
 	var converted []*policymonitoringv1.PortView
-	for i := range ports {
-		converted = append(converted, ports[i])
-	}
-	return converted
+	return append(converted, ports...)
 }
 
 // Mermaid returns Components and Links as a mermaid graph.

--- a/playground/demo_app/Dockerfile
+++ b/playground/demo_app/Dockerfile
@@ -14,5 +14,11 @@ EOF
 
 # Final image
 FROM debian:bullseye-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY --link --from=builder /demo_app /demo_app
 ENTRYPOINT ["/demo_app"]

--- a/playground/graphql_demo_app/Dockerfile
+++ b/playground/graphql_demo_app/Dockerfile
@@ -14,5 +14,11 @@ EOF
 
 # Final image
 FROM debian:bullseye-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY --link --from=builder /graphql_demo_app /graphql_demo_app
 ENTRYPOINT ["/graphql_demo_app"]

--- a/sdks/aperture-go/Dockerfile
+++ b/sdks/aperture-go/Dockerfile
@@ -11,8 +11,11 @@ FROM debian:bullseye-slim
 
 COPY --from=builder /src/aperture-go-example /local/bin/aperture-go-example
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates \
     wget \
+ && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 HEALTHCHECK --interval=5s --timeout=60s --retries=3 --start-period=5s \


### PR DESCRIPTION
### Description of change
Newly used `debian-slim` images do not have root certs installed by default.

Drive-by: Fix lint error from new linter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1266)
<!-- Reviewable:end -->
