### PR TITLE
Fixed the charts render when helm repo is missing

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -435,14 +435,6 @@ def wrapped_k8s_yaml(yaml, allow_duplicates=False):
     k8s_yaml(yaml, allow_duplicates)
 
 
-def refresh_chart_dependencies(chart_dir):
-    dep_output = local(command=["helm", "dependency", "list"], dir=chart_dir)
-    lines = str(dep_output).splitlines()
-    for number in range(1, len(lines) - 1):
-        if not lines[number].strip().endswith("ok"):
-            local(command=["helm", "dependency", "update"], dir=chart_dir)
-            return
-
 def render_tanka(environment, env_vars, base_dir, namespace, enable_cloud_extension):
     print(
         "Rendering tanka environment",

--- a/playground/scripts/deps_install.sh
+++ b/playground/scripts/deps_install.sh
@@ -50,7 +50,7 @@ for path in "${CHARTS_DIR}"/*; do
 	pushd "$path" >/dev/null
 	echo "Processing $path"
 	if helm dependency list | grep -q missing$; then
-		helm dependency build
+		helm dependency update
 	fi
 	popd >/dev/null
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Bug fix: Fixed the issue with chart rendering when helm repo is missing. 

- Updated `helm dependency build` command to `helm dependency update`.
- Removed unused function `refresh_chart_dependencies`.
<!-- end of auto-generated comment: release notes by openai -->