### PR TITLE
Generate dashboards from blueprints in playground

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -27,6 +27,7 @@ DEFAULT_TEST_SCENARIO = "scenarios/demo-app"
 TANKA = "tk"
 SKIP_LOCAL_CMDS = False  # If set to true, skips actually running local commands (useful for developing and testing Tiltfile itself)
 TANKA_DEPS_HANDLED = []
+DASHBOARDS = []
 
 # Dependency tree and service configuration.
 # Top level maps NAMESPACE to services
@@ -81,7 +82,8 @@ DEP_TREE = {
                     "new_name": "dashboards",
                     "resource_deps": ["grafana-operator-bootstrap"],
                     "extra_objects": [
-                        (None, "GrafanaDashboard", APERTURE_CONTROLLER_NS)
+                        "aperture-signals:grafanadashboard",
+                        "k8s-resources:grafanadashboard"
                     ]
                 },
                 {
@@ -442,7 +444,7 @@ def refresh_chart_dependencies(chart_dir):
             local(command=["helm", "dependency", "update"], dir=chart_dir)
             return
 
-def render_tanka(environment, env_vars, base_dir, namespace,enable_cloud_plugin):
+def render_tanka(environment, env_vars, base_dir, namespace, enable_cloud_plugin):
     print(
         "Rendering tanka environment",
         environment,
@@ -487,6 +489,25 @@ def render_tanka(environment, env_vars, base_dir, namespace,enable_cloud_plugin)
     if namespace:
         rendered = namespace_inject(rendered, namespace)
     wrapped_k8s_yaml(rendered)
+
+
+def render_dashboards(policies):
+    aperturectl_bin = str(local(command=["../scripts/build_aperturectl.sh"], quiet=True))
+
+    blueprints_uri = os.path.join(GIT_ROOT, "blueprints")
+    dashboards = {}
+    base_dir = os.path.join(GIT_ROOT, "playground")
+    for policy in policies:
+        blueprint_name = policy["blueprint_name"]
+        policy_name = policy["policy_name"]
+        values_file = policy["values_file"]
+        dashboard_name = policy["dashboard_name"]
+        dashboard_mixin_dir = policy["dashboard_mixin_dir"]
+        rendered = local(command=["./scripts/render-dashboard.sh", base_dir, aperturectl_bin, blueprints_uri,
+                                    blueprint_name, policy_name, values_file], quiet=True)
+        dashboards[dashboard_name] = {"path": dashboard_mixin_dir, "content": rendered}
+
+    return dashboards
 
 
 def render_aperturectl(policies, namespace):
@@ -792,9 +813,8 @@ def process_aperture_scenario(scenario_path):
     for policy in aperture_policies:
         if "values_file" in policy:
             policy["values_file"] = scenario_path + "/" + policy["values_file"]
-
-    print("scenario_path", scenario_path)
-    print("aperture_policies", aperture_policies)
+        if "dashboard_mixin_dir" in policy:
+            policy["dashboard_mixin_dir"] = scenario_path + "/" + policy["dashboard_mixin_dir"]
 
     if aperture_policies:
         policies = {
@@ -815,6 +835,27 @@ def process_aperture_scenario(scenario_path):
             ]
         }
         DEP_TREE[APERTURE_DEMOAPP_NS]["scenario-policies"] = policies
+
+        for dashboard_name, dashboard in render_dashboards(aperture_policies).items():
+            ds = {
+                "renderer": "jsonnet",
+                "namespace": APERTURE_CONTROLLER_NS,
+                "labels": "ApertureController",
+                "needs": ["aperture-grafana"],
+                "manifests_path": dashboard["path"] + "/main.jsonnet",
+                "jsonnet_args": ["-J", PLAYGROUND_ROOT + "/tanka/vendor", "--ext-str", "APERTURE_DASHBOARD=%s" % dashboard["content"]],
+                "child_resources": [
+                    {
+                        "new_name": dashboard_name,
+                        "resource_deps": ["grafana-operator-bootstrap"],
+                        "extra_objects": [
+                            ("^%s" % dashboard_name, "GrafanaDashboard", APERTURE_CONTROLLER_NS)
+                        ]
+                    },
+                ]
+            }
+            DEP_TREE[APERTURE_CONTROLLER_NS]["scenario-dashboard-%s" % dashboard_name] = ds
+
 
     # Load k6 configuration and process it for inclusion into a yaml file
     wavepool_js = str(read_file(scenario_path + "/" + "load_generator/test.js"))
@@ -943,7 +984,7 @@ def declare_resources(resources, dep_tree, inv_dep_tree,race_arg,enable_cloud_pl
             namespace = app_config.get("namespace", None)
             if tkenv:
                 base_dir = app_config.get("base_dir")
-                render_tanka(tkenv, env_vars, base_dir, namespace,enable_cloud_plugin)
+                render_tanka(tkenv, env_vars, base_dir, namespace, enable_cloud_plugin)
             elif renderer == "yaml":
                 render_yaml(manifests_path, env_vars)
             elif renderer == "jsonnet":
@@ -1123,6 +1164,10 @@ to_run = ["agent", "controller", "aperture-grafana", "istio", "scenario-app", "s
 # Not all scenarios have policies, so only load policies if they were generated based on the scenario.
 if "scenario-policies" in DEP_TREE[APERTURE_DEMOAPP_NS]:
     to_run += ["scenario-policies"]
+
+for resource in DEP_TREE[APERTURE_CONTROLLER_NS]:
+    if "scenario-dashboard" in resource:
+        to_run += [resource]
 
 cfg_trace = cfg.get("trace", os.getenv("NINJA_TILT_TRACE", "false"))
 TRACE = cfg_trace == True

--- a/playground/scenarios/autoscaling/dashboards/main.jsonnet
+++ b/playground/scenarios/autoscaling/dashboards/main.jsonnet
@@ -1,0 +1,18 @@
+local grafanaOperator = import 'github.com/jsonnet-libs/grafana-operator-libsonnet/4.3/main.libsonnet';
+
+local grafana = grafanaOperator.integreatly.v1alpha1.grafana;
+local dashboard = grafanaOperator.integreatly.v1alpha1.grafanaDashboard;
+
+local dashboardMixin = std.parseJson(std.extVar('APERTURE_DASHBOARD'));
+
+local dashboards =
+  dashboard.new('load-based-autoscale-service1-dashboard') +
+  dashboard.metadata.withNamespace('aperture-controller') +
+  dashboard.metadata.withLabels({ 'fluxninja.com/grafana-instance': 'aperture-grafana' }) +
+  dashboard.spec.withJson(std.manifestJsonEx(dashboardMixin, indent='  ')) +
+  dashboard.spec.withDatasources({
+    inputName: 'DS_CONTROLLER-PROMETHEUS',
+    datasourceName: 'controller-prometheus',
+  });
+
+dashboards

--- a/playground/scenarios/autoscaling/metadata.json
+++ b/playground/scenarios/autoscaling/metadata.json
@@ -6,7 +6,9 @@
     {
       "blueprint_name": "policies/latency-aimd-concurrency-limiting",
       "policy_name": "load-based-autoscale-service1",
-      "values_file": "policies/load-based-autoscale-service1.yaml"
+      "values_file": "policies/load-based-autoscale-service1.yaml",
+      "dashboard_name": "load-based-autoscale-service1-dashboard",
+      "dashboard_mixin_dir": "dashboards/"
     }
   ],
   "images": [

--- a/playground/scenarios/demo-app/dashboards/main.jsonnet
+++ b/playground/scenarios/demo-app/dashboards/main.jsonnet
@@ -1,0 +1,32 @@
+local grafanaOperator = import 'github.com/jsonnet-libs/grafana-operator-libsonnet/4.3/main.libsonnet';
+
+local aperture = import '../../../../blueprints/main.libsonnet';
+local rateLimitpolicyDashboard = aperture.policies.StaticRateLimiting.dashboard;
+
+local grafana = grafanaOperator.integreatly.v1alpha1.grafana;
+local dashboard = grafanaOperator.integreatly.v1alpha1.grafanaDashboard;
+
+local dashboardMixin = std.parseJson(std.extVar('APERTURE_DASHBOARD'));
+
+local rateLimitPanel =
+  rateLimitpolicyDashboard({
+    policy_name: 'service1-demo-app',
+  }).dashboard.panels[0];
+
+local policyDashBoardMixin =
+  dashboardMixin
+  {
+    panels+: [rateLimitPanel { id: std.length(dashboardMixin.panels) + 2 }],
+  };
+
+local dashboards =
+  dashboard.new('service1-demo-app-dashboard') +
+  dashboard.metadata.withNamespace('aperture-controller') +
+  dashboard.metadata.withLabels({ 'fluxninja.com/grafana-instance': 'aperture-grafana' }) +
+  dashboard.spec.withJson(std.manifestJsonEx(policyDashBoardMixin, indent='  ')) +
+  dashboard.spec.withDatasources({
+    inputName: 'DS_CONTROLLER-PROMETHEUS',
+    datasourceName: 'controller-prometheus',
+  });
+
+dashboards

--- a/playground/scenarios/demo-app/metadata.json
+++ b/playground/scenarios/demo-app/metadata.json
@@ -6,7 +6,9 @@
     {
       "blueprint_name": "policies/latency-aimd-concurrency-limiting",
       "policy_name": "service1-demo-app",
-      "values_file": "policies/service1-demo-app.yaml"
+      "values_file": "policies/service1-demo-app.yaml",
+      "dashboard_name": "service1-demo-app-dashboard",
+      "dashboard_mixin_dir": "dashboards/"
     }
   ],
   "images": [

--- a/playground/scenarios/graphql-example-1/dashboards/main.jsonnet
+++ b/playground/scenarios/graphql-example-1/dashboards/main.jsonnet
@@ -1,0 +1,18 @@
+local grafanaOperator = import 'github.com/jsonnet-libs/grafana-operator-libsonnet/4.3/main.libsonnet';
+
+local grafana = grafanaOperator.integreatly.v1alpha1.grafana;
+local dashboard = grafanaOperator.integreatly.v1alpha1.grafanaDashboard;
+
+local dashboardMixin = std.parseJson(std.extVar('APERTURE_DASHBOARD'));
+
+local dashboards =
+  dashboard.new('graphql-static-rate-limiting-dashboard') +
+  dashboard.metadata.withNamespace('aperture-controller') +
+  dashboard.metadata.withLabels({ 'fluxninja.com/grafana-instance': 'aperture-grafana' }) +
+  dashboard.spec.withJson(std.manifestJsonEx(dashboardMixin, indent='  ')) +
+  dashboard.spec.withDatasources({
+    inputName: 'DS_CONTROLLER-PROMETHEUS',
+    datasourceName: 'controller-prometheus',
+  });
+
+dashboards

--- a/playground/scenarios/graphql-example-1/metadata.json
+++ b/playground/scenarios/graphql-example-1/metadata.json
@@ -5,7 +5,9 @@
     {
       "blueprint_name": "policies/static-rate-limiting",
       "policy_name": "graphql-static-rate-limiting",
-      "values_file": "policies/graphql-static-rate-limiting.yaml"
+      "values_file": "policies/graphql-static-rate-limiting.yaml",
+      "dashboard_name": "graphql-static-rate-limiting-dashboard",
+      "dashboard_mixin_dir": "dashboards/"
     }
   ],
   "images": [

--- a/playground/scripts/render-dashboard.sh
+++ b/playground/scripts/render-dashboard.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_dir=$1
+aperturectl=$2
+blueprints_uri=$3
+blueprint_name=$4
+policy_name=$5
+values_file=$6
+
+_GEN_DIR="${base_dir}/_gen"
+trap 'rm -rf -- "$_GEN_DIR"' EXIT
+
+"${aperturectl}" blueprints generate --name "${blueprint_name}" --uri "${blueprints_uri}" \
+	--values-file "${values_file}" --output-dir "${_GEN_DIR}" >&2
+
+rendered_dashboard="${_GEN_DIR}/dashboards/${policy_name}.json"
+if [ ! -f "${rendered_dashboard}" ]; then
+	echo >&2 "Could not find dashboard file: ${rendered_dashboard}"
+	exit 1
+fi
+
+tr -d '\n' < "${rendered_dashboard}"

--- a/playground/tanka/lib/apps/aperture-grafana/main.libsonnet
+++ b/playground/tanka/lib/apps/aperture-grafana/main.libsonnet
@@ -42,33 +42,8 @@ local kubeDashboards =
      },
    }).grafanaDashboards;
 
-local latencyGradientPolicyDashboard =
-  policyDashboard({
-    policy_name: 'service1-demo-app',
-  }).dashboard;
-
-local rateLimitPanel =
-  rateLimitpolicyDashboard({
-    policy_name: 'service1-demo-app',
-  }).dashboard.panels[0];
-
-local policyDashBoardMixin =
-  latencyGradientPolicyDashboard
-  {
-    panels+: [rateLimitPanel { id: std.length(latencyGradientPolicyDashboard.panels) + 2 }],
-  }
-;
-
 local dashboards =
   [
-    dashboard.new('example-dashboard') +
-    dashboard.metadata.withLabels({ 'fluxninja.com/grafana-instance': 'aperture-grafana' }) +
-    dashboard.spec.withJson(std.manifestJsonEx(policyDashBoardMixin, indent='  ')) +
-    dashboard.spec.withDatasources({
-      inputName: 'DS_CONTROLLER-PROMETHEUS',
-      datasourceName: 'controller-prometheus',
-    }),
-
     dashboard.new('k8s-resources') +
     dashboard.metadata.withLabels({ 'fluxninja.com/grafana-instance': 'aperture-grafana' }) +
     dashboard.spec.withJson(std.manifestJsonEx(kubeDashboards['k8s-resources-pod.json'], indent='  ')) +


### PR DESCRIPTION
### Description of change

Grafana dashboards will be generated using the same policy blueprints bundle instead of static one from `lib/apps`.

##### Checklist

- [x] Tested in playground or other setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1474)
<!-- Reviewable:end -->
