### PR TITLE
Fixed issue of aperturectl failing on first execution

### DIFF
--- a/cmd/aperturectl/cmd/blueprints/root.go
+++ b/cmd/aperturectl/cmd/blueprints/root.go
@@ -96,8 +96,6 @@ Use this command to pull, list, remove and generate Aperture Policy resources us
 			return err
 		}
 
-		blueprintsDir = filepath.Join(blueprintsURIRoot, getRelPath(blueprintsURIRoot))
-
 		// lock blueprintsDir to prevent concurrent access using flock package
 		lock = flock.New(filepath.Join(blueprintsURIRoot, lockFilename))
 
@@ -110,6 +108,8 @@ Use this command to pull, list, remove and generate Aperture Policy resources us
 		} else {
 			log.Debug().Msg("skipping pulling blueprints")
 		}
+
+		blueprintsDir = filepath.Join(blueprintsURIRoot, getRelPath(blueprintsURIRoot))
 		return nil
 	},
 	PersistentPostRun: func(_ *cobra.Command, _ []string) {


### PR DESCRIPTION
### Description of change

`aperturectl` was throwing error for `blueprints generate` when the cache directory is not present due to relPath is getting generated after executing pull command and we were generating the `blueprintsDir` path before that.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1415)
<!-- Reviewable:end -->
