### PR TITLE
Restore build.sh in info package

### DIFF
--- a/pkg/info/build.sh
+++ b/pkg/info/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -eux
+
+# This script builds a Go binary and injects build-time variables.
+# TODO: it should be used in every Dockerfile requiring version endpoint.
+
+VERSION=${VERSION:-0.0.1}
+BUILD_TIME=${BUILD_TIME:-$(date -Iseconds)}
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+HOSTNAME=$(hostname)
+PREFIX="${PREFIX:-aperture}"
+
+SERVICE_FILE=$(basename -- "${TARGET}")
+SERVICE="${SERVICE_FILE%.*}"
+
+LDFLAGS="\
+    ${LDFLAGS:-} \
+    -X 'github.com/fluxninja/aperture/pkg/info.Version=${VERSION}' \
+    -X 'github.com/fluxninja/aperture/pkg/info.Service=${SERVICE}' \
+    -X 'github.com/fluxninja/aperture/pkg/info.BuildHost=${HOSTNAME}' \
+    -X 'github.com/fluxninja/aperture/pkg/info.BuildOS=${GOOS}/${GOARCH}' \
+    -X 'github.com/fluxninja/aperture/pkg/info.BuildTime=${BUILD_TIME}' \
+    -X 'github.com/fluxninja/aperture/pkg/info.GitBranch=${GIT_BRANCH}' \
+    -X 'github.com/fluxninja/aperture/pkg/info.GitCommitHash=${GIT_COMMIT_HASH}' \
+    -X 'github.com/fluxninja/aperture/pkg/info.Prefix=${PREFIX}' \
+"
+
+if [ -n "${RACE:-}" ]; then
+	build_args=(-race)
+fi
+
+build_args+=(
+	--ldflags "${LDFLAGS}"
+	-o "${TARGET}"
+	"${SOURCE}"
+)
+
+go build "${build_args[@]}"


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

This pull request adds a script to build a Go binary and inject build-time variables, which is used in every Dockerfile requiring version endpoint. 

- Chore: Adds `build.sh` script for building Go binaries with build-time variables.
<!-- end of auto-generated comment: release notes by openai -->