### PR TITLE
Use generic command in build.sh for linux and macos

### DIFF
--- a/pkg/info/build.sh
+++ b/pkg/info/build.sh
@@ -5,7 +5,7 @@ set -eux
 # TODO: it should be used in every Dockerfile requiring version endpoint.
 
 VERSION=${VERSION:-0.0.1}
-BUILD_TIME=$(date --rfc-3339=seconds)
+BUILD_TIME=$(date -Iseconds)
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 HOSTNAME=$(hostname)


### PR DESCRIPTION
### Description of change

The options which we were using to get the rfc-3339 date format with `date` command was not valid so I have updated it with a generic command compatible on both OS.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1287)
<!-- Reviewable:end -->
