### PR TITLE
Avoid data race in cache.GetAll

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -29,10 +29,15 @@ func (c *Cache[K]) Put(k K) {
 	c.cache[k] = struct{}{}
 }
 
-// GetAll returns the current state of cache.
-func (c *Cache[K]) GetAll() map[K]struct{} {
+// GetAll returns a copy of current state of cache.
+//
+// State is returned as a list in an arbitrary order.
+func (c *Cache[K]) GetAll() []K {
 	c.Lock()
 	defer c.Unlock()
-	result := c.cache
-	return result
+	items := make([]K, 0, len(c.cache))
+	for elem := range c.cache {
+		items = append(items, elem)
+	}
+	return items
 }

--- a/pkg/otelcollector/metricsprocessor/processor_test.go
+++ b/pkg/otelcollector/metricsprocessor/processor_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Metrics Processor", func() {
 
 		cp := cpCache.GetAll()
 		for _, service := range baseCheckResp.GetServices() {
-			Expect(cp).To(HaveKey(selectors.NewControlPointID(service, baseCheckResp.GetControlPoint())))
+			Expect(cp).To(ContainElement(selectors.NewControlPointID(service, baseCheckResp.GetControlPoint())))
 		}
 	})
 

--- a/pkg/policies/flowcontrol/service/controlpoints/controlpoints.go
+++ b/pkg/policies/flowcontrol/service/controlpoints/controlpoints.go
@@ -25,12 +25,12 @@ func NewHandler(serviceControlPointCache *cache.Cache[selectors.ControlPointID])
 
 // GetControlPoints returns all control points.
 func (h *Handler) GetControlPoints(ctx context.Context, _ *emptypb.Empty) (*flowcontrolcontrolpointsv1.FlowControlControlPoints, error) {
-	serviceControlPointObjects := make(map[selectors.ControlPointID]struct{})
+	var serviceControlPointObjects []selectors.ControlPointID
 	if h.serviceControlPointCache != nil {
 		serviceControlPointObjects = h.serviceControlPointCache.GetAll()
 	}
 	controlpoints := make([]*flowcontrolcontrolpointsv1.FlowControlControlPoint, 0, len(serviceControlPointObjects))
-	for controlPointID := range serviceControlPointObjects {
+	for _, controlPointID := range serviceControlPointObjects {
 		cp := &flowcontrolcontrolpointsv1.FlowControlControlPoint{
 			Service:      controlPointID.Service,
 			ControlPoint: controlPointID.ControlPoint,

--- a/plugins/service/aperture-plugin-fluxninja/heartbeats/heartbeats.go
+++ b/plugins/service/aperture-plugin-fluxninja/heartbeats/heartbeats.go
@@ -224,13 +224,13 @@ func (h *Heartbeats) newHeartbeat(
 		policies.PolicyWrappers = h.policyFactory.GetPolicyWrappers()
 	}
 
-	serviceControlPointObjects := make(map[selectors.ControlPointID]struct{})
+	var serviceControlPointObjects []selectors.ControlPointID
 	if h.serviceControlPointCache != nil {
 		serviceControlPointObjects = h.serviceControlPointCache.GetAll()
 	}
 
 	serviceControlPoints := make([]*heartbeatv1.ServiceControlPoint, 0, len(serviceControlPointObjects))
-	for cp := range serviceControlPointObjects {
+	for _, cp := range serviceControlPointObjects {
 		serviceControlPoints = append(serviceControlPoints, &heartbeatv1.ServiceControlPoint{
 			Name:        cp.ControlPoint,
 			ServiceName: cp.Service,


### PR DESCRIPTION
### Description of change

GetAll returned the same map as cache uses internally. This map can then
be accessed by GetAll's caller without any synchronization, risking a
data race with Put. To avoid the race, a copy is made and returned.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1373)
<!-- Reviewable:end -->
