### PR TITLE
Improved error handling for aperturectl install/uninstall

### DIFF
--- a/cmd/aperturectl/cmd/installation/agent.go
+++ b/cmd/aperturectl/cmd/installation/agent.go
@@ -1,16 +1,9 @@
 package installation
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"time"
 
-	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v3/pkg/releaseutil"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // agentInstallCmd is the command to install Aperture Agent on Kubernetes.
@@ -29,19 +22,7 @@ aperturectl install agent --values-file=values.yaml --namespace=aperture`,
 			return fmt.Errorf("--values-file must be provided")
 		}
 
-		crds, _, manifests, err := getTemplets(apertureAgent, agent, releaseutil.InstallOrder)
-		for _, crd := range crds {
-			if err = applyManifest(string(crd.File.Data)); err != nil {
-				return err
-			}
-		}
-
-		for _, manifest := range manifests {
-			if err = applyManifest(manifest.Content); err != nil {
-				return err
-			}
-		}
-		return err
+		return handleInstall(apertureAgent, agent)
 	},
 }
 
@@ -56,44 +37,6 @@ Use this command to uninstall Aperture Agent from your Kubernetes cluster`,
 
 aperturectl uninstall agent --namespace=aperture`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		crds, hooks, manifests, err := getTemplets(apertureAgent, agent, releaseutil.UninstallOrder)
-
-		for _, hook := range hooks {
-			log.Info().Msgf("Executing hook - %s", hook.Name)
-			if err = applyManifest(hook.Manifest); err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-			defer cancel()
-			if err = waitForHook(hook.Name, ctx); err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					return fmt.Errorf("timed out waiting for pre-delete hook completion")
-				}
-				return err
-			}
-
-			if err = deleteManifest(hook.Manifest); err != nil {
-				return err
-			}
-
-			if err = kubeClient.DeleteAllOf(
-				context.Background(), &corev1.Pod{}, client.InNamespace(namespace), client.MatchingLabels{"job-name": hook.Name}); err != nil {
-				return err
-			}
-		}
-
-		for _, manifest := range manifests {
-			if err = deleteManifest(manifest.Content); err != nil {
-				return err
-			}
-		}
-
-		for _, crd := range crds {
-			if err = deleteManifest(string(crd.File.Data)); err != nil {
-				return err
-			}
-		}
-		return err
+		return handleUnInstall(apertureAgent, agent)
 	},
 }

--- a/cmd/aperturectl/cmd/installation/controller.go
+++ b/cmd/aperturectl/cmd/installation/controller.go
@@ -1,16 +1,7 @@
 package installation
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"time"
-
-	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v3/pkg/releaseutil"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // controllerInstallCmd is the command to install Aperture Controller on Kubernetes.
@@ -25,19 +16,7 @@ Refer https://artifacthub.io/packages/helm/aperture/aperture-controller#paramete
 
 aperturectl install controller --values-file=values.yaml --namespace=aperture`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		crds, _, manifests, err := getTemplets(apertureController, controller, releaseutil.InstallOrder)
-		for _, crd := range crds {
-			if err = applyManifest(string(crd.File.Data)); err != nil {
-				return err
-			}
-		}
-
-		for _, manifest := range manifests {
-			if err = applyManifest(manifest.Content); err != nil {
-				return err
-			}
-		}
-		return err
+		return handleInstall(apertureController, controller)
 	},
 }
 
@@ -52,45 +31,6 @@ Use this command to uninstall Aperture Controller and its dependencies from your
 
 aperturectl uninstall controller --namespace=aperture`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		crds, hooks, manifests, err := getTemplets(apertureController, controller, releaseutil.UninstallOrder)
-
-		for _, hook := range hooks {
-			log.Info().Msgf("Executing hook - %s", hook.Name)
-			if err = applyManifest(hook.Manifest); err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-			defer cancel()
-			if err = waitForHook(hook.Name, ctx); err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					return fmt.Errorf("timed out waiting for pre-delete hook completion")
-				}
-				return err
-			}
-
-			if err = deleteManifest(hook.Manifest); err != nil {
-				return err
-			}
-
-			if err = kubeClient.DeleteAllOf(
-				context.Background(), &corev1.Pod{}, client.InNamespace(namespace), client.MatchingLabels{"job-name": hook.Name}); err != nil {
-				return err
-			}
-		}
-
-		for _, manifest := range manifests {
-			if err = deleteManifest(manifest.Content); err != nil {
-				return err
-			}
-		}
-
-		for _, crd := range crds {
-			if err = deleteManifest(string(crd.File.Data)); err != nil {
-				return err
-			}
-		}
-
-		return err
+		return handleUnInstall(apertureController, controller)
 	},
 }

--- a/cmd/aperturectl/cmd/installation/istioconfig.go
+++ b/cmd/aperturectl/cmd/installation/istioconfig.go
@@ -2,7 +2,6 @@ package installation
 
 import (
 	"github.com/spf13/cobra"
-	"helm.sh/helm/v3/pkg/releaseutil"
 )
 
 // istioConfigInstallCmd is the command to install example Istio EnvoyFilter on Kubernetes.
@@ -17,14 +16,7 @@ Refer https://artifacthub.io/packages/helm/aperture/istioconfig#parameters for l
 
 aperturectl install istioconfig --values-file=values.yaml --namespace=istio-system`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _, manifests, err := getTemplets(istioConfig, istioConfigReleaseName, releaseutil.InstallOrder)
-
-		for _, manifest := range manifests {
-			if err = applyManifest(manifest.Content); err != nil {
-				return err
-			}
-		}
-		return err
+		return handleInstall(istioConfig, istioConfigReleaseName)
 	},
 }
 
@@ -39,13 +31,6 @@ Use this command to uninstall example Istio EnvoyFilter from your Kubernetes clu
 
 aperturectl uninstall istioconfig --namespace=istio-system`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, _, manifests, err := getTemplets(istioConfig, istioConfigReleaseName, releaseutil.InstallOrder)
-
-		for _, manifest := range manifests {
-			if err = deleteManifest(manifest.Content); err != nil {
-				return err
-			}
-		}
-		return err
+		return handleUnInstall(istioConfig, istioConfigReleaseName)
 	},
 }


### PR DESCRIPTION
### Description of change

Improved error handling for `aperturectl install` and `aperturectl uninstall` to not throw the error per resource failure but collect them and print at the end.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1329)
<!-- Reviewable:end -->
