### PR TITLE
Propagate `instance` in user defined metrics

### DIFF
--- a/cmd/aperture-agent/agent/otel-config.go
+++ b/cmd/aperture-agent/agent/otel-config.go
@@ -163,7 +163,7 @@ func addCustomMetricsPipelines(
 			Processors: append(
 				normalizeComponentNames(pipelineName, metricConfig.Pipeline.Processors),
 				otelconsts.ProcessorCustromMetrics,
-				otelconsts.ProcessorAgentGroup,
+				otelconsts.ProcessorAgentResourceLabels,
 			),
 			Exporters: []string{otelconsts.ExporterPrometheusRemoteWrite},
 		})

--- a/cmd/aperture-agent/agent/provider.go
+++ b/cmd/aperture-agent/agent/provider.go
@@ -35,17 +35,19 @@ func AddAgentInfoAttribute(in FxIn) {
 			},
 		},
 	})
-	in.BaseConfig.AddProcessor(otelconsts.ProcessorAgentResourceLabels, map[string]interface{}{
-		"log_statements": []map[string]interface{}{
-			{
-				"context": "resource",
-				"statements": []string{
-					fmt.Sprintf(`set(attributes["%v"], "%v")`,
-						otelconsts.AgentGroupLabel, in.AgentInfo.GetAgentGroup()),
-					fmt.Sprintf(`set(attributes["%v"], "%v")`,
-						otelconsts.InstanceLabel, info.Hostname),
-				},
+	transformStatements := []map[string]interface{}{
+		{
+			"context": "resource",
+			"statements": []string{
+				fmt.Sprintf(`set(attributes["%v"], "%v")`,
+					otelconsts.AgentGroupLabel, in.AgentInfo.GetAgentGroup()),
+				fmt.Sprintf(`set(attributes["%v"], "%v")`,
+					otelconsts.InstanceLabel, info.Hostname),
 			},
 		},
+	}
+	in.BaseConfig.AddProcessor(otelconsts.ProcessorAgentResourceLabels, map[string]interface{}{
+		"log_statements":    transformStatements,
+		"metric_statements": transformStatements,
 	})
 }


### PR DESCRIPTION
### Description of change
This label is required to avoid metrics with same set of labels and timestamp to be pushed to FluxNinja ARC. It causes errors in the metrics backend.

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1350)
<!-- Reviewable:end -->
