### PR TITLE
Revert "Export metrics for with pod count"

### DIFF
--- a/pkg/discovery/kubernetes/provide.go
+++ b/pkg/discovery/kubernetes/provide.go
@@ -4,13 +4,11 @@ package kubernetes
 import (
 	"context"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 
 	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/discovery/common"
 	"github.com/fluxninja/aperture/pkg/discovery/entities"
-	"github.com/fluxninja/aperture/pkg/etcd/election"
 	"github.com/fluxninja/aperture/pkg/k8s"
 	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/fluxninja/aperture/pkg/status"
@@ -36,13 +34,11 @@ func Module() fx.Option {
 // FxInSvc describes parameters passed to k8s discovery constructor.
 type FxInSvc struct {
 	fx.In
-	Unmarshaller       config.Unmarshaller
-	Lifecycle          fx.Lifecycle
-	StatusRegistry     status.Registry
-	KubernetesClient   k8s.K8sClient
-	EntityTrackers     *entities.EntityTrackers
-	PrometheusRegistry *prometheus.Registry
-	Election           *election.Election `optional:"true"`
+	Unmarshaller     config.Unmarshaller
+	Lifecycle        fx.Lifecycle
+	StatusRegistry   status.Registry
+	KubernetesClient k8s.K8sClient
+	EntityTrackers   *entities.EntityTrackers
 }
 
 // InvokeServiceDiscovery creates a Kubernetes service discovery.
@@ -63,7 +59,7 @@ func InvokeServiceDiscovery(in FxInSvc) error {
 		return nil
 	}
 	entityEvents := in.EntityTrackers.RegisterServiceDiscovery(podTrackerPrefix)
-	ksd, err := newServiceDiscovery(entityEvents, in.KubernetesClient, in.PrometheusRegistry, in.Election)
+	ksd, err := newServiceDiscovery(entityEvents, in.KubernetesClient)
 	if err != nil {
 		log.Info().Err(err).Msg("Failed to create Kubernetes service discovery")
 		return err

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -152,27 +152,4 @@ const (
 	DefaultWorkloadIndex = "default"
 	// DefaultAgentGroup - default agent group.
 	DefaultAgentGroup = "default"
-
-	// K8S METRICS.
-
-	// K8sPodCount - number of pods in the cluster.
-	K8sPodCount = "k8s_pod_count"
-	// K8sNamespaceName - namespace of a resource.
-	K8sNamespaceName = "k8s_namespace_name"
-	// K8sNodeName - name of a node.
-	K8sNodeName = "k8s_node_name"
-	// K8sStatus - status of a resource.
-	K8sStatus = "k8s_status"
-	// K8sReplicasetName - name of a replicaset.
-	K8sReplicasetName = "k8s_replicaset_name"
-	// K8sDaemonsetName - name of a daemonset.
-	K8sDaemonsetName = "k8s_daemonset_name"
-	// K8sStatefulsetName - name of a statefulset.
-	K8sStatefulsetName = "k8s_statefulset_name"
-	// K8sJobName - name of a job.
-	K8sJobName = "k8s_job_name"
-	// K8sCronjobName - name of a cronjob.
-	K8sCronjobName = "k8s_cronjob_name"
-	// K8sDeploymentName - name of a deployment.
-	K8sDeploymentName = "k8s_deployment_name"
 )


### PR DESCRIPTION
Reverts fluxninja/aperture#1588

While we discuss the trade-offs of making this change.

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Revert: This pull request reverts a previous change while discussing its trade-offs. The changes include removing unused imports and dependencies, removing Prometheus registry and election dependency from FxInSvc, updating newServiceDiscovery function call, removing podCounter and election fields, and removing k8s metrics constants.
<!-- end of auto-generated comment: release notes by openai -->