### PR TITLE
Enable cloud plugin using  API key 

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -442,7 +442,7 @@ def refresh_chart_dependencies(chart_dir):
             local(command=["helm", "dependency", "update"], dir=chart_dir)
             return
 
-def render_tanka(environment, env_vars, base_dir, namespace):
+def render_tanka(environment, env_vars, base_dir, namespace,enable_cloud_plugin):
     print(
         "Rendering tanka environment",
         environment,
@@ -466,12 +466,14 @@ def render_tanka(environment, env_vars, base_dir, namespace):
 
     trace("Rendering tanka with env: %s" % env_vars)
 
+    enable_cloud_plugin = str(enable_cloud_plugin)
     # Generate manifests with tanka
     rendered = local(
         quiet=True,
         command=[
             TANKA,
             "--ext-str=projectRoot=" + base_dir,
+            "--ext-str=ENABLE_CLOUD_PLUGIN=" + enable_cloud_plugin,
             "show",
             # Allow dumping the templates to stdout,
             # instead of using tk export to generate files
@@ -861,7 +863,7 @@ def forward_port_delayed(workload, labels, resource_deps, namespace, service, lo
     )
 
 
-def declare_resources(resources, dep_tree, inv_dep_tree,race_arg):
+def declare_resources(resources, dep_tree, inv_dep_tree,race_arg,enable_cloud_plugin):
     """
     Declares resource-specific actions (images, ports, etc)
     Generating manifests with tanka is done separately, in order to speed up builds
@@ -936,7 +938,7 @@ def declare_resources(resources, dep_tree, inv_dep_tree,race_arg):
             namespace = app_config.get("namespace", None)
             if tkenv:
                 base_dir = app_config.get("base_dir")
-                render_tanka(tkenv, env_vars, base_dir, namespace)
+                render_tanka(tkenv, env_vars, base_dir, namespace,enable_cloud_plugin)
             elif renderer == "yaml":
                 render_yaml(manifests_path, env_vars)
             elif renderer == "jsonnet":
@@ -1079,6 +1081,7 @@ config.define_string("scenario", usage="Demo scenario to execute")
 config.define_string_list("dockerhub-image", usage="A list of images to pull directly from docker.io/fluxninja")
 config.define_bool("race",usage="Enable race detector for agent and controller")
 config.define_bool("skip-plugins", usage="Skip plugin building")
+config.define_bool("enable-cloud-plugin",usage="Enable ARC API key authentication, which will send the data to the ARC cloud")
 cfg = config.parse()
 # Enable all resources, as calling `config.parse()` by default disables all
 config.set_enabled_resources([])
@@ -1096,6 +1099,7 @@ if cfg.get("manual", False):
     trigger_mode(TRIGGER_MODE_MANUAL)
 
 get_race = cfg.get("race",False)
+enable_cloud_plugin = cfg.get("enable-cloud-plugin",False)
 
 # Optionally, process a list of images that should be pulled from dockerhub instead of being
 # built locally. This is mostly meant for aperture-agent, aperture-controller and aperture-operator.
@@ -1193,4 +1197,4 @@ cmd_button('aperture-java-trigger',
         icon_name='ads_click',
         text='Trigger library example',
 )
-declare_resources(resources, DEP_TREE, inverted_dep_tree,get_race)
+declare_resources(resources, DEP_TREE, inverted_dep_tree,get_race, enable_cloud_plugin)

--- a/playground/tanka/apps/aperture-agent/mixins.libsonnet
+++ b/playground/tanka/apps/aperture-agent/mixins.libsonnet
@@ -1,5 +1,7 @@
 local apertureAgentApp = import 'apps/aperture-agent/main.libsonnet';
 
+local pluginEnv = std.extVar('ENABLE_CLOUD_PLUGIN');
+
 local apertureAgentMixin =
   apertureAgentApp {
     values+:: {
@@ -13,10 +15,24 @@ local apertureAgentMixin =
       agent+: {
         createUninstallHook: false,
         config+: {
+          fluxninja_plugin+: {
+            fluxninja_endpoint: 'aperture.latest.dev.fluxninja.com' + ':443',
+            client+: {
+              grpc+: {
+                insecure: false,
+                tls+: {
+                  insecure_skip_verify: true,
+                },
+              },
+              http+: {
+                tls+: {
+                  insecure_skip_verify: true,
+                },
+              },
+            },
+          },
           plugins+: {
-            disabled_plugins: [
-              'aperture-plugin-fluxninja',
-            ],
+            disabled_plugins: if pluginEnv == 'True' then [] else ['aperture-plugin-fluxninja'],
           },
           log+: {
             pretty_console: true,
@@ -35,6 +51,12 @@ local apertureAgentMixin =
             },
           },
         },
+        secrets+: {
+          fluxNinjaPlugin+: {
+            create: pluginEnv,
+            value: '2b97802cf7984791919758a537c05ad0',
+          },
+        },
         image: {
           registry: '',
           repository: 'docker.io/fluxninja/aperture-agent',
@@ -49,4 +71,5 @@ local apertureAgentMixin =
 
 {
   agent: apertureAgentMixin,
+  // pluign_env : pluginEnv(),
 }

--- a/playground/tanka/apps/aperture-controller/mixins.libsonnet
+++ b/playground/tanka/apps/aperture-controller/mixins.libsonnet
@@ -1,5 +1,7 @@
 local apertureControllerApp = import 'apps/aperture-controller/main.libsonnet';
 
+local pluginEnv = std.extVar('ENABLE_CLOUD_PLUGIN');
+
 local apertureControllerMixin =
   apertureControllerApp {
     values+:: {
@@ -14,10 +16,24 @@ local apertureControllerMixin =
       controller+: {
         createUninstallHook: false,
         config+: {
+          fluxninja_plugin+: {
+            fluxninja_endpoint: 'aperture.latest.dev.fluxninja.com' + ':443',
+            client+: {
+              grpc+: {
+                insecure: false,
+                tls+: {
+                  insecure_skip_verify: true,
+                },
+              },
+              http+: {
+                tls+: {
+                  insecure_skip_verify: true,
+                },
+              },
+            },
+          },
           plugins+: {
-            disabled_plugins: [
-              'aperture-plugin-fluxninja',
-            ],
+            disabled_plugins: if pluginEnv == 'True' then [] else ['aperture-plugin-fluxninja'],
           },
           log+: {
             pretty_console: true,
@@ -29,6 +45,12 @@ local apertureControllerMixin =
           },
           prometheus+: {
             address: 'http://controller-prometheus-server.aperture-controller.svc.cluster.local:80',
+          },
+        },
+        secrets+: {
+          fluxNinjaPlugin+: {
+            create: pluginEnv,
+            value: '2b97802cf7984791919758a537c05ad0',
           },
         },
         image: {

--- a/scripts/precommit/check_tanka_show.sh
+++ b/scripts/precommit/check_tanka_show.sh
@@ -26,7 +26,7 @@ tk tool charts vendor
 exit_code=0
 while read -r app; do
 	env_dir=$(dirname "$app")
-	tk show --dangerous-allow-redirect --ext-str=projectRoot="${TOP_LEVEL}"/playground/tanka/ "$env_dir" >/dev/null || {
+	tk show --ext-str=ENABLE_CLOUD_PLUGIN=false --dangerous-allow-redirect --ext-str=projectRoot="${TOP_LEVEL}"/playground/tanka/ "$env_dir" >/dev/null || {
 		exit_code="$?"
 		printf '\n##########\nFAILED SHOWING ENV %s\n##########\n' "${env_dir}" >&2
 	}


### PR DESCRIPTION
### Description of change
Now, users can use the `--enable-cloud-plugin` flag on aperture tilt playground and see the  telemetry data from agent and controller will be gathered in our cloud product at this url (https://aperture.latest.dev.fluxninja.com/)

Closes https://github.com/fluxninja/aperture/issues/1361

Usage :

```
tilt up -- --enable-cloud-plugin
```

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1412)
<!-- Reviewable:end -->
