### PR TITLE
Fix packaging releases

### DIFF
--- a/.circleci/post-release.yaml
+++ b/.circleci/post-release.yaml
@@ -91,6 +91,7 @@ jobs:
       GOARCH: <<parameters.goarch>>
       COMPONENT: <<parameters.component>>
       VERSION: <<parameters.tag>>
+      APERTURECTL_BUILD_VERSION: <<parameters.tag>>
     steps:
       - checkout
       - asdf_install:
@@ -256,7 +257,7 @@ jobs:
             git diff
             git add .
             git commit -m "${msg}"
-            git push origin "${branch}"
+            git push --set-upstream origin "${branch}"
             gh pr create --title "${msg}" --body "" --label "pr-pull"
 
 workflows:

--- a/.circleci/scripts/compile.sh
+++ b/.circleci/scripts/compile.sh
@@ -13,13 +13,13 @@ export PATH="$PATH:$GOPATH/bin"
 
 : "${APERTURECTL_BUILD_VERSION?APERTURECTL_BUILD_VERSION needs to be set}"
 
+aperturectl="$(./scripts/build_aperturectl.sh)"
+
 case "${1:-}" in
 agent)
-	aperturectl="$(./scripts/build_aperturectl.sh)"
 	"$aperturectl" build agent --output-dir ./dist --uri .
 	;;
 cli)
-	aperturectl="$(./scripts/build_aperturectl.sh)"
 	mkdir -p ./dist
 	cp "$aperturectl" ./dist/aperturectl
 	;;


### PR DESCRIPTION
Sets correct env var for compiling the binary for NFPM


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Release Notes**

This pull request fixes packaging releases by setting the correct environment variable for compiling the binary for NFPM. It also updates the `git push` command with the `--set-upstream` flag. This is a bug fix that ensures the binary is compiled correctly and can be packaged for release.
<!-- end of auto-generated comment: release notes by openai -->