### PR TITLE
Add missing `process_uuid` label to custom metrics

### DIFF
--- a/cmd/aperture-agent/agent/provider.go
+++ b/cmd/aperture-agent/agent/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fluxninja/aperture/pkg/agentinfo"
 	"github.com/fluxninja/aperture/pkg/info"
+	"github.com/fluxninja/aperture/pkg/metrics"
 	otelconfig "github.com/fluxninja/aperture/pkg/otelcollector/config"
 	otelconsts "github.com/fluxninja/aperture/pkg/otelcollector/consts"
 	"github.com/fluxninja/aperture/pkg/peers"
@@ -43,6 +44,8 @@ func AddAgentInfoAttribute(in FxIn) {
 					otelconsts.AgentGroupLabel, in.AgentInfo.GetAgentGroup()),
 				fmt.Sprintf(`set(attributes["%v"], "%v")`,
 					otelconsts.InstanceLabel, info.Hostname),
+				fmt.Sprintf(`set(attributes["%v"], "%v")`,
+					metrics.ProcessUUIDLabel, info.UUID),
 			},
 		},
 	}


### PR DESCRIPTION
### Description of change
Without this label, there could be duplicate metrics when container restarts.

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1502)
<!-- Reviewable:end -->
