### PR TITLE
Increased default no output timeout for CircleCI image build

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -146,7 +146,7 @@ jobs:
         default: true
       no_output_timeout:
         type: string
-        default: 10m
+        default: 20m
         description: |
           Pass through a default timeout if your Docker build does not output anything for more than 10 minutes.
     executor: <<parameters.executor>>


### PR DESCRIPTION
### Description of change

Increased the default timeout for image building to `20m` instead of `10m`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1449)
<!-- Reviewable:end -->
