### PR TITLE
fix: make confimap test more robust

### DIFF
--- a/operator/controllers/agent/config_test.tpl
+++ b/operator/controllers/agent/config_test.tpl
@@ -162,10 +162,6 @@ sentry_plugin:
   sample_rate: 1
   traces_sample_rate: 0.2
 server:
-  listener:
-    addr: :80
-    keep_alive: 180s
-    network: tcp
   grpc:
     connection_timeout: 120s
     enable_reflection: false
@@ -190,6 +186,10 @@ server:
     read_header_timeout: 10s
     read_timeout: 10s
     write_timeout: 45s
+  listener:
+    addr: :80
+    keep_alive: 180s
+    network: tcp
   tls:
     allowed_cn: ""
     cert_file: ""

--- a/operator/controllers/agent/configmaps_test.go
+++ b/operator/controllers/agent/configmaps_test.go
@@ -19,6 +19,7 @@ package agent
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"text/template"
 	"time"
@@ -151,7 +152,14 @@ var _ = Describe("ConfigMap for Agent", func() {
 			result, err := configMapForAgentConfig(instance.DeepCopy(), scheme.Scheme)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Data).To(Equal(expected.Data))
+
+			resultByte, err := json.Marshal(result.Data)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedByte, err := json.Marshal(expected.Data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resultByte).Should(MatchYAML(expectedByte))
 		})
 	})
 })

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"path"
 	"text/template"
@@ -143,7 +144,14 @@ var _ = Describe("ConfigMap for Controller", func() {
 			result, err := configMapForControllerConfig(instance.DeepCopy(), scheme.Scheme)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Data).To(Equal(expected.Data))
+
+			resultByte, err := json.Marshal(result.Data)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedByte, err := json.Marshal(expected.Data)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resultByte).Should(MatchYAML(expectedByte))
 		})
 	})
 })


### PR DESCRIPTION
### Description of change

The Configmap test for agent was failing. The main reason was the sequence in which the actual and expected file was getting generated. 
Use the `MatchYAML` which will handle the `key ordering` and other checks. 
##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [x] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1428)
<!-- Reviewable:end -->
