### PR TITLE
Fixed an issue of builds not getting commit and branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@
 !tools
 !cmd/*/build-config.yaml
 !scripts/build_aperturectl.sh
+!.git

--- a/cmd/aperturectl/cmd/build/build.go
+++ b/cmd/aperturectl/cmd/build/build.go
@@ -364,8 +364,8 @@ func getLdFlags(service string) (string, error) {
 		return "", err
 	}
 
-	// if builderDir is a git project, find the git commit hash and branch
-	if cfg.Build.GitCommitHash != "" && cfg.Build.GitBranch != "" {
+	// if builderDir is a git project, find the git commit hash
+	if cfg.Build.GitCommitHash == "" {
 		// git commit is 'git rev-parse HEAD'
 		gitCommit := exec.Command("git", "rev-parse", "HEAD")
 		gitCommit.Dir = builderDir
@@ -375,6 +375,10 @@ func getLdFlags(service string) (string, error) {
 		} else {
 			cfg.Build.GitCommitHash = strings.TrimSpace(string(gitCommitOut))
 		}
+	}
+
+	// if builderDir is a git project, find the git branch
+	if cfg.Build.GitBranch == "" {
 		// git branch is 'git rev-parse --abbrev-ref HEAD'
 		gitBranch := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 		gitBranch.Dir = builderDir


### PR DESCRIPTION
### Description of change

We were checking non-empty so even when we pass commit and branch, it was setting them to unknown as the .git directory was not copied and the git command was throwing errors.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Bug fix: Fixed an issue where builds were not getting the correct commit and branch information due to errors thrown by the git command. The changes include updating the `getLdFlags` function to find the git commit hash and branch separately, and adding `.git` to the list of files that should not be ignored by Docker.
<!-- end of auto-generated comment: release notes by openai -->