### PR TITLE
Added nil check for using provided writers in logger

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -157,8 +157,12 @@ func (constructor LoggerConstructor) provideLogger(w []io.Writer,
 		writers = append(writers, log.GetPrettyConsoleWriter())
 	}
 
-	// append writers provided via Fx
-	writers = append(writers, w...)
+	// append writers provided via Fx if they are not nil
+	for _, w := range w {
+		if w != nil {
+			writers = append(writers, w)
+		}
+	}
 
 	multi := zerolog.MultiLevelWriter(writers...)
 


### PR DESCRIPTION
### Description of change

If we don't enable the sentry plugin, it was trying to add `nil` in log writer which is causing nil pointer panics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1458)
<!-- Reviewable:end -->
