### PR TITLE
Fixed nil pointer panic in aperturectl generate

### DIFF
--- a/cmd/aperturectl/cmd/apply/dynamic-config.go
+++ b/cmd/aperturectl/cmd/apply/dynamic-config.go
@@ -34,7 +34,7 @@ var ApplyDynamicConfigCmd = &cobra.Command{
 	Short:         "Apply Aperture DynamicConfig to a Policy",
 	Long:          `Use this command to apply the Aperture DynamicConfig to a Policy.`,
 	SilenceErrors: true,
-	Example:       `aperturectl apply dynamic-config --name=static-rate-limiting --file=dynamic-config.yaml`,
+	Example:       `aperturectl apply dynamic-config --policy=static-rate-limiting --file=dynamic-config.yaml`,
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		if policyName == "" {
 			return errors.New("policy name is required")

--- a/cmd/aperturectl/cmd/apply/policy.go
+++ b/cmd/aperturectl/cmd/apply/policy.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	languagev1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/language/v1"
+	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/tui"
 	"github.com/fluxninja/aperture/operator/api"
 	policyv1alpha1 "github.com/fluxninja/aperture/operator/api/policy/v1alpha1"
 	"github.com/fluxninja/aperture/pkg/log"
@@ -47,39 +49,52 @@ aperturectl apply policy --dir=policies`,
 		if file != "" {
 			return ApplyPolicy(file)
 		} else if dir != "" {
-			return ApplyPolicies(dir)
+			policies, err := GetPolicies(dir)
+			if err != nil {
+				return err
+			}
+
+			model := tui.InitialCheckboxModel(policies, "Which policies to apply?")
+			p := tea.NewProgram(model)
+			if _, err := p.Run(); err != nil {
+				return err
+			}
+
+			for policyIndex := range model.Selected {
+				fileName := policies[policyIndex]
+				if err := ApplyPolicy(fileName); err != nil {
+					log.Error().Msgf("failed to apply policy '%s' on Kubernetes.", fileName)
+				}
+			}
+			return nil
 		} else {
 			return errors.New("either --file or --dir must be provided")
 		}
 	},
 }
 
-// ApplyPolicies applies all policies in a directory to the cluster.
-func ApplyPolicies(policyDir string) error {
+// GetPolicies applies all policies in a directory to the cluster.
+func GetPolicies(policyDir string) ([]string, error) {
+	policies := []string{}
 	// walk the directory and apply all policies
-	return filepath.Walk(policyDir, func(path string, info os.FileInfo, err error) error {
+	return policies, filepath.Walk(policyDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		fileBase := info.Name()[:len(info.Name())-len(filepath.Ext(info.Name()))]
 		if filepath.Ext(info.Name()) == ".yaml" && !strings.HasSuffix(fileBase, "-cr") {
-			err = ApplyPolicy(path)
-			if err != nil {
-				return err
+			if policy := GetPolicy(path); policy != nil {
+				policies = append(policies, path)
 			}
 		}
 		return nil
 	})
 }
 
-// ApplyPolicy applies a policy to the cluster.
-func ApplyPolicy(policyFile string) error {
-	policyFileBase := filepath.Base(policyFile)
-	policyName := policyFileBase[:len(policyFileBase)-len(filepath.Ext(policyFileBase))]
-
+func GetPolicy(policyFile string) *languagev1.Policy {
 	content, err := os.ReadFile(policyFile)
 	if err != nil {
-		return err
+		return nil
 	}
 	policy := &languagev1.Policy{}
 	err = yaml.Unmarshal(content, policy)
@@ -87,6 +102,19 @@ func ApplyPolicy(policyFile string) error {
 		log.Warn().Msgf("Skipping apply for policy '%s' due to invalid spec.", policyFile)
 		return nil
 	}
+	return policy
+}
+
+// ApplyPolicy applies a policy to the cluster.
+func ApplyPolicy(policyFile string) error {
+	policyFileBase := filepath.Base(policyFile)
+	policyName := policyFileBase[:len(policyFileBase)-len(filepath.Ext(policyFileBase))]
+
+	policy := GetPolicy(policyFile)
+	if policy == nil {
+		return nil
+	}
+
 	policyBytes, err := policy.MarshalJSON()
 	if err != nil {
 		return err
@@ -99,21 +127,21 @@ func ApplyPolicy(policyFile string) error {
 }
 
 func createAndApplyPolicy(policy *policyv1alpha1.Policy) error {
-	err := api.AddToScheme(scheme.Scheme)
+	deployment, err := getControllerDeployment()
+	if err != nil {
+		return err
+	}
+
+	err = api.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Kubernetes: %w", err)
 	}
 
-	c, err := client.New(kubeRestConfig, client.Options{
+	client, err := client.New(kubeRestConfig, client.Options{
 		Scheme: scheme.Scheme,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
-
-	deployment, err := getControllerDeployment()
-	if err != nil {
-		return err
 	}
 
 	policy.Namespace = deployment.GetNamespace()
@@ -121,7 +149,7 @@ func createAndApplyPolicy(policy *policyv1alpha1.Policy) error {
 		"fluxninja.com/validate": "true",
 	}
 	spec := policy.Spec
-	_, err = controllerutil.CreateOrUpdate(context.Background(), c, policy, func() error {
+	_, err = controllerutil.CreateOrUpdate(context.Background(), client, policy, func() error {
 		policy.Spec = spec
 		return nil
 	})

--- a/cmd/aperturectl/cmd/apply/root.go
+++ b/cmd/aperturectl/cmd/apply/root.go
@@ -34,7 +34,4 @@ Use this command to apply the Aperture Policies.`,
 		}
 		return nil
 	},
-	Example: `aperturectl apply --file=policy.yaml
-
-aperturectl apply --dir=policy-dir`,
 }

--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -118,17 +118,17 @@ aperturectl blueprints generate --name=policies/static-rate-limiting --values-fi
 		log.Info().Msgf("Generated manifests at %s", updatedOutputDir)
 
 		if applyPolicy {
-			err = apply.ApplyCmd.Flag("dir").Value.Set(updatedOutputDir)
+			err = apply.ApplyPolicyCmd.Flag("dir").Value.Set(updatedOutputDir)
 			if err != nil {
 				return err
 			}
 
-			err = apply.ApplyCmd.PreRunE(cmd, args)
+			err = apply.ApplyCmd.PersistentPreRunE(cmd, args)
 			if err != nil {
 				return err
 			}
 
-			err = apply.ApplyCmd.RunE(cmd, args)
+			err = apply.ApplyPolicyCmd.RunE(cmd, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/aperturectl/cmd/tui/checkbox.go
+++ b/cmd/aperturectl/cmd/tui/checkbox.go
@@ -41,17 +41,17 @@ func (m checkBoxModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 
 		// These keys should exit the program.
-		case "ctrl+c", "c":
+		case "ctrl+c", "c", "C", "q", "Q":
 			return m, tea.Quit
 
 		// The "d" key to de-select all
-		case "d":
+		case "d", "D":
 			for option := range m.choices {
 				delete(m.Selected, option)
 			}
 
 		// The "s" key to select all
-		case "s":
+		case "s", "S":
 			for option := range m.choices {
 				m.Selected[option] = struct{}{}
 			}
@@ -110,8 +110,8 @@ func (m checkBoxModel) View() string {
 
 	// The footer
 	s += "\nPress s to select all.\n"
-	s += "\nPress d to de-select all.\n"
-	s += "\nPress c to confirm.\n"
+	s += "Press d to de-select all.\n"
+	s += "Press c to confirm.\n"
 
 	// Send the UI for rendering
 	return s

--- a/docs/content/reference/aperturectl/apply/apply.md
+++ b/docs/content/reference/aperturectl/apply/apply.md
@@ -14,14 +14,6 @@ Apply Aperture Policies
 
 Use this command to apply the Aperture Policies.
 
-### Examples
-
-```
-aperturectl apply --file=policy.yaml
-
-aperturectl apply --dir=policy-dir
-```
-
 ### Options
 
 ```

--- a/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
+++ b/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
@@ -21,7 +21,7 @@ aperturectl apply dynamic-config [flags]
 ### Examples
 
 ```
-aperturectl apply dynamic-config --name=static-rate-limiting --file=dynamic-config.yaml
+aperturectl apply dynamic-config --policy=static-rate-limiting --file=dynamic-config.yaml
 ```
 
 ### Options


### PR DESCRIPTION
### Description of change

We were getting some nil pointer panics in `aperturectl generate --apply` due to recent changes in `aperturectl apply` command so fixed that and re-added the TUI which was removed during the same change.

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1340)
<!-- Reviewable:end -->
