### PR TITLE
increase `PV` to `10Gi` for aperture controller

### DIFF
--- a/playground/tanka/lib/apps/aperture-controller/main.libsonnet
+++ b/playground/tanka/lib/apps/aperture-controller/main.libsonnet
@@ -11,6 +11,13 @@ local helm = tanka.helm.new(helpers.helmChartsRoot);
     name: 'controller',
   },
   values:: {
+    prometheus: {
+      server: {
+        persistentVolume: {
+          size: '10Gi',
+        },
+      },
+    },
   },
   'aperture-controller':
     helm.template($.environment.name, 'charts/aperture-controller', {


### PR DESCRIPTION
### Description of change
We are getting `Kubernetes Volume full in four days` alerts on #producation-alert slack channel . After looking into this we found that the average usage is around 6 GB and the current Capicity was set to 8 GB . After having discussion with Szymon . We decided to Increase to Volume to 10 Gi.

cc @sbienkow-ninja 

![Screenshot from 2023-02-14 22-46-15](https://user-images.githubusercontent.com/57769917/218947003-cbba7948-163e-4f94-926d-6b7b398c3935.png)


##### Checklist

- [ ] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1365)
<!-- Reviewable:end -->
