### PR TITLE
Reduce metrics batching time

### DIFF
--- a/plugins/service/aperture-plugin-fluxninja/otel/otel_test.go
+++ b/plugins/service/aperture-plugin-fluxninja/otel/otel_test.go
@@ -154,7 +154,7 @@ func basePluginOTELConfigWithMetrics(pipelineName string) *otelconfig.OTELConfig
 	cfg.AddProcessor("batch/metrics-slow", batchprocessor.Config{
 		SendBatchSize:    10000,
 		SendBatchMaxSize: 10000,
-		Timeout:          10 * time.Second,
+		Timeout:          5 * time.Second,
 	})
 	processors := []string{
 		"batch/metrics-slow",

--- a/plugins/service/aperture-plugin-fluxninja/otel/provide.go
+++ b/plugins/service/aperture-plugin-fluxninja/otel/provide.go
@@ -141,7 +141,7 @@ func addFNToPipeline(
 
 func addMetricsSlowPipeline(baseConfig, config *otelconfig.OTELConfig) {
 	addFluxNinjaPrometheusReceiver(baseConfig, config)
-	config.AddBatchProcessor(processorBatchMetricsSlow, 10*time.Second, 10000, 10000)
+	config.AddBatchProcessor(processorBatchMetricsSlow, 5*time.Second, 10000, 10000)
 	config.Service.AddPipeline("metrics/slow", otelconfig.Pipeline{
 		Receivers: []string{receiverPrometheus},
 		Processors: []string{
@@ -154,7 +154,7 @@ func addMetricsSlowPipeline(baseConfig, config *otelconfig.OTELConfig) {
 
 func addMetricsControllerSlowPipeline(baseConfig, config *otelconfig.OTELConfig) {
 	addFluxNinjaPrometheusReceiver(baseConfig, config)
-	config.AddBatchProcessor(processorBatchMetricsSlow, 10*time.Second, 10000, 10000)
+	config.AddBatchProcessor(processorBatchMetricsSlow, 5*time.Second, 10000, 10000)
 	config.Service.AddPipeline("metrics/controller-slow", otelconfig.Pipeline{
 		Receivers: []string{receiverPrometheus},
 		Processors: []string{


### PR DESCRIPTION
### Description of change
Scrape interval for metrics sent to FN ARC is 10 seconds. Having batching set at the same value (10 seconds) may lead to two data points for the same metrics sent in the same batch and thus rejected.

##### Checklist

- [x] Tested in playground or other setup
