### PR TITLE
Add readiness system in status registry

### DIFF
--- a/operator/controllers/agent/daemonset_test.go
+++ b/operator/controllers/agent/daemonset_test.go
@@ -552,7 +552,7 @@ var _ = Describe("Agent DaemonSet", func() {
 									LivenessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
-												Path:   "/v1/status/subsystem/liveness",
+												Path:   "/v1/status/system/liveness",
 												Port:   intstr.FromString(Server),
 												Scheme: corev1.URISchemeHTTP,
 											},
@@ -566,7 +566,7 @@ var _ = Describe("Agent DaemonSet", func() {
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
-												Path:   "/v1/status/subsystem/readiness",
+												Path:   "/v1/status/system/readiness",
 												Port:   intstr.FromString(Server),
 												Scheme: corev1.URISchemeHTTP,
 											},

--- a/operator/controllers/controller/deployment_test.go
+++ b/operator/controllers/controller/deployment_test.go
@@ -19,8 +19,6 @@ package controller
 import (
 	"fmt"
 
-	controller "github.com/fluxninja/aperture/cmd/aperture-controller/config"
-	. "github.com/fluxninja/aperture/operator/controllers"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,6 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
+
+	controller "github.com/fluxninja/aperture/cmd/aperture-controller/config"
+	. "github.com/fluxninja/aperture/operator/controllers"
 
 	"github.com/fluxninja/aperture/operator/api/common"
 	controllerv1alpha1 "github.com/fluxninja/aperture/operator/api/controller/v1alpha1"
@@ -566,7 +567,7 @@ var _ = Describe("Controller Deployment", func() {
 									LivenessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
-												Path:   "/v1/status/subsystem/liveness",
+												Path:   "/v1/status/system/liveness",
 												Port:   intstr.FromString(Server),
 												Scheme: corev1.URISchemeHTTP,
 											},
@@ -580,7 +581,7 @@ var _ = Describe("Controller Deployment", func() {
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
-												Path:   "/v1/status/subsystem/readiness",
+												Path:   "/v1/status/system/readiness",
 												Port:   intstr.FromString(Server),
 												Scheme: corev1.URISchemeHTTP,
 											},

--- a/operator/controllers/mutatingwebhook/agent_pod_test.go
+++ b/operator/controllers/mutatingwebhook/agent_pod_test.go
@@ -522,7 +522,7 @@ var _ = Describe("Sidecar container for Agent", func() {
 				LivenessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/v1/status/subsystem/liveness",
+							Path:   "/v1/status/system/liveness",
 							Port:   intstr.FromString(Server),
 							Scheme: corev1.URISchemeHTTP,
 						},
@@ -536,7 +536,7 @@ var _ = Describe("Sidecar container for Agent", func() {
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/v1/status/subsystem/readiness",
+							Path:   "/v1/status/system/readiness",
 							Port:   intstr.FromString(Server),
 							Scheme: corev1.URISchemeHTTP,
 						},

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -33,11 +34,6 @@ import (
 	"strings"
 	"time"
 
-	cryptorand "crypto/rand"
-
-	agentv1alpha1 "github.com/fluxninja/aperture/operator/api/agent/v1alpha1"
-	"github.com/fluxninja/aperture/operator/api/common"
-	controllerv1alpha1 "github.com/fluxninja/aperture/operator/api/controller/v1alpha1"
 	"github.com/imdario/mergo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -47,6 +43,10 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	agentv1alpha1 "github.com/fluxninja/aperture/operator/api/agent/v1alpha1"
+	"github.com/fluxninja/aperture/operator/api/common"
+	controllerv1alpha1 "github.com/fluxninja/aperture/operator/api/controller/v1alpha1"
 )
 
 // ContainerSecurityContext prepares SecurityContext for containers based on the provided parameter.
@@ -137,7 +137,7 @@ func ContainerProbes(spec common.CommonSpec, scheme corev1.URIScheme) (*corev1.P
 		livenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/v1/status/subsystem/liveness",
+					Path:   "/v1/status/system/liveness",
 					Port:   intstr.FromString(Server),
 					Scheme: scheme,
 				},
@@ -156,7 +156,7 @@ func ContainerProbes(spec common.CommonSpec, scheme corev1.URIScheme) (*corev1.P
 		readinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/v1/status/subsystem/readiness",
+					Path:   "/v1/status/system/readiness",
 					Port:   intstr.FromString(Server),
 					Scheme: scheme,
 				},

--- a/operator/controllers/utils_test.go
+++ b/operator/controllers/utils_test.go
@@ -334,7 +334,7 @@ var _ = Describe("Tests for containerProbes", func() {
 			expectedLiveness := &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path:   "/v1/status/subsystem/liveness",
+						Path:   "/v1/status/system/liveness",
 						Port:   intstr.FromString(Server),
 						Scheme: corev1.URISchemeHTTP,
 					},
@@ -359,7 +359,7 @@ var _ = Describe("Tests for containerProbes", func() {
 			probe := &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/status/subsystem/liveness",
+						Path: "/v1/status/system/liveness",
 						Port: intstr.FromString(Server),
 					},
 				},
@@ -416,7 +416,7 @@ var _ = Describe("Tests for containerProbes", func() {
 			expectedReadiness := &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path:   "/v1/status/subsystem/readiness",
+						Path:   "/v1/status/system/readiness",
 						Port:   intstr.FromString(Server),
 						Scheme: corev1.URISchemeHTTP,
 					},
@@ -441,7 +441,7 @@ var _ = Describe("Tests for containerProbes", func() {
 			probe := &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/status/subsystem/readiness",
+						Path: "/v1/status/system/readiness",
 						Port: intstr.FromString(Server),
 					},
 				},
@@ -506,7 +506,7 @@ var _ = Describe("Tests for containerProbes", func() {
 			expectedReadiness := &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path:   "/v1/status/subsystem/readiness",
+						Path:   "/v1/status/system/readiness",
 						Port:   intstr.FromString(Server),
 						Scheme: corev1.URISchemeHTTP,
 					},
@@ -521,7 +521,7 @@ var _ = Describe("Tests for containerProbes", func() {
 			expectedLiveness := &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path:   "/v1/status/subsystem/liveness",
+						Path:   "/v1/status/system/liveness",
 						Port:   intstr.FromString(Server),
 						Scheme: corev1.URISchemeHTTP,
 					},

--- a/pkg/jobs/job-group.go
+++ b/pkg/jobs/job-group.go
@@ -90,7 +90,7 @@ func (jgc JobGroupConstructor) provideJobGroup(
 		gwAll = append(gwAll, jgc.GW...)
 		gwAll = append(gwAll, gw...)
 	}
-	reg := registry.Child("jg", jgc.Name)
+	reg := registry.Child("job-group", jgc.Name)
 
 	jg, err := NewJobGroup(reg, schedulerConfig, gwAll)
 	if err != nil {
@@ -142,8 +142,8 @@ func NewJobGroup(
 // Start starts the JobGroup.
 func (jg *JobGroup) Start() error {
 	jg.livenessRegistry = jg.gt.statusRegistry.Root().
-		Child("subsystem", "liveness").
-		Child("jg", "job_groups").
+		Child("system", "liveness").
+		Child("job-group", "job_groups").
 		Child(jg.gt.statusRegistry.Key(), jg.gt.statusRegistry.Value())
 	jg.scheduler.Start(context.Background())
 	return nil

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"time"
 
-	statusv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/status/v1"
-	"github.com/fluxninja/aperture/pkg/alerts"
-	"github.com/fluxninja/aperture/pkg/config"
-	"github.com/fluxninja/aperture/pkg/log"
-	"github.com/fluxninja/aperture/pkg/status"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	statusv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/status/v1"
+	"github.com/fluxninja/aperture/pkg/alerts"
+	"github.com/fluxninja/aperture/pkg/config"
+	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/status"
 )
 
 var _ JobWatcher = (*testGroupConfig)(nil)
@@ -284,8 +285,8 @@ func runJobGroup(jobGroup *JobGroup, groupConfig *testGroupConfig, jobConfig Job
 	for _, job := range groupConfig.jobs {
 		registry := jobGroup.livenessRegistry
 		livenessReg := registry.Root().
-			Child("subsystem", "liveness").
-			Child("jg", "job_groups").
+			Child("system", "liveness").
+			Child("job-group", "job_groups").
 			Child(registry.Key(), registry.Value()).
 			Child("executor", job.Name())
 

--- a/pkg/notifiers/fx-driver.go
+++ b/pkg/notifiers/fx-driver.go
@@ -175,7 +175,7 @@ func (fxd *fxDriver) GetKeyNotifier(key Key) (KeyNotifier, error) {
 	fr := &fxRunner{
 		fxOptionsFuncs:         fxd.fxOptionsFuncs,
 		statusRegistry:         statusRegistry,
-		fxRunnerStatusRegistry: statusRegistry.Child("subsystem", "fx_runner"),
+		fxRunnerStatusRegistry: statusRegistry.Child("system", "fx_runner"),
 		prometheusRegistry:     fxd.prometheusRegistry,
 	}
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -162,7 +162,7 @@ func ServerModule(testMode bool) fx.Option {
 
 // Run is an fx helper function to gracefully start and stop an app container.
 func Run(app *fx.App) {
-	platform.statusRegistry = platform.statusRegistry.Child("subsystem", "readiness").Child("component", "platform")
+	platform.statusRegistry = platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath)
 	// Check for dotflag
 	if platform.unmarshaller != nil {
 		dotfile := config.GetStringValue(platform.unmarshaller, dotFileKey, "")

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -162,7 +162,7 @@ func ServerModule(testMode bool) fx.Option {
 
 // Run is an fx helper function to gracefully start and stop an app container.
 func Run(app *fx.App) {
-	platform.statusRegistry = platform.statusRegistry.Child("system", platformStatusPath)
+	platform.statusRegistry = platform.statusRegistry.Child("subsystem", "readiness").Child("component", "platform")
 	// Check for dotflag
 	if platform.unmarshaller != nil {
 		dotfile := config.GetStringValue(platform.unmarshaller, dotFileKey, "")

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -162,7 +162,6 @@ func ServerModule(testMode bool) fx.Option {
 
 // Run is an fx helper function to gracefully start and stop an app container.
 func Run(app *fx.App) {
-	platform.statusRegistry = platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath)
 	// Check for dotflag
 	if platform.unmarshaller != nil {
 		dotfile := config.GetStringValue(platform.unmarshaller, dotFileKey, "")
@@ -186,11 +185,11 @@ func Run(app *fx.App) {
 
 	defer stop(app)
 
-	platform.statusRegistry.SetStatus(status.NewStatus(wrapperspb.String("platform running"), nil))
+	platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath).SetStatus(status.NewStatus(wrapperspb.String("platform running"), nil))
 
 	// Wait for os.Signal
 	<-app.Done()
-	platform.statusRegistry.SetStatus(status.NewStatus(nil, errors.New("platform stopping")))
+	platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath).SetStatus(status.NewStatus(nil, errors.New("platform stopping")))
 }
 
 func stop(app *fx.App) {

--- a/pkg/platform/readiness.go
+++ b/pkg/platform/readiness.go
@@ -28,11 +28,11 @@ type platformReadinessStatusIn struct {
 func platformReadinessStatus(in platformReadinessStatusIn) error {
 	in.Lifecycle.Append(fx.Hook{
 		OnStart: func(context.Context) error {
-			platform.statusRegistry.SetStatus(status.NewStatus(nil, errors.New("platform starting")))
+			platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath).SetStatus(status.NewStatus(nil, errors.New("platform starting")))
 			return nil
 		},
 		OnStop: func(context.Context) error {
-			platform.statusRegistry.SetStatus(status.NewStatus(nil, errors.New("platform stopped")))
+			platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath).SetStatus(status.NewStatus(nil, errors.New("platform stopped")))
 			return nil
 		},
 	})

--- a/pkg/platform/readiness.go
+++ b/pkg/platform/readiness.go
@@ -9,6 +9,11 @@ import (
 	"github.com/fluxninja/aperture/pkg/status"
 )
 
+const (
+	readinessStatusPath = "readiness"
+	platformStatusPath  = "platform"
+)
+
 func platformStatusModule() fx.Option {
 	return fx.Options(
 		fx.Invoke(platformReadinessStatus),

--- a/pkg/platform/readiness.go
+++ b/pkg/platform/readiness.go
@@ -9,11 +9,6 @@ import (
 	"github.com/fluxninja/aperture/pkg/status"
 )
 
-const (
-	readinessStatusPath = "readiness"
-	platformStatusPath  = "platform"
-)
-
 func platformStatusModule() fx.Option {
 	return fx.Options(
 		fx.Invoke(platformReadinessStatus),

--- a/pkg/policies/controlplane/policy-factory.go
+++ b/pkg/policies/controlplane/policy-factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 
 	policylangv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/language/v1"
@@ -17,7 +18,6 @@ import (
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/iface"
 	prom "github.com/fluxninja/aperture/pkg/prometheus"
 	"github.com/fluxninja/aperture/pkg/status"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // policyFactoryModule module for policy factory.
@@ -66,7 +66,7 @@ func providePolicyFactory(
 	policiesStatusRegistry := registry.Child("system", iface.PoliciesRoot)
 	logger := policiesStatusRegistry.GetLogger()
 
-	circuitJobGroup, err := jobs.NewJobGroup(policiesStatusRegistry.Child("jg", "circuit_jobs"), jobs.JobGroupConfig{}, nil)
+	circuitJobGroup, err := jobs.NewJobGroup(policiesStatusRegistry.Child("job-group", "circuit_jobs"), jobs.JobGroupConfig{}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to create job group")
 		return nil, err

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -82,7 +82,7 @@ func (constructor Constructor) setupWatchdog(in WatchdogIn) error {
 		return err
 	}
 
-	watchdogRegistry := in.StatusRegistry.Child("subsystem", "liveness").Child(watchdogJobName, watchdogJobName)
+	watchdogRegistry := in.StatusRegistry.Child("system", "liveness").Child(watchdogJobName, watchdogJobName)
 
 	w := newWatchdog(in.JobGroup, watchdogRegistry, config)
 

--- a/test/readiness_test.go
+++ b/test/readiness_test.go
@@ -1,0 +1,19 @@
+package test
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Readiness", func() {
+	When("it is queried for readiness", func() {
+		It("returns system readiness status", func() {
+			resp, err := http.Get(fmt.Sprintf("http://%v/v1/status", addr))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
+})


### PR DESCRIPTION
### Description of change
- Add platform's readiness status under `/system/readiness/component/platform` path to mark agent as ready
- Rename status paths
  - Rename `subsystem` -> `system`
  - Rename `jg` -> `job-group`
- Add test for platform readiness status

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes
