### PR TITLE
Separate main binary and plugin caches

### DIFF
--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /src
 COPY --link . .
 
 RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/ \
   go mod download
 
 # App build
@@ -19,8 +18,8 @@ ARG RACE
 ENV RACE=${RACE}
 
 FROM base AS builder
-RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/ \
+RUN --mount=type=cache,target=/go/pkg/,readonly \
+  --mount=type=cache,target=/root/.cache/go-build/,sharing=private \
   CGO_ENABLED=1 TARGET="/aperture-agent" PREFIX="aperture" SOURCE="./cmd/aperture-agent" \
   LDFLAGS="-s -w -extldflags \"-Wl,--allow-multiple-definition\"" \
   ./pkg/info/build.sh
@@ -29,8 +28,8 @@ RUN --mount=type=cache,target=/go/pkg/ \
 # BUILD PLUGINS STAGE
 FROM base AS plugins-builder
 # Plugins build
-RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/ \
+RUN --mount=type=cache,target=/go/pkg/,readonly \
+  --mount=type=cache,target=/root/.cache/go-build/,sharing=private \
   /bin/bash -c \
   'set -euo pipefail; \
   shopt -s nullglob; \

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /src
 COPY --link . .
 
 RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/ \
   go mod download
 
 # App build
@@ -19,8 +18,8 @@ ARG RACE
 ENV RACE=${RACE}
 
 FROM base AS builder
-RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/ \
+RUN --mount=type=cache,target=/go/pkg/,readonly \
+  --mount=type=cache,target=/root/.cache/go-build/,sharing=private \
   CGO_ENABLED=1 TARGET="/aperture-controller" PREFIX="aperture" SOURCE="./cmd/aperture-controller" \
   LDFLAGS="-s -w -extldflags \"-Wl,--allow-multiple-definition\"" \
   ./pkg/info/build.sh
@@ -28,8 +27,8 @@ RUN --mount=type=cache,target=/go/pkg/ \
 
 # BUILD PLUGINS STAGE
 FROM base AS plugins-builder
-RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/ \
+RUN --mount=type=cache,target=/go/pkg/,readonly \
+  --mount=type=cache,target=/root/.cache/go-build/,sharing=private \
   /bin/bash -c \
   'set -euo pipefail; \
   shopt -s nullglob; \


### PR DESCRIPTION
### Description of change
This prevents overwriting each others caches when both main binary and plugin binaries are build at the same time.

Ref: GH-1270

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1272)
<!-- Reviewable:end -->
