### PR TITLE
aperturectl: Take KUBECONFIG env var into account

### DIFF
--- a/cmd/aperturectl/cmd/apply/root.go
+++ b/cmd/aperturectl/cmd/apply/root.go
@@ -13,7 +13,7 @@ var (
 )
 
 func init() {
-	ApplyCmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the Kubernetes cluster config. Defaults to '~/.kube/config'")
+	ApplyCmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG")
 
 	ApplyCmd.AddCommand(ApplyPolicyCmd)
 	ApplyCmd.AddCommand(ApplyDynamicConfigCmd)

--- a/cmd/aperturectl/cmd/utils/utils.go
+++ b/cmd/aperturectl/cmd/utils/utils.go
@@ -148,11 +148,15 @@ func FetchPolicyFromCR(crPath string) (string, error) {
 // GetKubeConfig prepares Kubernetes config to connect with the cluster using provided or default kube config file location.
 func GetKubeConfig(kubeConfig string) (*rest.Config, error) {
 	if kubeConfig == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, err
+		if kubeConfigEnv, exists := os.LookupEnv("KUBECONFIG"); exists {
+			kubeConfig = kubeConfigEnv
+		} else {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return nil, err
+			}
+			kubeConfig = filepath.Join(homeDir, ".kube", "config")
 		}
-		kubeConfig = filepath.Join(homeDir, ".kube", "config")
 		log.Info().Msgf("Using Kubernetes config '%s'", kubeConfig)
 	}
 	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfig)

--- a/docs/content/reference/aperturectl/apply/apply.md
+++ b/docs/content/reference/aperturectl/apply/apply.md
@@ -18,7 +18,7 @@ Use this command to apply the Aperture Policies.
 
 ```
   -h, --help                 help for apply
-      --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
+      --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
### Description of change

This should make aperturectl use the same config as kubectl

> For configuration, kubectl looks for a file named config in the
> $HOME/.kube directory. You can specify other kubeconfig files by setting
> the KUBECONFIG environment variable or by setting the --kubeconfig flag.

BTW, we call the flag `--kube-config`, should we make it `--kubeconfig`?

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [x] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1426)
<!-- Reviewable:end -->
