### PR TITLE
Made map comparison order safe in ConfigMap tests

### DIFF
--- a/operator/controllers/agent/config_test.tpl
+++ b/operator/controllers/agent/config_test.tpl
@@ -5,8 +5,8 @@ client:
     http: ""
     https: ""
 dist_cache:
-  bind_addr: :3320
   memberlist_advertise_addr: ""
+  bind_addr: :3320
   memberlist_bind_addr: :3322
   replica_count: 1
 etcd:
@@ -29,8 +29,8 @@ fluxninja_plugin:
   client:
     grpc:
       backoff:
-        base_delay: 1s
         jitter: 0.2
+        base_delay: 1s
         max_delay: 120s
         multiplier: 1.6
       insecure: false

--- a/operator/controllers/agent/configmaps_test.go
+++ b/operator/controllers/agent/configmaps_test.go
@@ -19,7 +19,6 @@ package agent
 import (
 	"bytes"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"text/template"
 	"time"
@@ -150,16 +149,9 @@ var _ = Describe("ConfigMap for Agent", func() {
 			}
 
 			result, err := configMapForAgentConfig(instance.DeepCopy(), scheme.Scheme)
-
 			Expect(err).NotTo(HaveOccurred())
 
-			resultByte, err := json.Marshal(result.Data)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedByte, err := json.Marshal(expected.Data)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(resultByte).Should(MatchYAML(expectedByte))
+			CompareComfigMap(result, expected, "aperture-agent.yaml")
 		})
 	})
 })

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"bytes"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"path"
 	"text/template"
@@ -142,16 +141,9 @@ var _ = Describe("ConfigMap for Controller", func() {
 			}
 
 			result, err := configMapForControllerConfig(instance.DeepCopy(), scheme.Scheme)
-
 			Expect(err).NotTo(HaveOccurred())
 
-			resultByte, err := json.Marshal(result.Data)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedByte, err := json.Marshal(expected.Data)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(resultByte).Should(MatchYAML(expectedByte))
+			CompareComfigMap(result, expected, "aperture-controller.yaml")
 		})
 	})
 })


### PR DESCRIPTION
### Description of change

We were facing issues in ConfigMap tests as it required the config fields to be in the exact order.
With this change, we need to just add new fields in config and tests should pass.

##### Checklist

- [x] Tested in playground or other setup
- [x] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1435)
<!-- Reviewable:end -->
