### PR TITLE
Fix plugin building

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -599,7 +599,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596 // indirect
+	k8s.io/kube-openapi v0.0.0-20230202010329-39b3636cbaa3
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2983,6 +2983,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596 h1:8cNCQs+WqqnSpZ7y0LMQPKD+RZUHU17VqLPMW3qxnxc=
 k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596/go.mod h1:/BYxry62FuDzmI+i9B+X2pqfySRmSOW2ARmj5Zbqhj0=
+k8s.io/kube-openapi v0.0.0-20230202010329-39b3636cbaa3 h1:vV3ZKAUX0nMjTflyfVea98dTfROpIxDaEsQws0FT2Ts=
+k8s.io/kube-openapi v0.0.0-20230202010329-39b3636cbaa3/go.mod h1:/BYxry62FuDzmI+i9B+X2pqfySRmSOW2ARmj5Zbqhj0=
 k8s.io/kubelet v0.26.0 h1:08bDb5IoUH/1K1t2NUwnGIIWxjm9LSqn6k3FWw1tJGI=
 k8s.io/kubelet v0.26.0/go.mod h1:DluF+d8jS2nE/Hs7CC3QM+OZlIEb22NTOihQ3EDwCQ4=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=

--- a/pkg/info/build.sh
+++ b/pkg/info/build.sh
@@ -25,6 +25,7 @@ LDFLAGS="\
 "
 
 build_args=(
+  --trimpath
   --ldflags "${LDFLAGS}"
   -o "${TARGET}"
   "${SOURCE}"

--- a/pkg/plugins/build.sh
+++ b/pkg/plugins/build.sh
@@ -21,6 +21,7 @@ LDFLAGS="\
 "
 
 build_args=(
+  --trimpath
   -buildmode=plugin
   --ldflags "${LDFLAGS}"
   -o "${TARGET}"

--- a/pkg/plugins/hack.go
+++ b/pkg/plugins/hack.go
@@ -1,0 +1,8 @@
+package plugins
+
+import (
+	// This is needed to pin kube-openapi version in go mod as direct dependency.
+	// Without it, loading plugin fails with `plugin was built with a different
+	// version of package k8s.io/kube-openapi`.
+	_ "k8s.io/kube-openapi/pkg/util"
+)

--- a/pkg/plugins/plugin-registry.go
+++ b/pkg/plugins/plugin-registry.go
@@ -158,7 +158,7 @@ func (constructor Constructor) newPluginRegistry(unmarshaller config.Unmarshalle
 			plugin, err := plugin.Open(pluginPath)
 			if err != nil {
 				log.Warn().Err(err).Str("plugin", pluginName).Msg("unable to open plugin")
-				continue
+				return nil, nil, err
 			}
 			for _, pluginSymbol := range pluginSymbols {
 				// lookup symbol

--- a/plugins/service/aperture-plugin-fluxninja/hack.go
+++ b/plugins/service/aperture-plugin-fluxninja/hack.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	// This is needed to pin kube-openapi version in go mod as direct dependency.
+	// Without it, loading plugin fails with `plugin was built with a different
+	// version of package k8s.io/kube-openapi`.
+	_ "k8s.io/kube-openapi/pkg/util"
+)


### PR DESCRIPTION
### Description of change
This is a set of changes which fix error when loading plugin `plugin was built with a different version of package k8s.io/kube-openapi`:
* Add `--trimpath` flag to builders.
* Pin `k8s.io/kube-builder` as direct dep.

Ref: GH-1270

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1274)
<!-- Reviewable:end -->
