### PR TITLE
Update readiness test in aperture test suite

### DIFF
--- a/test/readiness_test.go
+++ b/test/readiness_test.go
@@ -2,18 +2,57 @@ package test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	statusv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/status/v1"
 )
 
 var _ = Describe("Readiness", func() {
 	When("it is queried for readiness", func() {
 		It("returns system readiness status", func() {
-			resp, err := http.Get(fmt.Sprintf("http://%v/v1/status", addr))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Eventually(func() bool {
+				resp, err := http.Get(fmt.Sprintf("http://%v/v1/status/system/readiness", addr))
+				if err != nil {
+					return false
+				}
+
+				// get response body
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					return false
+				}
+
+				// unmarshal response body
+				groupStatus := &statusv1.GroupStatus{}
+				err = groupStatus.UnmarshalJSON(body)
+				if err != nil {
+					return false
+				}
+
+				// check if overall group status has not error
+				if groupStatus.Status.Error != nil {
+					return false
+				}
+
+				// check if all component status has no error
+				for _, group := range groupStatus.Groups {
+					if group.Status.Error != nil {
+						return false
+					}
+				}
+
+				// finally check if response status code is 200
+				if resp.StatusCode != http.StatusOK {
+					return false
+				}
+
+				return true
+			}).MustPassRepeatedly(2).WithTimeout(15 * time.Second).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
### Description of change
In this change, we check for components under `/system/readiness` to all be ready. If any of the components are not ready, we fail the test. This check needs to pass 2 times repeatedly before we can pass the test because some of the OTEL components might not be ready yet.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes
