### PR TITLE
docs: add js-sdk npm link to docs

### DIFF
--- a/docs/content/get-started/integrations/flow-control/sdk/javascript/manual.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/javascript/manual.md
@@ -12,8 +12,9 @@ keywords:
   - manual
 ---
 
-Aperture Javascript SDK can be used to manually set feature Control Points
-within a Javascript service.
+<a href={`https://www.npmjs.com/package/aperture-sdk`}>Aperture Javascript
+SDK</a> can be used to manually set feature Control Points within a Javascript
+service.
 
 To do so, first create an instance of ApertureClient. Agent host and port will
 be read from env variables `FN_AGENT_HOST` and `FN_AGENT_PORT`, defaulting to


### PR DESCRIPTION
### Description of change
Closes https://github.com/fluxninja/aperture/issues/1575

##### Checklist




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Documentation: Added hyperlink to NPM package page for Aperture Javascript SDK in the documentation.
<!-- end of auto-generated comment: release notes by openai -->