### PR TITLE
Add simple epoch-based expiry to cache.Cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,42 +2,114 @@ package cache
 
 import (
 	"sync"
+	"time"
+
+	"go.uber.org/fx"
 )
 
 // Provide cache.
-func Provide[K comparable]() *Cache[K] {
-	return NewCache[K]()
+func Provide[K comparable](lc fx.Lifecycle) *Cache[K] {
+	cache := NewCache[K]()
+	lc.Append(fx.StartStopHook(cache.Start, cache.Stop))
+	return cache
 }
 
 // NewCache returns new instance of cache.
 func NewCache[K comparable]() *Cache[K] {
 	return &Cache[K]{
-		cache: map[K]struct{}{},
+		current: make(map[K]struct{}),
 	}
 }
 
 // Cache is a set of unique keys of type K.
+//
+// Cache implements epoch-based expiry. Each PERIOD current keys are marked as
+// stale and stale keys are discarded.  This means that effective per-key
+// expiry time is in between PERIOD and 2*PERIOD.
 type Cache[K comparable] struct {
-	sync.Mutex
-	cache map[K]struct{}
+	prev    map[K]struct{} // keys from previous epoch
+	current map[K]struct{} // keys from current epoch
+	mutex   sync.Mutex     // protects prev & current maps
+	stopCh  chan struct{}
+	ticker  *time.Ticker
+}
+
+const (
+	gcPeriod = 30 * time.Second
+)
+
+// Start starts the periodic epoch rotation in background.
+func (c *Cache[K]) Start() {
+	c.ticker = time.NewTicker(gcPeriod)
+	c.stopCh = make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-c.stopCh:
+				return
+			case <-c.ticker.C:
+				c.gc()
+			}
+		}
+	}()
+}
+
+// Stop stops all the background tasks of the cache.
+func (c *Cache[K]) Stop() {
+	c.ticker.Stop()
+	close(c.stopCh)
 }
 
 // Put inserts k into the cache.
 func (c *Cache[K]) Put(k K) {
-	c.Lock()
-	defer c.Unlock()
-	c.cache[k] = struct{}{}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.current[k] = struct{}{}
 }
+
+// Contains checks if map contains given key.
+func (c *Cache[K]) Contains(k K) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if _, inPrev := c.prev[k]; inPrev {
+		return true
+	}
+
+	_, inCurrent := c.current[k]
+	return inCurrent
+}
+
+func (c *Cache[K]) gc() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.prev = c.current
+	c.current = make(map[K]struct{}, 2*len(c.current))
+}
+
+// NewEpochForTest triggers manual epoch rotation.
+//
+// Should be used only in tests.
+func (c *Cache[K]) NewEpochForTest() { c.gc() }
 
 // GetAll returns a copy of current state of cache.
 //
 // State is returned as a list in an arbitrary order.
 func (c *Cache[K]) GetAll() []K {
-	c.Lock()
-	defer c.Unlock()
-	items := make([]K, 0, len(c.cache))
-	for elem := range c.cache {
-		items = append(items, elem)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	keys := make([]K, 0, len(c.prev)+len(c.current))
+	for k := range c.current {
+		keys = append(keys, k)
 	}
-	return items
+	for k := range c.prev {
+		if _, inCurrent := c.current[k]; inCurrent {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/pkg/cache/cache_suite_test.go
+++ b/pkg/cache/cache_suite_test.go
@@ -1,0 +1,30 @@
+package cache_test
+
+import (
+	"io"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/utils"
+)
+
+func TestLog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Log Suite")
+}
+
+var l *utils.GoLeakDetector
+
+var _ = BeforeSuite(func() {
+	l = utils.NewGoLeakDetector()
+	// This suite test the global logger via hooks, so hide its output.
+	log.SetGlobalLogger(log.NewLogger(io.Discard, "info"))
+})
+
+var _ = AfterSuite(func() {
+	err := l.FindLeaks()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,38 @@
+package cache_test
+
+import (
+	"github.com/fluxninja/aperture/pkg/cache"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cache", func() {
+	It("Doesn't crash/leak on start/stop", func() {
+		c := cache.NewCache[int]()
+		c.Start()
+		c.Stop()
+	})
+
+	It("Handles epoch-based expiration", func() {
+		c := cache.NewCache[string]()
+		c.Put("a")
+		c.Put("a")
+		c.Put("b")
+		Expect(c.GetAll()).To(ConsistOf("a", "b"))
+
+		c.NewEpochForTest()
+		c.Put("b")
+		c.Put("c")
+		Expect(c.GetAll()).To(ConsistOf("a", "b", "c"))
+		Expect(c.Contains("a")).To(BeTrue())
+		Expect(c.Contains("b")).To(BeTrue())
+		Expect(c.Contains("c")).To(BeTrue())
+
+		c.NewEpochForTest()
+		Expect(c.GetAll()).To(ConsistOf("b", "c"))
+		Expect(c.Contains("a")).To(BeFalse())
+
+		c.NewEpochForTest()
+		Expect(c.GetAll()).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
### Description of change

Right now, the period is hardcoded to 30s (so effective expiry is 30s–1m). We
can make it configurable in the future, if we want, but I didn't feel it's a
must have.

Resolves #1345

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Tests and/or benchmarks are included

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/aperture/1504)
<!-- Reviewable:end -->
