### PR TITLE
Use per-cmd build-config.yaml in Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,4 @@
 !api
 !operator
 !tools
-!*.yaml
+!cmd/*/build-config.yaml

--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -14,8 +14,10 @@ ENV APERTURECTL_BUILD_GIT_BRANCH=${APERTURECTL_BUILD_GIT_BRANCH}
 ARG APERTURECTL_BUILD_FLAGS
 ENV APERTURECTL_BUILD_FLAGS=${APERTURECTL_BUILD_FLAGS}
 
-# if config.yaml doesn't exist, create empty config.yaml
-RUN if [ ! -f "config.yaml" ]; then touch config.yaml; fi
+ENV CONFIG_FILE=cmd/aperture-agent/build-config.yaml
+
+# if build-config.yaml doesn't exist, create empty build-config.yaml
+RUN if [ ! -f "${CONFIG_FILE}" ]; then touch "${CONFIG_FILE}"; fi
 
 RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.cache/go-build/,id=agent-1.19.6,sharing=private \
@@ -23,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg/ \
   /bin/bash -c \
   'go mod download; \
   go build -o cmd/aperturectl/aperturectl ./cmd/aperturectl; \
-  ./cmd/aperturectl/aperturectl build agent -c ./config.yaml -o / --uri .; \
+  ./cmd/aperturectl/aperturectl build agent -o / --uri . -c "${CONFIG_FILE}"; \
   '
 
 # Final image

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -14,8 +14,10 @@ ENV APERTURECTL_BUILD_GIT_BRANCH=${APERTURECTL_BUILD_GIT_BRANCH}
 ARG APERTURECTL_BUILD_FLAGS
 ENV APERTURECTL_BUILD_FLAGS=${APERTURECTL_BUILD_FLAGS}
 
-# if config.yaml doesn't exist, create empty config.yaml
-RUN if [ ! -f "config.yaml" ]; then touch config.yaml; fi
+ENV CONFIG_FILE=cmd/aperture-agent/build-config.yaml
+
+# if build-config.yaml doesn't exist, create empty build-config.yaml
+RUN if [ ! -f "${CONFIG_FILE}" ]; then touch "${CONFIG_FILE}"; fi
 
 RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.cache/go-build/,id=controller-1.19.6,sharing=private \
@@ -23,7 +25,7 @@ RUN --mount=type=cache,target=/go/pkg/ \
   /bin/bash -c \
   'go mod download; \
   go build -o cmd/aperturectl/aperturectl ./cmd/aperturectl; \
-  ./cmd/aperturectl/aperturectl build controller -c ./config.yaml -o / --uri .; \
+  ./cmd/aperturectl/aperturectl build controller -o / --uri . -c "${CONFIG_FILE}"; \
   '
 
 # Final image


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

This pull request updates the Dockerfiles to use `build-config.yaml` instead of `config.yaml`. It also modifies the `.dockerignore` file to include `cmd/*/build-config.yaml` and exclude `*.yaml`. This change is a `Chore` that improves the build process.
<!-- end of auto-generated comment: release notes by openai -->