### PR TITLE
Fix Aperture Version build arg

### DIFF
--- a/.circleci/scripts/docker_build.sh
+++ b/.circleci/scripts/docker_build.sh
@@ -68,7 +68,7 @@ build_args=(
 	"$DOCKER_TAGS_ARG"
 	"--build-arg=APERTURECTL_GIT_BRANCH=$PARAM_GIT_BRANCH"
 	"--build-arg=APERTURECTL_GIT_COMMIT_HASH=$PARAM_GIT_COMMIT_HASH"
-	"--build-arg=APERTURECTL_VERSION=$(fetch_aperture_version)"
+	"--build-arg=APERTURECTL_BUILD_VERSION=$(fetch_aperture_version)"
 )
 
 if [ -n "$PARAM_SSH_FORWARD" ]; then

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 !operator
 !tools
 !cmd/*/build-config.yaml
+!scripts/build_aperturectl.sh

--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.aperturectl,id=agent-1.20.2,sharing=private \
   /bin/bash -c \
   'go mod download; \
-  go build -o cmd/aperturectl/aperturectl ./cmd/aperturectl; \
+  ./scripts/build_aperturectl.sh ./cmd/aperturectl; \
   ./cmd/aperturectl/aperturectl build agent -o / --uri .; \
   '
 

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.aperturectl,id=controller-1.20.2,sharing=private \
   /bin/bash -c \
   'go mod download; \
-  go build -o cmd/aperturectl/aperturectl ./cmd/aperturectl; \
+  ./scripts/build_aperturectl.sh ./cmd/aperturectl; \
   ./cmd/aperturectl/aperturectl build controller -o / --uri .; \
   '
 

--- a/pkg/config/koanf-unmarshaller.go
+++ b/pkg/config/koanf-unmarshaller.go
@@ -320,7 +320,7 @@ func (u *KoanfUnmarshaller) bindEnvsKey(keyPrefix string, in interface{}, prev .
 				reg := regexp.MustCompile(`^\[(.*)\]$`)
 				matches := reg.FindStringSubmatch(val)
 				if len(matches) != 2 {
-					return
+					break
 				}
 				if matches[1] == "" {
 					v, err = nil, errors.New("empty slice provided in env var")

--- a/pkg/otelcollector/rollupprocessor/processor_test.go
+++ b/pkg/otelcollector/rollupprocessor/processor_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Rollup processor", func() {
 		JustBeforeEach(func() {
 			var err error
 			logsProcessor, err = CreateLogsProcessor(
-				context.TODO(), processor.CreateSettings{}, config, testConsumer)
+				context.Background(), processor.CreateSettings{}, config, testConsumer)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -62,7 +62,7 @@ var _ = Describe("Rollup processor", func() {
 			logRecord.Attributes().PutStr(otelconsts.ApertureSourceLabel, otelconsts.ApertureSourceEnvoy)
 			logRecord.Attributes().PutStr(otelconsts.WorkloadDurationLabel, strconv.Itoa(attributeValues[0]))
 
-			err = logsProcessor.ConsumeLogs(context.TODO(), input)
+			err = logsProcessor.ConsumeLogs(context.Background(), input)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(testConsumer.receivedLogs).To(HaveLen(1))
@@ -93,7 +93,7 @@ var _ = Describe("Rollup processor", func() {
 			logRecord = logs.AppendEmpty()
 			logRecord.Attributes().PutStr(otelconsts.HTTPRequestContentLength, strconv.Itoa(1234))
 
-			err = logsProcessor.ConsumeLogs(context.TODO(), input)
+			err = logsProcessor.ConsumeLogs(context.Background(), input)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(testConsumer.receivedLogs).To(HaveLen(1))
@@ -121,7 +121,7 @@ var _ = Describe("Rollup processor", func() {
 				logRecord.Attributes().PutStr("high-cardinality", strconv.Itoa(i))
 			}
 
-			err := logsProcessor.ConsumeLogs(context.TODO(), input)
+			err := logsProcessor.ConsumeLogs(context.Background(), input)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(testConsumer.receivedLogs).To(HaveLen(1))

--- a/scripts/build_aperturectl.sh
+++ b/scripts/build_aperturectl.sh
@@ -9,8 +9,10 @@ GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 HOSTNAME=$(hostname)
 
-APERTURECTL_BUILD_GIT_BRANCH=${APERTURECTL_BUILD_GIT_BRANCH:-$(git branch --show-current)}
-APERTURECTL_BUILD_GIT_COMMIT_HASH=${APERTURECTL_BUILD_GIT_COMMIT_HASH:-$(git log -n1 --format=%H)}
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  APERTURECTL_BUILD_GIT_BRANCH=${APERTURECTL_BUILD_GIT_BRANCH:-$(git branch --show-current)}
+  APERTURECTL_BUILD_GIT_COMMIT_HASH=${APERTURECTL_BUILD_GIT_COMMIT_HASH:-$(git log -n1 --format=%H)}
+fi
 
 LDFLAGS="\
     ${LDFLAGS:-} \

--- a/scripts/build_aperturectl.sh
+++ b/scripts/build_aperturectl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-APERTURECTL_DIR=$(git rev-parse --show-toplevel)/cmd/aperturectl
+APERTURECTL_DIR=${1:-$(git rev-parse --show-toplevel)/cmd/aperturectl}
 
 APERTURECTL_BUILD_VERSION=${APERTURECTL_BUILD_VERSION:-0.0.1}
 BUILD_TIME=${BUILD_TIME:-$(date -Iseconds)}


### PR DESCRIPTION
### Description of change
Aperture Agent/Controller version was not properly passed to the Docker image.

Also, this PR changes `context.TODO` to `context.Background` in OTEL tests. This changes is used as trigger to build new Aperture images with proper versions.

##### Checklist

- [x] Tested in playground or other setup






















<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

This pull request fixes the Aperture Agent/Controller version that was not properly passed to the Docker image. Additionally, it changes `context.TODO` to `context.Background` in OTEL tests, which triggers building new Aperture images with proper versions.

- Bug fix: Fixed Aperture Agent/Controller version not being properly passed to Docker image.
- Test: Replaced `context.TODO()` with `context.Background()` in OTEL tests.
- Chore: Added support for passing directory path as argument and added check for git directory before setting git branch and commit hash in `scripts/build_aperturectl.sh`.
<!-- end of auto-generated comment: release notes by openai -->