### PR TITLE
Export metrics for with pod count

### DIFF
--- a/pkg/discovery/kubernetes/provide.go
+++ b/pkg/discovery/kubernetes/provide.go
@@ -4,11 +4,13 @@ package kubernetes
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 
 	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/discovery/common"
 	"github.com/fluxninja/aperture/pkg/discovery/entities"
+	"github.com/fluxninja/aperture/pkg/etcd/election"
 	"github.com/fluxninja/aperture/pkg/k8s"
 	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/fluxninja/aperture/pkg/status"
@@ -34,11 +36,13 @@ func Module() fx.Option {
 // FxInSvc describes parameters passed to k8s discovery constructor.
 type FxInSvc struct {
 	fx.In
-	Unmarshaller     config.Unmarshaller
-	Lifecycle        fx.Lifecycle
-	StatusRegistry   status.Registry
-	KubernetesClient k8s.K8sClient
-	EntityTrackers   *entities.EntityTrackers
+	Unmarshaller       config.Unmarshaller
+	Lifecycle          fx.Lifecycle
+	StatusRegistry     status.Registry
+	KubernetesClient   k8s.K8sClient
+	EntityTrackers     *entities.EntityTrackers
+	PrometheusRegistry *prometheus.Registry
+	Election           *election.Election `optional:"true"`
 }
 
 // InvokeServiceDiscovery creates a Kubernetes service discovery.
@@ -59,7 +63,7 @@ func InvokeServiceDiscovery(in FxInSvc) error {
 		return nil
 	}
 	entityEvents := in.EntityTrackers.RegisterServiceDiscovery(podTrackerPrefix)
-	ksd, err := newServiceDiscovery(entityEvents, in.KubernetesClient)
+	ksd, err := newServiceDiscovery(entityEvents, in.KubernetesClient, in.PrometheusRegistry, in.Election)
 	if err != nil {
 		log.Info().Err(err).Msg("Failed to create Kubernetes service discovery")
 		return err

--- a/pkg/discovery/kubernetes/service-discovery.go
+++ b/pkg/discovery/kubernetes/service-discovery.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/conc/stream"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -14,8 +15,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	entitiesv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/discovery/entities/v1"
+	"github.com/fluxninja/aperture/pkg/etcd/election"
 	"github.com/fluxninja/aperture/pkg/k8s"
 	"github.com/fluxninja/aperture/pkg/log"
+	"github.com/fluxninja/aperture/pkg/metrics"
 	"github.com/fluxninja/aperture/pkg/notifiers"
 	"github.com/fluxninja/aperture/pkg/utils"
 )
@@ -31,16 +34,41 @@ type serviceDiscovery struct {
 	cancel          context.CancelFunc
 	serviceStream   *stream.Stream
 	clusterDomain   string
+
+	podCounter *prometheus.GaugeVec
+	election   *election.Election
 }
 
 func newServiceDiscovery(
 	entityEvents notifiers.EventWriter,
 	k8sClient k8s.K8sClient,
+	pr *prometheus.Registry,
+	election *election.Election,
 ) (*serviceDiscovery, error) {
 	kd := &serviceDiscovery{
 		cli:           k8sClient.GetClientSet(),
 		entityEvents:  entityEvents,
 		serviceStream: stream.New(),
+		election:      election,
+	}
+	if kd.election != nil && kd.election.IsLeader() {
+		defaultLabels := []string{
+			metrics.K8sNamespaceName, metrics.K8sNodeName, metrics.K8sStatus,
+			metrics.K8sCronjobName, metrics.K8sDaemonsetName, metrics.K8sDeploymentName, metrics.K8sJobName, metrics.K8sReplicasetName, metrics.K8sStatefulsetName,
+		}
+		podCounter := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: metrics.K8sPodCount,
+			Help: "The number of pods",
+		}, defaultLabels)
+		err := pr.Register(podCounter)
+		if err != nil {
+			// Ignore already registered error, as this is not harmful. Metrics may
+			// be registered by other running server.
+			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+				return nil, fmt.Errorf("couldn't register prometheus metrics: %w", err)
+			}
+		}
+		kd.podCounter = podCounter
 	}
 	kd.informerFactory = informers.NewSharedInformerFactory(kd.cli, 0)
 	kd.ctx, kd.cancel = context.WithCancel(context.Background())
@@ -55,7 +83,7 @@ func (kd *serviceDiscovery) start(startCtx context.Context) error {
 		return err
 	}
 	kd.clusterDomain = clusterDomain
-
+	var informerSynced []cache.InformerSynced
 	endpointsInformer := kd.informerFactory.Core().V1().Endpoints().Informer()
 	_, err = endpointsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    kd.handleEndpointsAdd,
@@ -65,7 +93,7 @@ func (kd *serviceDiscovery) start(startCtx context.Context) error {
 	if err != nil {
 		return err
 	}
-
+	informerSynced = append(informerSynced, endpointsInformer.HasSynced)
 	serviceInformer := kd.informerFactory.Core().V1().Services().Informer()
 	_, err = serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    kd.handleServiceAdd,
@@ -74,10 +102,22 @@ func (kd *serviceDiscovery) start(startCtx context.Context) error {
 	if err != nil {
 		return err
 	}
-
+	informerSynced = append(informerSynced, serviceInformer.HasSynced)
+	if kd.election != nil && kd.election.IsLeader() {
+		podInformer := kd.informerFactory.Core().V1().Pods().Informer()
+		_, err = podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    kd.handlePodAdd,
+			UpdateFunc: kd.handlePodUpdate,
+			DeleteFunc: kd.handlePodDelete,
+		})
+		if err != nil {
+			return err
+		}
+		informerSynced = append(informerSynced, podInformer.HasSynced)
+	}
 	kd.informerFactory.Start(kd.ctx.Done())
 
-	if !cache.WaitForCacheSync(startCtx.Done(), endpointsInformer.HasSynced, serviceInformer.HasSynced) {
+	if !cache.WaitForCacheSync(startCtx.Done(), informerSynced...) {
 		return errors.New("timed out waiting for caches to sync")
 	}
 
@@ -265,7 +305,66 @@ func (kd *serviceDiscovery) updateEntity(pod *entitiesv1.Entity) error {
 	return nil
 }
 
+func (kd *serviceDiscovery) handlePodAdd(obj any) {
+	pod := obj.(*v1.Pod)
+	labels := podLabels(pod)
+
+	podCounter, err := kd.podCounter.GetMetricWith(labels)
+	if err != nil {
+		log.Debug().Msgf("Could not extract request counter metric from registry: %v", err)
+		return
+	}
+	podCounter.Inc()
+}
+
+func (kd *serviceDiscovery) handlePodDelete(obj any) {
+	pod := obj.(*v1.Pod)
+	newPod := pod.DeepCopy()
+	newPod.Status.Phase = v1.PodSucceeded
+	kd.handlePodUpdate(pod, newPod)
+}
+
+func (kd *serviceDiscovery) handlePodUpdate(oldObj, newObj any) {
+	oldPod := oldObj.(*v1.Pod)
+	newPod := newObj.(*v1.Pod)
+
+	if oldPod.Status.Phase != newPod.Status.Phase || oldPod.Spec.NodeName != newPod.Spec.NodeName {
+		oldPodCounter, errOld := kd.podCounter.GetMetricWith(podLabels(oldPod))
+		newPodCounter, errNew := kd.podCounter.GetMetricWith(podLabels(newPod))
+		if errOld != nil {
+			log.Error().Msgf("Could not extract request counter metric from registry: %v", errOld)
+			return
+		}
+		if errNew != nil {
+			log.Error().Msgf("Could not extract request counter metric from registry: %v", errNew)
+			return
+		}
+		oldPodCounter.Dec()
+		newPodCounter.Inc()
+	}
+}
+
 /* Helper functions */
+
+func podLabels(pod *v1.Pod) map[string]string {
+	labels := map[string]string{
+		metrics.K8sNamespaceName:   pod.Namespace,
+		metrics.K8sNodeName:        pod.Spec.NodeName,
+		metrics.K8sStatus:          string(pod.Status.Phase),
+		metrics.K8sCronjobName:     "",
+		metrics.K8sDaemonsetName:   "",
+		metrics.K8sDeploymentName:  "",
+		metrics.K8sJobName:         "",
+		metrics.K8sReplicasetName:  "",
+		metrics.K8sStatefulsetName: "",
+	}
+	owners := pod.GetObjectMeta().GetOwnerReferences()
+	for _, owner := range owners {
+		kind := strings.ToLower(owner.Kind)
+		labels[fmt.Sprintf("k8s_%s_name", kind)] = owner.Name
+	}
+	return labels
+}
 
 func getClusterIPsFromService(svc *v1.Service) []string {
 	if svc.Spec.Type != v1.ServiceTypeClusterIP {

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -152,4 +152,27 @@ const (
 	DefaultWorkloadIndex = "default"
 	// DefaultAgentGroup - default agent group.
 	DefaultAgentGroup = "default"
+
+	// K8S METRICS.
+
+	// K8sPodCount - number of pods in the cluster.
+	K8sPodCount = "k8s_pod_count"
+	// K8sNamespaceName - namespace of a resource.
+	K8sNamespaceName = "k8s_namespace_name"
+	// K8sNodeName - name of a node.
+	K8sNodeName = "k8s_node_name"
+	// K8sStatus - status of a resource.
+	K8sStatus = "k8s_status"
+	// K8sReplicasetName - name of a replicaset.
+	K8sReplicasetName = "k8s_replicaset_name"
+	// K8sDaemonsetName - name of a daemonset.
+	K8sDaemonsetName = "k8s_daemonset_name"
+	// K8sStatefulsetName - name of a statefulset.
+	K8sStatefulsetName = "k8s_statefulset_name"
+	// K8sJobName - name of a job.
+	K8sJobName = "k8s_job_name"
+	// K8sCronjobName - name of a cronjob.
+	K8sCronjobName = "k8s_cronjob_name"
+	// K8sDeploymentName - name of a deployment.
+	K8sDeploymentName = "k8s_deployment_name"
 )


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

New Feature: This pull request adds the ability to export metrics for pod count in Kubernetes clusters. Users can now monitor their clusters more effectively with this new feature. Various Kubernetes metrics such as namespace name, node name, status, replicaset name, daemonset name, statefulset name, job name, cronjob name, and deployment name have also been added.
<!-- end of auto-generated comment: release notes by openai -->