### PR TITLE
Update makefile to copy policy CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ operator-manifests: ## Generate WebhookConfiguration, ClusterRole and CustomReso
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:ignoreUnexportedFields=true,allowDangerousTypes=true webhook paths="./operator/..." output:crd:artifacts:config=operator/config/crd/bases output:rbac:artifacts:config=operator/config/rbac output:webhook:artifacts:config=operator/config/webhook
 	cp ./operator/config/crd/bases/fluxninja.com_agents.yaml ./manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
 	cp ./operator/config/crd/bases/fluxninja.com_controllers.yaml ./manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+	cp ./operator/config/crd/bases/fluxninja.com_policies.yaml ./manifests/charts/aperture-controller/crds/fluxninja.com_policies.yaml
 	./operator/hack/create_policy_sample.sh
 
 .PHONY: operator-generate


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

**Purpose:** This pull request adds a new feature to the Makefile that copies policy CRD. 

- New Feature: Adds support for copying policy CRD in the Makefile.
<!-- end of auto-generated comment: release notes by openai -->