### PR TITLE
Add `service.name` label to custom metrics

### DIFF
--- a/cmd/aperture-agent/agent/otel-config.go
+++ b/cmd/aperture-agent/agent/otel-config.go
@@ -135,6 +135,15 @@ func addCustomMetricsPipelines(
 	config *otelconfig.OTELConfig,
 	agentConfig *agentconfig.AgentOTELConfig,
 ) {
+	config.AddProcessor(otelconsts.ProcessorCustromMetrics, map[string]any{
+		"attributes": []map[string]interface{}{
+			{
+				"key":    "service.name",
+				"action": "upsert",
+				"value":  "aperture-custom-metrics",
+			},
+		},
+	})
 	if _, ok := agentConfig.CustomMetrics[otelconsts.ReceiverKubeletStats]; !ok {
 		if agentConfig.CustomMetrics == nil {
 			agentConfig.CustomMetrics = map[string]agentconfig.CustomMetricsConfig{}
@@ -153,6 +162,7 @@ func addCustomMetricsPipelines(
 			Receivers: normalizeComponentNames(pipelineName, metricConfig.Pipeline.Receivers),
 			Processors: append(
 				normalizeComponentNames(pipelineName, metricConfig.Pipeline.Processors),
+				otelconsts.ProcessorCustromMetrics,
 				otelconsts.ProcessorAgentGroup,
 			),
 			Exporters: []string{otelconsts.ExporterPrometheusRemoteWrite},

--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -142,6 +142,8 @@ const (
 	ProcessorRollup = "rollup"
 	// ProcessorAgentGroup adds `agent_group` attribute.
 	ProcessorAgentGroup = "attributes/agent_group"
+	// ProcessorCustromMetrics adds `service.name` resource attribute.
+	ProcessorCustromMetrics = "resource/custom_metrics"
 	// ProcessorAgentResourceLabels adds `instance` and `agent_group` resource attributes.
 	ProcessorAgentResourceLabels = "transform/agent_resource_labels"
 	// ProcessorTracesToLogs converts received tracess to logs and passes them to configured


### PR DESCRIPTION
### Description of change
All metrics coming from Prometheus like scrapers have `service.name` label. This adds such label to kubelet metrics, which are not gathered by Prometheus like scraper. This allows better metrics handing in FluxNinja ARC.

##### Checklist
- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1341)
<!-- Reviewable:end -->
