### PR TITLE
integrator: max inport should be optional

### DIFF
--- a/docs/content/concepts/integrations/flow-control/components/concurrency-limiter.md
+++ b/docs/content/concepts/integrations/flow-control/components/concurrency-limiter.md
@@ -19,9 +19,9 @@ See also
 
 Concurrency Limiter is about protecting your services from overload. Its goal is
 to limit number of concurrent requests to service to a level the service can
-handle. It's implemented by configurable load-shedding. Thanks to the ability to
-define workloads of different priorities and weights, it allows to shed some
-“less useful” flows, while not affecting the more important ones.
+handle. With the ability to define workloads of different priorities and
+weights, it allows to shed some “less useful” requests, while minimally
+impacting the "more important" ones.
 
 Concurrency Limiter is configured as a [policy][policies] component.
 
@@ -29,31 +29,41 @@ Concurrency Limiter is configured as a [policy][policies] component.
 
 Each Aperture Agent instantiates a
 [Weighted Fair Queueing](https://en.wikipedia.org/wiki/Weighted_fair_queueing)
-based Scheduler as a way to prioritize flows based on their weights (priority)
-and size(tokens). Concurrency Limiter applies a load-shed-factor that the
-Scheduler uses to compute a level of [tokens](#tokens) per second, which it
+based scheduler as a way to prioritize requests based on their weights
+(priority) and size(tokens). Concurrency Limiter applies a multiplier that the
+scheduler uses to compute fill rate of [tokens](#tokens) per second, which it
 tries to maintain.
 
-If rate of tokens in flows entering the scheduler exceeds the desired rate,
-flows are queued in the scheduler. If a flow can't be scheduled within its
-specified timeout, it will be rejected.
+If rate of tokens in requests entering the scheduler exceeds the desired rate,
+requests are queued in the scheduler. If a flow can't be scheduled within its
+specified timeout, it is rejected.
 
 ### Workload {#workload}
 
-Workloads are groups of flows based on common attributes. Workloads are
+Workloads are groups of requests based on common attributes. Workloads are
 expressed by [label matcher][label-matcher] rules in Aperture. Aperture Agents
 schedule workloads based on their priorities and by estimating their
 [tokens](#tokens).
 
 ### Priority {#priority}
 
-Priority represents the importance of a flow with respect to other flows in the
-queue.
+Priority represents the importance of a request with respect to other requests
+in the queue.
 
 :::note
 
 Priority levels are in the range `0 to 255`. `0` is the lowest priority and
 `255` is the highest priority.
+
+Priority levels have non-linear effect on the scheduler. The following formula
+is used to compute the position in the queue based on the concept of (virtual
+finish times)[https://en.wikipedia.org/wiki/Weighted_fair_queueing#Algorithm]:
+
+`virtual_finish_time = virtual_time + (tokens * (256 - priority))`
+
+This means that requests with a priority level `255` will see double the
+acceptance rate compared to requests with a priority level `254`, if they have
+same number of tokens.
 
 :::
 
@@ -61,8 +71,8 @@ Priority levels are in the range `0 to 255`. `0` is the lowest priority and
 
 Tokens represent the cost of admitting a flow in the system. Most commonly,
 tokens are estimated based on milliseconds of response time observed when a flow
-is processed. Token estimation of flows within a workload is crucial when making
-flow control decisions. The concept of tokens is aligned with
+is processed. Token estimation of requests within a workload is crucial when
+making flow control decisions. The concept of tokens is aligned with
 [Little's Law](https://en.wikipedia.org/wiki/Little%27s_law), which defines the
 relationship between response times, arrival rate and the number of requests
 currently in the system (concurrency).
@@ -79,8 +89,8 @@ workload. See `auto-tokens`
 
 Aperture Agents use a variant of a
 [token bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket) to control
-the flows entering the system. Each flow has to acquire tokens from the bucket
-within a deadline period in order to be admitted.
+the requests entering the system. Each flow has to acquire tokens from the
+bucket within a deadline period in order to be admitted.
 
 ### Timeout Factor {#timeout-factor}
 
@@ -93,7 +103,7 @@ The timeout is calculated as `timeout = timeout_factor * tokens`.
 :::info
 
 It's advisable to configure the timeouts in the same order of magnitude as the
-normal latency of the workload flows in order to protect from retry storms
+normal latency of the workload requests in order to protect from retry storms
 during overload scenarios.
 
 :::

--- a/pkg/policies/controlplane/components/integrator.go
+++ b/pkg/policies/controlplane/components/integrator.go
@@ -51,13 +51,13 @@ func (in *Integrator) Execute(inPortReadings runtime.PortToReading, tickInfo run
 	if resetVal.Valid() && resetVal.Value() != 0 {
 		in.sum = 0
 	} else if inputVal.Valid() {
-		maxVal := inPortReadings.ReadSingleReadingPort("max")
 
+		in.sum += inputVal.Value()
+
+		maxVal := inPortReadings.ReadSingleReadingPort("max")
 		if maxVal.Valid() {
 			in.minMax.Max = maxVal.Value()
 			in.minMax.Min = 0
-
-			in.sum += inputVal.Value()
 			in.sum, _ = in.minMax.Constrain(in.sum)
 		}
 	}


### PR DESCRIPTION
### Description of change

Integrator assumed max port (and earlier min port) to have valid values in order to calculate sum. These ports should be optional.

##### Checklist

- [X] Tested in playground or other setup
- [X] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1393)
<!-- Reviewable:end -->
