### PR TITLE
docs: gen: Tweaks to policy documentation generation

### DIFF
--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -4,6 +4,10 @@ sidebar_position: 11
 sidebar_label: Agent
 ---
 
+<head>
+  <body className="schema-docs" />
+</head>
+
 :::info
 See also [Aperture Agent installation](/get-started/installation/agent/agent.md).
 :::
@@ -517,8 +521,6 @@ Type: [WatchdogConfig](#watchdog-config)
 
 AdaptivePolicy creates a policy that forces GC when the usage surpasses the configured factor of the available memory. This policy calculates next target as usage+(limit-usage)\*factor.
 
-#### Properties
-
 <dl>
 <dt>enabled</dt>
 <dd>
@@ -538,8 +540,6 @@ AdaptivePolicy creates a policy that forces GC when the usage surpasses the conf
 
 AgentInfoConfig is the configuration for the agent group and other agent attributes.
 
-#### Properties
-
 <dl>
 <dt>agent_group</dt>
 <dd>
@@ -554,8 +554,6 @@ AgentInfoConfig is the configuration for the agent group and other agent attribu
 ### AgentOTELConfig {#agent-o-t-e-l-config}
 
 AgentOTELConfig is the configuration for Agent's OTEL collector.
-
-#### Properties
 
 <dl>
 <dt>custom_metrics</dt>
@@ -598,8 +596,6 @@ By default `kubeletstats` custom metrics is added, which can be overwritten.
 
 BackoffConfig holds configuration for GRPC Client Backoff.
 
-#### Properties
-
 <dl>
 <dt>base_delay</dt>
 <dd>
@@ -631,8 +627,6 @@ BackoffConfig holds configuration for GRPC Client Backoff.
 
 BatchAlertsConfig defines configuration for OTEL batch processor.
 
-#### Properties
-
 <dl>
 <dt>send_batch_max_size</dt>
 <dd>
@@ -658,8 +652,6 @@ into smaller units.
 ### BatchPostrollupConfig {#batch-postrollup-config}
 
 BatchPostrollupConfig defines configuration for OTEL batch processor.
-
-#### Properties
 
 <dl>
 <dt>send_batch_max_size</dt>
@@ -687,8 +679,6 @@ into smaller units.
 
 BatchPrerollupConfig defines configuration for OTEL batch processor.
 
-#### Properties
-
 <dl>
 <dt>send_batch_max_size</dt>
 <dd>
@@ -715,8 +705,6 @@ into smaller units.
 
 ClientConfig is the client configuration.
 
-#### Properties
-
 <dl>
 <dt>grpc</dt>
 <dd>
@@ -735,8 +723,6 @@ ClientConfig is the client configuration.
 ### ClientTLSConfig {#client-tls-config}
 
 ClientTLSConfig is the config for client TLS.
-
-#### Properties
 
 <dl>
 <dt>ca_file</dt>
@@ -786,8 +772,6 @@ CustomMetricsConfig defines receivers, processors and single metrics pipeline,
 
 which will be exported to the controller prometheus.
 
-#### Properties
-
 <dl>
 <dt>pipeline</dt>
 <dd>
@@ -813,8 +797,6 @@ which will be exported to the controller prometheus.
 
 CustomMetricsPipelineConfig defines a custom metrics pipeline.
 
-#### Properties
-
 <dl>
 <dt>processors</dt>
 <dd>
@@ -833,8 +815,6 @@ CustomMetricsPipelineConfig defines a custom metrics pipeline.
 ### DistCacheConfig {#dist-cache-config}
 
 DistCacheConfig configures distributed cache that holds per-label counters in distributed rate limiters.
-
-#### Properties
 
 <dl>
 <dt>bind_addr</dt>
@@ -867,8 +847,6 @@ DistCacheConfig configures distributed cache that holds per-label counters in di
 
 EntityConfig describes a single entity.
 
-#### Properties
-
 <dl>
 <dt>ip_address</dt>
 <dd>
@@ -893,8 +871,6 @@ EntityConfig describes a single entity.
 ### EtcdConfig {#etcd-config}
 
 EtcdConfig holds configuration for etcd client.
-
-#### Properties
 
 <dl>
 <dt>endpoints</dt>
@@ -933,8 +909,6 @@ EtcdConfig holds configuration for etcd client.
 
 FlowPreviewConfig is the configuration for the flow control preview service.
 
-#### Properties
-
 <dl>
 <dt>enabled</dt>
 <dd>
@@ -947,8 +921,6 @@ FlowPreviewConfig is the configuration for the flow control preview service.
 ### FluxNinjaPluginConfig {#flux-ninja-plugin-config}
 
 FluxNinjaPluginConfig is the configuration for FluxNinja ARC integration plugin.
-
-#### Properties
 
 <dl>
 <dt>api_key</dt>
@@ -980,8 +952,6 @@ FluxNinjaPluginConfig is the configuration for FluxNinja ARC integration plugin.
 ### GRPCClientConfig {#g-rpc-client-config}
 
 GRPCClientConfig holds configuration for GRPC Client.
-
-#### Properties
 
 <dl>
 <dt>insecure</dt>
@@ -1020,8 +990,6 @@ GRPCClientConfig holds configuration for GRPC Client.
 
 GRPCGatewayConfig holds configuration for grpc-http gateway
 
-#### Properties
-
 <dl>
 <dt>grpc_server_address</dt>
 <dd>
@@ -1034,8 +1002,6 @@ GRPCGatewayConfig holds configuration for grpc-http gateway
 ### GRPCServerConfig {#g-rpc-server-config}
 
 GRPCServerConfig holds configuration for GRPC Server.
-
-#### Properties
 
 <dl>
 <dt>connection_timeout</dt>
@@ -1061,8 +1027,6 @@ GRPCServerConfig holds configuration for GRPC Server.
 ### HTTPClientConfig {#http-client-config}
 
 HTTPClientConfig holds configuration for HTTP Client.
-
-#### Properties
 
 <dl>
 <dt>disable_compression</dt>
@@ -1185,8 +1149,6 @@ HTTPClientConfig holds configuration for HTTP Client.
 
 HTTPServerConfig holds configuration for HTTP Server.
 
-#### Properties
-
 <dl>
 <dt>disable_http_keep_alives</dt>
 <dd>
@@ -1245,8 +1207,6 @@ CanonicalHeaderKey.
 
 HeapConfig holds configuration for heap Watchdog.
 
-#### Properties
-
 <dl>
 <dt>limit</dt>
 <dd>
@@ -1278,8 +1238,6 @@ HeapConfig holds configuration for heap Watchdog.
 
 JobConfig is config for Job
 
-#### Properties
-
 <dl>
 <dt>execution_period</dt>
 <dd>
@@ -1305,8 +1263,6 @@ JobConfig is config for Job
 
 JobGroupConfig holds configuration for JobGroup.
 
-#### Properties
-
 <dl>
 <dt>blocking_execution</dt>
 <dd>
@@ -1331,8 +1287,6 @@ is ignored.
 ### KubernetesDiscoveryConfig {#kubernetes-discovery-config}
 
 KubernetesDiscoveryConfig for Kubernetes service discovery.
-
-#### Properties
 
 <dl>
 <dt>autoscale_enabled</dt>
@@ -1365,8 +1319,6 @@ KubernetesDiscoveryConfig for Kubernetes service discovery.
 
 ListenerConfig holds configuration for socket listeners.
 
-#### Properties
-
 <dl>
 <dt>addr</dt>
 <dd>
@@ -1391,8 +1343,6 @@ ListenerConfig holds configuration for socket listeners.
 ### LogConfig {#log-config}
 
 LogConfig holds configuration for a logger and log writers.
-
-#### Properties
 
 <dl>
 <dt>level</dt>
@@ -1424,8 +1374,6 @@ LogConfig holds configuration for a logger and log writers.
 ### LogWriterConfig {#log-writer-config}
 
 LogWriterConfig holds configuration for a log writer.
-
-#### Properties
 
 <dl>
 <dt>compress</dt>
@@ -1464,8 +1412,6 @@ LogWriterConfig holds configuration for a log writer.
 
 MetricsConfig holds configuration for service metrics.
 
-#### Properties
-
 <dl>
 <dt>enable_go_metrics</dt>
 <dd>
@@ -1491,8 +1437,6 @@ MetricsConfig holds configuration for service metrics.
 
 PeerDiscoveryConfig holds configuration for Agent Peer Discovery.
 
-#### Properties
-
 <dl>
 <dt>advertisement_addr</dt>
 <dd>
@@ -1505,8 +1449,6 @@ PeerDiscoveryConfig holds configuration for Agent Peer Discovery.
 ### PluginsConfig {#plugins-config}
 
 PluginsConfig holds configuration for plugins.
-
-#### Properties
 
 <dl>
 <dt>disable_plugins</dt>
@@ -1539,8 +1481,6 @@ PluginsConfig holds configuration for plugins.
 
 PortsConfig defines configuration for OTEL debug and extension ports.
 
-#### Properties
-
 <dl>
 <dt>debug_port</dt>
 <dd>
@@ -1572,8 +1512,6 @@ PortsConfig defines configuration for OTEL debug and extension ports.
 
 ProfilersConfig holds configuration for profilers.
 
-#### Properties
-
 <dl>
 <dt>cpu_profiler</dt>
 <dd>
@@ -1599,8 +1537,6 @@ ProfilersConfig holds configuration for profilers.
 
 PrometheusConfig holds configuration for Prometheus Server.
 
-#### Properties
-
 <dl>
 <dt>address</dt>
 <dd>
@@ -1615,8 +1551,6 @@ PrometheusConfig holds configuration for Prometheus Server.
 ProxyConfig holds proxy configuration.
 
 This configuration has preference over environment variables HTTP_PROXY, HTTPS_PROXY or NO_PROXY. See <https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config>
-
-#### Properties
 
 <dl>
 <dt>http</dt>
@@ -1642,8 +1576,6 @@ This configuration has preference over environment variables HTTP_PROXY, HTTPS_P
 ### SentryConfig {#sentry-config}
 
 SentryConfig holds configuration for Sentry.
-
-#### Properties
 
 <dl>
 <dt>attach_stack_trace</dt>
@@ -1696,8 +1628,6 @@ oss-aperture project dsn is set as default.
 
 ServerTLSConfig holds configuration for setting up server TLS support.
 
-#### Properties
-
 <dl>
 <dt>allowed_cn</dt>
 <dd>
@@ -1735,8 +1665,6 @@ ServerTLSConfig holds configuration for setting up server TLS support.
 
 ServiceConfig describes a service and its entities.
 
-#### Properties
-
 <dl>
 <dt>entities</dt>
 <dd>
@@ -1756,8 +1684,6 @@ ServiceConfig describes a service and its entities.
 
 StaticDiscoveryConfig for pre-determined list of services.
 
-#### Properties
-
 <dl>
 <dt>services</dt>
 <dd>
@@ -1770,8 +1696,6 @@ StaticDiscoveryConfig for pre-determined list of services.
 ### WatchdogConfig {#watchdog-config}
 
 WatchdogConfig holds configuration for Watchdog Policy. For each policy, either watermark or adaptive should be configured.
-
-#### Properties
 
 <dl>
 <dt>cgroup</dt>
@@ -1804,8 +1728,6 @@ WatchdogConfig holds configuration for Watchdog Policy. For each policy, either 
 
 WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algorithms are configured then only watermark algorithm is used.
 
-#### Properties
-
 <dl>
 <dt>adaptive_policy</dt>
 <dd>
@@ -1824,8 +1746,6 @@ WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algor
 ### WatermarksPolicy {#watermarks-policy}
 
 WatermarksPolicy creates a Watchdog policy that schedules GC at concrete watermarks.
-
-#### Properties
 
 <dl>
 <dt>enabled</dt>

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -4,6 +4,10 @@ sidebar_position: 10
 sidebar_label: Controller
 ---
 
+<head>
+  <body className="schema-docs" />
+</head>
+
 :::info
 See also [Aperture Controller installation](/get-started/installation/controller/controller.md).
 :::
@@ -410,8 +414,6 @@ Type: [WatchdogConfig](#watchdog-config)
 
 AdaptivePolicy creates a policy that forces GC when the usage surpasses the configured factor of the available memory. This policy calculates next target as usage+(limit-usage)\*factor.
 
-#### Properties
-
 <dl>
 <dt>enabled</dt>
 <dd>
@@ -430,8 +432,6 @@ AdaptivePolicy creates a policy that forces GC when the usage surpasses the conf
 ### BackoffConfig {#backoff-config}
 
 BackoffConfig holds configuration for GRPC Client Backoff.
-
-#### Properties
 
 <dl>
 <dt>base_delay</dt>
@@ -464,8 +464,6 @@ BackoffConfig holds configuration for GRPC Client Backoff.
 
 BatchAlertsConfig defines configuration for OTEL batch processor.
 
-#### Properties
-
 <dl>
 <dt>send_batch_max_size</dt>
 <dd>
@@ -492,8 +490,6 @@ into smaller units.
 
 ClientConfig is the client configuration.
 
-#### Properties
-
 <dl>
 <dt>grpc</dt>
 <dd>
@@ -512,8 +508,6 @@ ClientConfig is the client configuration.
 ### ClientTLSConfig {#client-tls-config}
 
 ClientTLSConfig is the config for client TLS.
-
-#### Properties
 
 <dl>
 <dt>ca_file</dt>
@@ -552,8 +546,6 @@ ClientTLSConfig is the config for client TLS.
 
 ControllerOTELConfig is the configuration for Agent's OTEL collector.
 
-#### Properties
-
 <dl>
 <dt>batch_alerts</dt>
 <dd>
@@ -572,8 +564,6 @@ ControllerOTELConfig is the configuration for Agent's OTEL collector.
 ### EtcdConfig {#etcd-config}
 
 EtcdConfig holds configuration for etcd client.
-
-#### Properties
 
 <dl>
 <dt>endpoints</dt>
@@ -612,8 +602,6 @@ EtcdConfig holds configuration for etcd client.
 
 FluxNinjaPluginConfig is the configuration for FluxNinja ARC integration plugin.
 
-#### Properties
-
 <dl>
 <dt>api_key</dt>
 <dd>
@@ -644,8 +632,6 @@ FluxNinjaPluginConfig is the configuration for FluxNinja ARC integration plugin.
 ### GRPCClientConfig {#g-rpc-client-config}
 
 GRPCClientConfig holds configuration for GRPC Client.
-
-#### Properties
 
 <dl>
 <dt>insecure</dt>
@@ -684,8 +670,6 @@ GRPCClientConfig holds configuration for GRPC Client.
 
 GRPCGatewayConfig holds configuration for grpc-http gateway
 
-#### Properties
-
 <dl>
 <dt>grpc_server_address</dt>
 <dd>
@@ -698,8 +682,6 @@ GRPCGatewayConfig holds configuration for grpc-http gateway
 ### GRPCServerConfig {#g-rpc-server-config}
 
 GRPCServerConfig holds configuration for GRPC Server.
-
-#### Properties
 
 <dl>
 <dt>connection_timeout</dt>
@@ -725,8 +707,6 @@ GRPCServerConfig holds configuration for GRPC Server.
 ### HTTPClientConfig {#http-client-config}
 
 HTTPClientConfig holds configuration for HTTP Client.
-
-#### Properties
 
 <dl>
 <dt>disable_compression</dt>
@@ -849,8 +829,6 @@ HTTPClientConfig holds configuration for HTTP Client.
 
 HTTPServerConfig holds configuration for HTTP Server.
 
-#### Properties
-
 <dl>
 <dt>disable_http_keep_alives</dt>
 <dd>
@@ -909,8 +887,6 @@ CanonicalHeaderKey.
 
 HeapConfig holds configuration for heap Watchdog.
 
-#### Properties
-
 <dl>
 <dt>limit</dt>
 <dd>
@@ -942,8 +918,6 @@ HeapConfig holds configuration for heap Watchdog.
 
 JobConfig is config for Job
 
-#### Properties
-
 <dl>
 <dt>execution_period</dt>
 <dd>
@@ -968,8 +942,6 @@ JobConfig is config for Job
 ### JobGroupConfig {#job-group-config}
 
 JobGroupConfig holds configuration for JobGroup.
-
-#### Properties
 
 <dl>
 <dt>blocking_execution</dt>
@@ -996,8 +968,6 @@ is ignored.
 
 ListenerConfig holds configuration for socket listeners.
 
-#### Properties
-
 <dl>
 <dt>addr</dt>
 <dd>
@@ -1022,8 +992,6 @@ ListenerConfig holds configuration for socket listeners.
 ### LogConfig {#log-config}
 
 LogConfig holds configuration for a logger and log writers.
-
-#### Properties
 
 <dl>
 <dt>level</dt>
@@ -1055,8 +1023,6 @@ LogConfig holds configuration for a logger and log writers.
 ### LogWriterConfig {#log-writer-config}
 
 LogWriterConfig holds configuration for a log writer.
-
-#### Properties
 
 <dl>
 <dt>compress</dt>
@@ -1095,8 +1061,6 @@ LogWriterConfig holds configuration for a log writer.
 
 MetricsConfig holds configuration for service metrics.
 
-#### Properties
-
 <dl>
 <dt>enable_go_metrics</dt>
 <dd>
@@ -1121,8 +1085,6 @@ MetricsConfig holds configuration for service metrics.
 ### PluginsConfig {#plugins-config}
 
 PluginsConfig holds configuration for plugins.
-
-#### Properties
 
 <dl>
 <dt>disable_plugins</dt>
@@ -1155,8 +1117,6 @@ PluginsConfig holds configuration for plugins.
 
 PortsConfig defines configuration for OTEL debug and extension ports.
 
-#### Properties
-
 <dl>
 <dt>debug_port</dt>
 <dd>
@@ -1188,8 +1148,6 @@ PortsConfig defines configuration for OTEL debug and extension ports.
 
 ProfilersConfig holds configuration for profilers.
 
-#### Properties
-
 <dl>
 <dt>cpu_profiler</dt>
 <dd>
@@ -1215,8 +1173,6 @@ ProfilersConfig holds configuration for profilers.
 
 PrometheusConfig holds configuration for Prometheus Server.
 
-#### Properties
-
 <dl>
 <dt>address</dt>
 <dd>
@@ -1231,8 +1187,6 @@ PrometheusConfig holds configuration for Prometheus Server.
 ProxyConfig holds proxy configuration.
 
 This configuration has preference over environment variables HTTP_PROXY, HTTPS_PROXY or NO_PROXY. See <https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config>
-
-#### Properties
 
 <dl>
 <dt>http</dt>
@@ -1258,8 +1212,6 @@ This configuration has preference over environment variables HTTP_PROXY, HTTPS_P
 ### SentryConfig {#sentry-config}
 
 SentryConfig holds configuration for Sentry.
-
-#### Properties
 
 <dl>
 <dt>attach_stack_trace</dt>
@@ -1312,8 +1264,6 @@ oss-aperture project dsn is set as default.
 
 ServerTLSConfig holds configuration for setting up server TLS support.
 
-#### Properties
-
 <dl>
 <dt>allowed_cn</dt>
 <dd>
@@ -1351,8 +1301,6 @@ ServerTLSConfig holds configuration for setting up server TLS support.
 
 WatchdogConfig holds configuration for Watchdog Policy. For each policy, either watermark or adaptive should be configured.
 
-#### Properties
-
 <dl>
 <dt>cgroup</dt>
 <dd>
@@ -1384,8 +1332,6 @@ WatchdogConfig holds configuration for Watchdog Policy. For each policy, either 
 
 WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algorithms are configured then only watermark algorithm is used.
 
-#### Properties
-
 <dl>
 <dt>adaptive_policy</dt>
 <dd>
@@ -1404,8 +1350,6 @@ WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algor
 ### WatermarksPolicy {#watermarks-policy}
 
 WatermarksPolicy creates a Watchdog policy that schedules GC at concrete watermarks.
-
-#### Properties
 
 <dl>
 <dt>enabled</dt>

--- a/docs/content/reference/policies/spec.md
+++ b/docs/content/reference/policies/spec.md
@@ -4,6 +4,10 @@ sidebar_position: 1
 sidebar_label: Specification
 ---
 
+<head>
+  <body className="schema-docs" />
+</head>
+
 Reference for all objects used in [the Policy language](/concepts/policy/policy.md).
 
 The top-level object representing a policy is [Policy](#policy).
@@ -12,38 +16,11 @@ The top-level object representing a policy is [Policy](#policy).
 Generated File Starts
 -->
 
-## Table of contents
-
-### POLICY CONFIGURATION
-
-| Key | Reference         |
-| --- | ----------------- |
-|     | [Policy](#policy) |
-
-## Reference
-
-### _Policy_ {#policy}
-
-#### Members
-
-<dl>
-
-<dt>body</dt>
-<dd>
-
-Type: [Policy](#policy)
-
-</dd>
-
-</dl>
-
 ## Objects
 
 ### AIMDConcurrencyController {#a-i-m-d-concurrency-controller}
 
 High level concurrency control component. Baselines a signal via exponential moving average and applies concurrency limits based on deviation of signal from the baseline. Internally implemented as a nested circuit.
-
-#### Properties
 
 <dl>
 <dt>alerter_parameters</dt>
@@ -112,8 +89,6 @@ High level concurrency control component. Baselines a signal via exponential mov
 
 Inputs for the AIMDConcurrencyController component.
 
-#### Properties
-
 <dl>
 <dt>setpoint</dt>
 <dd>
@@ -132,8 +107,6 @@ Inputs for the AIMDConcurrencyController component.
 ### AIMDConcurrencyControllerOuts {#a-i-m-d-concurrency-controller-outs}
 
 Outputs for the AIMDConcurrencyController component.
-
-#### Properties
 
 <dl>
 <dt>accepted_concurrency</dt>
@@ -185,8 +158,6 @@ Example:
 from: "source.address # or destination.address"
 ```
 
-#### Properties
-
 <dl>
 <dt>from</dt>
 <dd>
@@ -199,8 +170,6 @@ from: "source.address # or destination.address"
 ### Alerter {#alerter}
 
 Alerter reacts to a signal and generates alert to send to alert manager.
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -221,8 +190,6 @@ Alerter reacts to a signal and generates alert to send to alert manager.
 
 Inputs for the Alerter component.
 
-#### Properties
-
 <dl>
 <dt>signal</dt>
 <dd>
@@ -235,8 +202,6 @@ Inputs for the Alerter component.
 ### AlerterParameters {#alerter-parameters}
 
 Alerter Parameters is a common config for separate alerter components and alerters embedded in other components.
-
-#### Properties
 
 <dl>
 <dt>alert_channels</dt>
@@ -290,8 +255,6 @@ Signals are mapped to boolean values as follows:
 
   :::
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -311,8 +274,6 @@ Signals are mapped to boolean values as follows:
 
 Inputs for the And component.
 
-#### Properties
-
 <dl>
 <dt>inputs</dt>
 <dd>
@@ -325,8 +286,6 @@ Inputs for the And component.
 ### AndOuts {#and-outs}
 
 Output ports for the And component.
-
-#### Properties
 
 <dl>
 <dt>output</dt>
@@ -342,8 +301,6 @@ Will always be 0 (false), 1 (true) or invalid (unknown).
 ### ArithmeticCombinator {#arithmetic-combinator}
 
 Type of combinator that computes the arithmetic operation on the operand signals
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -373,8 +330,6 @@ In case of XOR and bitshifts, value of signals is cast to integers before perfor
 
 Inputs for the Arithmetic Combinator component.
 
-#### Properties
-
 <dl>
 <dt>lhs</dt>
 <dd>
@@ -394,8 +349,6 @@ Inputs for the Arithmetic Combinator component.
 
 Outputs for the Arithmetic Combinator component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -408,8 +361,6 @@ Outputs for the Arithmetic Combinator component.
 ### AutoScale {#auto-scale}
 
 AutoScale components are used to scale a service.
-
-#### Properties
 
 <dl>
 <dt>autoscaler</dt>
@@ -429,8 +380,6 @@ AutoScale components are used to scale a service.
 ### Autoscaler {#autoscaler}
 
 Autoscaler
-
-#### Properties
 
 <dl>
 <dt>cooldown_override_percentage</dt>
@@ -519,8 +468,6 @@ scale increases by 10% or more, the previous cooldown is cancelled. Defaults to 
 
 Decreasing Gradient defines a controller for scaling in based on Gradient Controller.
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -544,8 +491,6 @@ Decreasing Gradient defines a controller for scaling in based on Gradient Contro
 
 Inputs for Gradient.
 
-#### Properties
-
 <dl>
 <dt>setpoint</dt>
 <dd>
@@ -565,8 +510,6 @@ Inputs for Gradient.
 
 This allows subset of parameters with constrained values compared to a regular gradient controller. For full documentation of these parameters, refer to the [GradientControllerParameters](#gradient-controller-parameters).
 
-#### Properties
-
 <dl>
 <dt>min_gradient</dt>
 <dd>
@@ -585,8 +528,6 @@ This allows subset of parameters with constrained values compared to a regular g
 ### AutoscalerIncreasingGradient {#autoscaler-increasing-gradient}
 
 Increasing Gradient defines a controller for scaling out based on Gradient Controller.
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -611,8 +552,6 @@ Increasing Gradient defines a controller for scaling out based on Gradient Contr
 
 Inputs for Gradient.
 
-#### Properties
-
 <dl>
 <dt>setpoint</dt>
 <dd>
@@ -632,8 +571,6 @@ Inputs for Gradient.
 
 This allows subset of parameters with constrained values compared to a regular gradient controller. For full documentation of these parameters, refer to the [GradientControllerParameters](#gradient-controller-parameters).
 
-#### Properties
-
 <dl>
 <dt>max_gradient</dt>
 <dd>
@@ -652,8 +589,6 @@ This allows subset of parameters with constrained values compared to a regular g
 ### AutoscalerKubernetesReplicas {#autoscaler-kubernetes-replicas}
 
 KubernetesReplicas defines a horizontal pod scaler for Kubernetes.
-
-#### Properties
 
 <dl>
 <dt>default_config</dt>
@@ -680,8 +615,6 @@ KubernetesReplicas defines a horizontal pod scaler for Kubernetes.
 
 Outputs for Autoscaler.
 
-#### Properties
-
 <dl>
 <dt>actual_scale</dt>
 <dd>
@@ -705,8 +638,6 @@ Outputs for Autoscaler.
 
 ### AutoscalerScaleInController {#autoscaler-scale-in-controller}
 
-#### Properties
-
 <dl>
 <dt>alerter_parameters</dt>
 <dd>
@@ -724,8 +655,6 @@ Outputs for Autoscaler.
 
 ### AutoscalerScaleInControllerController {#autoscaler-scale-in-controller-controller}
 
-#### Properties
-
 <dl>
 <dt>gradient</dt>
 <dd>
@@ -736,8 +665,6 @@ Outputs for Autoscaler.
 </dl>
 
 ### AutoscalerScaleOutController {#autoscaler-scale-out-controller}
-
-#### Properties
 
 <dl>
 <dt>alerter_parameters</dt>
@@ -756,8 +683,6 @@ Outputs for Autoscaler.
 
 ### AutoscalerScaleOutControllerController {#autoscaler-scale-out-controller-controller}
 
-#### Properties
-
 <dl>
 <dt>gradient</dt>
 <dd>
@@ -768,8 +693,6 @@ Outputs for Autoscaler.
 </dl>
 
 ### AutoscalerScaler {#autoscaler-scaler}
-
-#### Properties
 
 <dl>
 <dt>kubernetes_replicas</dt>
@@ -811,8 +734,6 @@ logic, like eg. [Extrapolator](#extrapolator). Refer to a component's
 docs on how exactly it handles invalid inputs.
 
 :::
-
-#### Properties
 
 <dl>
 <dt>components</dt>
@@ -860,8 +781,6 @@ rules:
       from: request.http.headers.user-agent
   telemetry: false
 ```
-
-#### Properties
 
 <dl>
 <dt>flow_selector</dt>
@@ -933,8 +852,6 @@ You can use the [Variable](#variable) component.
 :::
 
 See also [Policy](#policy) for a higher-level explanation of circuits.
-
-#### Properties
 
 <dl>
 <dt>alerter</dt>
@@ -1106,8 +1023,6 @@ Concurrency is calculated in terms of total tokens which translate to (avg. late
 ConcurrencyLimiter configuration is split into two parts: An actuation
 strategy and a scheduler. Right now, only `load_actuator` strategy is available.
 
-#### Properties
-
 <dl>
 <dt>flow_selector</dt>
 <dd>
@@ -1138,8 +1053,6 @@ output signals.
 
 Special constant input for ports and Variable component. Can provide either a constant value or special Nan/+-Inf value.
 
-#### Properties
-
 <dl>
 <dt>special_value</dt>
 <dd>
@@ -1166,8 +1079,6 @@ transitions between 1.0 or 0.0 signal if the decider condition is
 true or false for at least "true_for" or "false_for" duration. If
 `true_for` and `false_for` durations are zero then the transitions are
 instantaneous.
-
-#### Properties
 
 <dl>
 <dt>false_for</dt>
@@ -1208,8 +1119,6 @@ If the duration is zero, the transition will happen instantaneously.
 
 Inputs for the Decider component.
 
-#### Properties
-
 <dl>
 <dt>lhs</dt>
 <dd>
@@ -1229,8 +1138,6 @@ Inputs for the Decider component.
 
 Outputs for the Decider component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -1243,8 +1150,6 @@ Outputs for the Decider component.
 ### Differentiator {#differentiator}
 
 Differentiator calculates rate of change per tick.
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -1271,8 +1176,6 @@ Differentiator calculates rate of change per tick.
 
 Inputs for the Differentiator component.
 
-#### Properties
-
 <dl>
 <dt>input</dt>
 <dd>
@@ -1285,8 +1188,6 @@ Inputs for the Differentiator component.
 ### DifferentiatorOuts {#differentiator-outs}
 
 Outputs for the Differentiator component.
-
-#### Properties
 
 <dl>
 <dt>output</dt>
@@ -1325,8 +1226,6 @@ $$
 \alpha = \frac{2}{N + 1} \quad\text{where } N = \frac{\text{ema\_window}}{\text{evaluation\_period}}
 $$
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -1351,8 +1250,6 @@ $$
 ### EMAIns {#e-m-a-ins}
 
 Inputs for the EMA component.
-
-#### Properties
 
 <dl>
 <dt>input</dt>
@@ -1391,8 +1288,6 @@ Behavior is similar to `max_envelope`.
 
 Outputs for the EMA component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -1405,8 +1300,6 @@ Outputs for the EMA component.
 ### EMAParameters {#e-m-a-parameters}
 
 Parameters for the EMA component.
-
-#### Properties
 
 <dl>
 <dt>correction_factor_on_max_envelope_violation</dt>
@@ -1447,8 +1340,6 @@ The initial value of the EMA is the average of signal readings received during t
 
 Label selector expression of the equal form "label == value".
 
-#### Properties
-
 <dl>
 <dt>label</dt>
 <dd>
@@ -1469,8 +1360,6 @@ Label selector expression of the equal form "label == value".
 Defines a high-level way to specify how to extract a flow label value given http request metadata, without a need to write rego code
 
 There are multiple variants of extractor, specify exactly one.
-
-#### Properties
 
 <dl>
 <dt>address</dt>
@@ -1530,8 +1419,6 @@ Extrapolates the input signal by repeating the last valid value during the perio
 
 It does so until `maximum_extrapolation_interval` is reached, beyond which it emits invalid signal unless input signal becomes valid again.
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -1557,8 +1444,6 @@ It does so until `maximum_extrapolation_interval` is reached, beyond which it em
 
 Inputs for the Extrapolator component.
 
-#### Properties
-
 <dl>
 <dt>input</dt>
 <dd>
@@ -1571,8 +1456,6 @@ Inputs for the Extrapolator component.
 ### ExtrapolatorOuts {#extrapolator-outs}
 
 Outputs for the Extrapolator component.
-
-#### Properties
 
 <dl>
 <dt>output</dt>
@@ -1587,8 +1470,6 @@ Outputs for the Extrapolator component.
 
 Parameters for the Extrapolator component.
 
-#### Properties
-
 <dl>
 <dt>max_extrapolation_interval</dt>
 <dd>
@@ -1601,8 +1482,6 @@ Parameters for the Extrapolator component.
 ### FirstValid {#first-valid}
 
 Picks the first valid input signal from the array of input signals and emits it as an output signal
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -1623,8 +1502,6 @@ Picks the first valid input signal from the array of input signals and emits it 
 
 Inputs for the FirstValid component.
 
-#### Properties
-
 <dl>
 <dt>inputs</dt>
 <dd>
@@ -1638,8 +1515,6 @@ Inputs for the FirstValid component.
 
 Outputs for the FirstValid component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -1652,8 +1527,6 @@ Outputs for the FirstValid component.
 ### FlowControl {#flow-control}
 
 FlowControl components are used to regulate requests flow.
-
-#### Properties
 
 <dl>
 <dt>aimd_concurrency_controller</dt>
@@ -1706,8 +1579,6 @@ label_matcher:
         regex: ^(?!.*Chrome).*Safari
 ```
 
-#### Properties
-
 <dl>
 <dt>control_point</dt>
 <dd>
@@ -1758,8 +1629,6 @@ to
 See also [FlowSelector overview](/concepts/integrations/flow-control/flow-selector.md).
 
 :::
-
-#### Properties
 
 <dl>
 <dt>flow_matcher</dt>
@@ -1813,8 +1682,6 @@ flow_selector:
 attribute_key: response_duration_ms
 ```
 
-#### Properties
-
 <dl>
 <dt>attribute_key</dt>
 <dd>
@@ -1867,8 +1734,6 @@ ExponentialBuckets creates `count` number of buckets where the lowest bucket has
 and each following bucket's upper bound is `factor` times the previous bucket's upper bound. The final +inf
 bucket is not counted.
 
-#### Properties
-
 <dl>
 <dt>count</dt>
 <dd>
@@ -1894,8 +1759,6 @@ bucket is not counted.
 
 ExponentialBucketsRange creates `count` number of buckets where the lowest bucket is `min` and the highest
 bucket is `max`. The final +inf bucket is not counted.
-
-#### Properties
 
 <dl>
 <dt>count</dt>
@@ -1923,8 +1786,6 @@ bucket is `max`. The final +inf bucket is not counted.
 LinearBuckets creates `count` number of buckets, each `width` wide, where the lowest bucket has an
 upper bound of `start`. The final +inf bucket is not counted.
 
-#### Properties
-
 <dl>
 <dt>count</dt>
 <dd>
@@ -1949,8 +1810,6 @@ upper bound of `start`. The final +inf bucket is not counted.
 ### FluxMeterStaticBuckets {#flux-meter-static-buckets}
 
 StaticBuckets holds the static value of the buckets where latency histogram will be stored.
-
-#### Properties
 
 <dl>
 <dt>buckets</dt>
@@ -1987,8 +1846,6 @@ controller into desired idle state.
 
 The output can be _optionally_ clamped to desired range using `max` and
 `min` input.
-
-#### Properties
 
 <dl>
 <dt>default_config</dt>
@@ -2027,8 +1884,6 @@ The output can be _optionally_ clamped to desired range using `max` and
 
 Dynamic Configuration for a Controller
 
-#### Properties
-
 <dl>
 <dt>manual_mode</dt>
 <dd>
@@ -2042,8 +1897,6 @@ In manual mode, the controller does not adjust the control variable I.E. emits t
 ### GradientControllerIns {#gradient-controller-ins}
 
 Inputs for the Gradient Controller component.
-
-#### Properties
 
 <dl>
 <dt>control_variable</dt>
@@ -2090,8 +1943,6 @@ This signal is multiplied by the gradient to produce the output.
 
 Outputs for the Gradient Controller component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -2104,8 +1955,6 @@ Outputs for the Gradient Controller component.
 ### GradientControllerParameters {#gradient-controller-parameters}
 
 Gradient Parameters.
-
-#### Properties
 
 <dl>
 <dt>max_gradient</dt>
@@ -2176,8 +2025,6 @@ so the _slope_ might not fully describe aggressiveness of the controller.
 Holds the last valid signal value for the specified duration then waits for next valid value to hold.
 If it's holding a value that means it ignores both valid and invalid new signals until the hold_for duration is finished.
 
-#### Properties
-
 <dl>
 <dt>hold_for</dt>
 <dd>
@@ -2203,8 +2050,6 @@ If it's holding a value that means it ignores both valid and invalid new signals
 
 Inputs for the Holder component.
 
-#### Properties
-
 <dl>
 <dt>input</dt>
 <dd>
@@ -2224,8 +2069,6 @@ Inputs for the Holder component.
 
 Outputs for the Holder component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -2238,8 +2081,6 @@ Outputs for the Holder component.
 ### InPort {#in-port}
 
 Components receive input from other components via InPorts
-
-#### Properties
 
 <dl>
 <dt>constant_signal</dt>
@@ -2260,8 +2101,6 @@ Components receive input from other components via InPorts
 
 Accumulates sum of signal every tick.
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -2280,8 +2119,6 @@ Accumulates sum of signal every tick.
 ### IntegratorIns {#integrator-ins}
 
 Inputs for the Integrator component.
-
-#### Properties
 
 <dl>
 <dt>input</dt>
@@ -2314,8 +2151,6 @@ Inputs for the Integrator component.
 
 Outputs for the Integrator component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -2330,8 +2165,6 @@ Outputs for the Integrator component.
 Logical NOT.
 
 See [And component](#and) on how signals are mapped onto boolean values.
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -2352,8 +2185,6 @@ See [And component](#and) on how signals are mapped onto boolean values.
 
 Inputs for the Inverter component.
 
-#### Properties
-
 <dl>
 <dt>input</dt>
 <dd>
@@ -2366,8 +2197,6 @@ Inputs for the Inverter component.
 ### InverterOuts {#inverter-outs}
 
 Output ports for the Inverter component.
-
-#### Properties
 
 <dl>
 <dt>output</dt>
@@ -2390,8 +2219,6 @@ Example:
 from: request.http.body
 pointer: /user/name
 ```
-
-#### Properties
 
 <dl>
 <dt>from</dt>
@@ -2427,8 +2254,6 @@ from: request.http.bearer
 json_pointer: /user/email
 ```
 
-#### Properties
-
 <dl>
 <dt>from</dt>
 <dd>
@@ -2450,8 +2275,6 @@ eg. `/foo/bar`. If the pointer points into an object, it'd be stringified.
 ### K8sLabelMatcherRequirement {#k8s-label-matcher-requirement}
 
 Label selector requirement which is a selector that contains values, a key, and an operator that relates the key and values.
-
-#### Properties
 
 <dl>
 <dt>key</dt>
@@ -2481,8 +2304,6 @@ If the operator is Exists or DoesNotExist, the values array must be empty.
 
 Describes which pods a control or observability
 component should apply to.
-
-#### Properties
 
 <dl>
 <dt>agent_group</dt>
@@ -2533,8 +2354,6 @@ It provides three ways to define requirements:
 If multiple requirements are set, they are all ANDed.
 An empty label matcher always matches.
 
-#### Properties
-
 <dl>
 <dt>expression</dt>
 <dd>
@@ -2565,8 +2384,6 @@ Note: The requirements are ANDed.
 
 Takes the load multiplier input signal and publishes it to the schedulers in the data-plane
 
-#### Properties
-
 <dl>
 <dt>default_config</dt>
 <dd>
@@ -2592,8 +2409,6 @@ Takes the load multiplier input signal and publishes it to the schedulers in the
 
 Dynamic Configuration for LoadActuator
 
-#### Properties
-
 <dl>
 <dt>dry_run</dt>
 <dd>
@@ -2607,8 +2422,6 @@ Useful for observing the behavior of Load Actuator without disrupting any real t
 ### LoadActuatorIns {#load-actuator-ins}
 
 Input for the Load Actuator component.
-
-#### Properties
 
 <dl>
 <dt>load_multiplier</dt>
@@ -2634,8 +2447,6 @@ all:
     - label_exists: foo
     - label_equals: { label = app, value = frobnicator }
 ```
-
-#### Properties
 
 <dl>
 <dt>all</dt>
@@ -2682,8 +2493,6 @@ List of MatchExpressions that is used for all/any matching
 
 eg. {any: {of: [expr1, expr2]}}.
 
-#### Properties
-
 <dl>
 <dt>of</dt>
 <dd>
@@ -2696,8 +2505,6 @@ eg. {any: {of: [expr1, expr2]}}.
 ### MatchesMatchExpression {#matches-match-expression}
 
 Label selector expression of the matches form "label matches regex".
-
-#### Properties
 
 <dl>
 <dt>label</dt>
@@ -2721,8 +2528,6 @@ Takes a list of input signals and emits the signal with the maximum value
 
 Max: output = max([]inputs).
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -2742,8 +2547,6 @@ Max: output = max([]inputs).
 
 Inputs for the Max component.
 
-#### Properties
-
 <dl>
 <dt>inputs</dt>
 <dd>
@@ -2756,8 +2559,6 @@ Inputs for the Max component.
 ### MaxOuts {#max-outs}
 
 Output for the Max component.
-
-#### Properties
 
 <dl>
 <dt>output</dt>
@@ -2772,8 +2573,6 @@ Output for the Max component.
 
 Takes an array of input signals and emits the signal with the minimum value
 Min: output = min([]inputs).
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -2794,8 +2593,6 @@ Min: output = min([]inputs).
 
 Inputs for the Min component.
 
-#### Properties
-
 <dl>
 <dt>inputs</dt>
 <dd>
@@ -2809,8 +2606,6 @@ Inputs for the Min component.
 
 Output ports for the Min component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -2823,8 +2618,6 @@ Output ports for the Min component.
 ### NestedCircuit {#nested-circuit}
 
 Nested circuit defines a sub-circuit as a high-level component. It consists of a list of components and a map of input and output ports.
-
-#### Properties
 
 <dl>
 <dt>components</dt>
@@ -2863,8 +2656,6 @@ Nested circuit defines a sub-circuit as a high-level component. It consists of a
 
 Nested signal egress is a special type of component that allows to extract a signal from a nested circuit.
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -2884,8 +2675,6 @@ Nested signal egress is a special type of component that allows to extract a sig
 
 Inputs for the NestedSignalEgress component.
 
-#### Properties
-
 <dl>
 <dt>signal</dt>
 <dd>
@@ -2898,8 +2687,6 @@ Inputs for the NestedSignalEgress component.
 ### NestedSignalIngress {#nested-signal-ingress}
 
 Nested signal ingress is a special type of component that allows to inject a signal into a nested circuit.
-
-#### Properties
 
 <dl>
 <dt>out_ports</dt>
@@ -2920,8 +2707,6 @@ Nested signal ingress is a special type of component that allows to inject a sig
 
 Outputs for the NestedSignalIngress component.
 
-#### Properties
-
 <dl>
 <dt>signal</dt>
 <dd>
@@ -2936,8 +2721,6 @@ Outputs for the NestedSignalIngress component.
 Logical OR.
 
 See [And component](#and) on how signals are mapped onto boolean values.
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -2958,8 +2741,6 @@ See [And component](#and) on how signals are mapped onto boolean values.
 
 Inputs for the Or component.
 
-#### Properties
-
 <dl>
 <dt>inputs</dt>
 <dd>
@@ -2972,8 +2753,6 @@ Inputs for the Or component.
 ### OrOuts {#or-outs}
 
 Output ports for the Or component.
-
-#### Properties
 
 <dl>
 <dt>output</dt>
@@ -2989,8 +2768,6 @@ Will always be 0 (false), 1 (true) or invalid (unknown).
 ### OutPort {#out-port}
 
 Components produce output for other components via OutPorts
-
-#### Properties
 
 <dl>
 <dt>signal_name</dt>
@@ -3008,8 +2785,6 @@ Matches HTTP Path to given path templates
 HTTP path will be matched against given path templates.
 If a match occurs, the value associated with the path template will be treated as a result.
 In case of multiple path templates matching, the most specific one will be chosen.
-
-#### Properties
 
 <dl>
 <dt>template_values</dt>
@@ -3045,8 +2820,6 @@ Example:
 
 Component for scaling pods based on a signal.
 
-#### Properties
-
 <dl>
 <dt>kubernetes_object_selector</dt>
 <dd>
@@ -3071,8 +2844,6 @@ Component for scaling pods based on a signal.
 ### PodScalerScaleActuator {#pod-scaler-scale-actuator}
 
 Actuates scaling of pods based on a signal.
-
-#### Properties
 
 <dl>
 <dt>default_config</dt>
@@ -3099,8 +2870,6 @@ Actuates scaling of pods based on a signal.
 
 Dynamic Configuration for ScaleActuator
 
-#### Properties
-
 <dl>
 <dt>dry_run</dt>
 <dd>
@@ -3115,8 +2884,6 @@ Useful for observing the behavior of Scaler without disrupting any real traffic.
 
 Inputs for the PodScaler component.
 
-#### Properties
-
 <dl>
 <dt>desired_replicas</dt>
 <dd>
@@ -3130,8 +2897,6 @@ Inputs for the PodScaler component.
 
 Reports actual and configured number of replicas.
 
-#### Properties
-
 <dl>
 <dt>out_ports</dt>
 <dd>
@@ -3144,8 +2909,6 @@ Reports actual and configured number of replicas.
 ### PodScalerScaleReporterOuts {#pod-scaler-scale-reporter-outs}
 
 Outputs for the PodScaler component.
-
-#### Properties
 
 <dl>
 <dt>actual_replicas</dt>
@@ -3174,8 +2937,6 @@ See also [Policy overview](/concepts/policy/policy.md).
 
 Policy specification contains a circuit that defines the controller logic and resources that need to be setup.
 
-#### Properties
-
 <dl>
 <dt>circuit</dt>
 <dd>
@@ -3194,8 +2955,6 @@ Policy specification contains a circuit that defines the controller logic and re
 ### PromQL {#prom-q-l}
 
 Component that runs a Prometheus query periodically and returns the result as an output signal
-
-#### Properties
 
 <dl>
 <dt>evaluation_interval</dt>
@@ -3229,8 +2988,6 @@ fluxmeters here or link to appropriate place in docs.
 
 Output for the PromQL component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -3243,8 +3000,6 @@ Output for the PromQL component.
 ### PulseGenerator {#pulse-generator}
 
 Generates 0 and 1 in turns.
-
-#### Properties
 
 <dl>
 <dt>false_for</dt>
@@ -3271,8 +3026,6 @@ Generates 0 and 1 in turns.
 
 Outputs for the PulseGenerator component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -3285,8 +3038,6 @@ Outputs for the PulseGenerator component.
 ### Query {#query}
 
 Query components that are query databases such as Prometheus.
-
-#### Properties
 
 <dl>
 <dt>promql</dt>
@@ -3309,8 +3060,6 @@ See also [Rate Limiter overview](/concepts/integrations/flow-control/components/
 
 Ratelimiting is done separately on per-label-value basis. Use _label_key_
 to select which label should be used as key.
-
-#### Properties
 
 <dl>
 <dt>default_config</dt>
@@ -3349,8 +3098,6 @@ to select which label should be used as key.
 
 Dynamic Configuration for the rate limiter
 
-#### Properties
-
 <dl>
 <dt>overrides</dt>
 <dd>
@@ -3363,8 +3110,6 @@ Dynamic Configuration for the rate limiter
 ### RateLimiterIns {#rate-limiter-ins}
 
 Inputs for the RateLimiter component
-
-#### Properties
 
 <dl>
 <dt>limit</dt>
@@ -3385,8 +3130,6 @@ under certain circumstances. [Decider](#decider) might be helpful.
 
 ### RateLimiterOverride {#rate-limiter-override}
 
-#### Properties
-
 <dl>
 <dt>label_value</dt>
 <dd>
@@ -3403,8 +3146,6 @@ under certain circumstances. [Decider](#decider) might be helpful.
 </dl>
 
 ### RateLimiterParameters {#rate-limiter-parameters}
-
-#### Properties
 
 <dl>
 <dt>label_key</dt>
@@ -3434,8 +3175,6 @@ label set up, set `label_key: "user"`.
 
 ### RateLimiterParametersLazySync {#rate-limiter-parameters-lazy-sync}
 
-#### Properties
-
 <dl>
 <dt>enabled</dt>
 <dd>
@@ -3462,8 +3201,6 @@ See also [Resources overview](/concepts/policy/resources.md).
 :::
 
 Resources are typically Flux Meters, Classifiers, etc. that can be used to create on-demand metrics or label the flows.
-
-#### Properties
 
 <dl>
 <dt>classifiers</dt>
@@ -3528,8 +3265,6 @@ telemetry: false
 
 [attribute-context]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto
 
-#### Properties
-
 <dl>
 <dt>extractor</dt>
 <dd>
@@ -3572,8 +3307,6 @@ Raw rego rules are compiled 1:1 to rego queries
 
 High-level extractor-based rules are compiled into a single rego query.
 
-#### Properties
-
 <dl>
 <dt>query</dt>
 <dd>
@@ -3606,8 +3339,6 @@ signals for accepted and incoming concurrency are aggregated across all agents.
 
 See [ConcurrencyLimiter](#concurrency-limiter) for more context.
 
-#### Properties
-
 <dl>
 <dt>out_ports</dt>
 <dd>
@@ -3626,8 +3357,6 @@ See [ConcurrencyLimiter](#concurrency-limiter) for more context.
 ### SchedulerOuts {#scheduler-outs}
 
 Output for the Scheduler component.
-
-#### Properties
 
 <dl>
 <dt>accepted_concurrency</dt>
@@ -3667,8 +3396,6 @@ rejected ones.
 ### SchedulerParameters {#scheduler-parameters}
 
 Scheduler parameters
-
-#### Properties
 
 <dl>
 <dt>auto_tokens</dt>
@@ -3756,8 +3483,6 @@ section](/concepts/integrations/flow-control/components/concurrency-limiter.md#w
 
 Workload defines a class of requests that preferably have similar properties such as response latency or desired priority.
 
-#### Properties
-
 <dl>
 <dt>label_matcher</dt>
 <dd>
@@ -3777,8 +3502,6 @@ Workload defines a class of requests that preferably have similar properties suc
 ### SchedulerWorkloadParameters {#scheduler-workload-parameters}
 
 Parameters defines parameters such as priority, tokens and fairness key that are applicable to flows within a workload.
-
-#### Properties
 
 <dl>
 <dt>fairness_key</dt>
@@ -3823,8 +3546,6 @@ to
 See also [FlowSelector overview](/concepts/integrations/flow-control/flow-selector.md).
 
 :::
-
-#### Properties
 
 <dl>
 <dt>agent_group</dt>
@@ -3872,8 +3593,6 @@ Type of combinator that switches between `on_signal` and `off_signal` signals ba
 `on_signal` will be returned if switch input is valid and not equal to 0.0 ,
 otherwise `off_signal` will be returned.
 
-#### Properties
-
 <dl>
 <dt>in_ports</dt>
 <dd>
@@ -3892,8 +3611,6 @@ otherwise `off_signal` will be returned.
 ### SwitcherIns {#switcher-ins}
 
 Inputs for the Switcher component.
-
-#### Properties
 
 <dl>
 <dt>off_signal</dt>
@@ -3920,8 +3637,6 @@ Inputs for the Switcher component.
 
 Outputs for the Switcher component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -3938,8 +3653,6 @@ Takes an input signal and emits the output after applying the specified unary op
 $$
 \text{output} = \unary_operator{\text{input}}
 $$
-
-#### Properties
 
 <dl>
 <dt>in_ports</dt>
@@ -4006,8 +3719,6 @@ The unary operator can be one of the following:
 
 Inputs for the UnaryOperator component.
 
-#### Properties
-
 <dl>
 <dt>input</dt>
 <dd>
@@ -4021,8 +3732,6 @@ Inputs for the UnaryOperator component.
 
 Outputs for the UnaryOperator component.
 
-#### Properties
-
 <dl>
 <dt>output</dt>
 <dd>
@@ -4035,8 +3744,6 @@ Outputs for the UnaryOperator component.
 ### Variable {#variable}
 
 Component that emits a variable value as an output signal, can be defined in dynamic configuration.
-
-#### Properties
 
 <dl>
 <dt>default_config</dt>
@@ -4061,8 +3768,6 @@ Component that emits a variable value as an output signal, can be defined in dyn
 
 ### VariableDynamicConfig {#variable-dynamic-config}
 
-#### Properties
-
 <dl>
 <dt>constant_signal</dt>
 <dd>
@@ -4075,8 +3780,6 @@ Component that emits a variable value as an output signal, can be defined in dyn
 ### VariableOuts {#variable-outs}
 
 Outputs for the Variable component.
-
-#### Properties
 
 <dl>
 <dt>output</dt>

--- a/docs/gen/config/agent/metadata
+++ b/docs/gen/config/agent/metadata
@@ -4,6 +4,10 @@ sidebar_position: 11
 sidebar_label: Agent
 ---
 
+<head>
+  <body className="schema-docs" />
+</head>
+
 :::info
 See also [Aperture Agent installation](/get-started/installation/agent/agent.md).
 :::

--- a/docs/gen/config/controller/metadata
+++ b/docs/gen/config/controller/metadata
@@ -4,6 +4,11 @@ sidebar_position: 10
 sidebar_label: Controller
 ---
 
+<head>
+  <body className="schema-docs" />
+</head>
+
+
 :::info
 See also [Aperture Controller installation](/get-started/installation/controller/controller.md).
 :::

--- a/docs/gen/policy/metadata
+++ b/docs/gen/policy/metadata
@@ -4,6 +4,10 @@ sidebar_position: 1
 sidebar_label: Specification
 ---
 
+<head>
+  <body className="schema-docs" />
+</head>
+
 Reference for all objects used in [the Policy language](/concepts/policy/policy.md).
 
 The top-level object representing a policy is [Policy](#policy).

--- a/docs/tools/swagger/swagger-templates/config.gotmpl
+++ b/docs/tools/swagger/swagger-templates/config.gotmpl
@@ -151,7 +151,6 @@ any
       {{- end }}
     {{- end }}
     {{- if .Properties }}
-#### {{ if .IsTuple }}Tuple members{{ else }}Properties{{ end }}
 
 <dl>
       {{- range .Properties }}
@@ -177,7 +176,8 @@ Generated File Starts
 
 {{/* Metadata, title and description are handled by `metadata` files in `/docs/gen` */}}
 
-{{- if or .OperationGroups .Operations }}
+{{/* Skip TOC & Operations reference for policy docs, as they're only dummy stubs */}}
+{{- if and (ne .Info.Title "Policy") (or .OperationGroups .Operations) }}
 ## Table of contents
 
 {{- $alltags := .Tags }}


### PR DESCRIPTION
### Description of change

* Removed noisy table of contents sections with dummy operations from
  policy docs.
* Removed "Properties" header. Didn't provide too much value and ate
  space.
* Injected "schema-docs" class to policy, agent and controller pages, so
  they can be styled differently.

##### Checklist

- [x] Documentation is changed or added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1475)
<!-- Reviewable:end -->
