### PR TITLE
docs: Remove swagger directives from docs

### DIFF
--- a/cmd/aperture-agent/agent.go
+++ b/cmd/aperture-agent/agent.go
@@ -7,7 +7,7 @@
 //
 //	BasePath: /aperture-agent
 //
-// swagger:meta
+//swagger:meta
 package main
 
 import (

--- a/cmd/aperture-agent/config/types.go
+++ b/cmd/aperture-agent/config/types.go
@@ -8,7 +8,7 @@ import (
 	otelconfig "github.com/fluxninja/aperture/pkg/otelcollector/config"
 )
 
-// swagger:operation POST /otel agent-configuration OTEL
+//swagger:operation POST /otel agent-configuration OTEL
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -17,8 +17,9 @@ import (
 //     "$ref": "#/definitions/AgentOTELConfig"
 
 // AgentOTELConfig is the configuration for Agent's OTEL collector.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type AgentOTELConfig struct {
 	otelconfig.CommonOTELConfig `json:",inline"`
 	// BatchPrerollup configures batch prerollup processor.
@@ -34,8 +35,9 @@ type AgentOTELConfig struct {
 }
 
 // BatchPrerollupConfig defines configuration for OTEL batch processor.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type BatchPrerollupConfig struct {
 	// Timeout sets the time after which a batch will be sent regardless of size.
 	Timeout config.Duration `json:"timeout" validate:"gt=0" default:"10s"`
@@ -49,8 +51,9 @@ type BatchPrerollupConfig struct {
 }
 
 // BatchPostrollupConfig defines configuration for OTEL batch processor.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type BatchPostrollupConfig struct {
 	// Timeout sets the time after which a batch will be sent regardless of size.
 	Timeout config.Duration `json:"timeout" validate:"gt=0" default:"1s"`
@@ -65,8 +68,9 @@ type BatchPostrollupConfig struct {
 
 // CustomMetricsConfig defines receivers, processors and single metrics pipeline,
 // which will be exported to the controller prometheus.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type CustomMetricsConfig struct {
 	// Receivers define receivers to be used in custom metrics pipelines. This should
 	// be in OTEL format - https://opentelemetry.io/docs/collector/configuration/#receivers.
@@ -116,8 +120,9 @@ func (in *Components) DeepCopy() *Components {
 }
 
 // CustomMetricsPipelineConfig defines a custom metrics pipeline.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type CustomMetricsPipelineConfig struct {
 	Receivers  []string `json:"receivers"`
 	Processors []string `json:"processors"`

--- a/cmd/aperture-controller/config/types.go
+++ b/cmd/aperture-controller/config/types.go
@@ -5,7 +5,7 @@ import (
 	otelconfig "github.com/fluxninja/aperture/pkg/otelcollector/config"
 )
 
-// swagger:operation POST /otel controller-configuration OTEL
+//swagger:operation POST /otel controller-configuration OTEL
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -14,8 +14,9 @@ import (
 //     "$ref": "#/definitions/ControllerOTELConfig"
 
 // ControllerOTELConfig is the configuration for Agent's OTEL collector.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ControllerOTELConfig struct {
 	otelconfig.CommonOTELConfig `json:",inline"`
 }

--- a/cmd/aperture-controller/controller.go
+++ b/cmd/aperture-controller/controller.go
@@ -7,7 +7,7 @@
 //
 //	BasePath: /aperture-controller
 //
-// swagger:meta
+//swagger:meta
 package main
 
 import (

--- a/extensions/fluxninja/extconfig/config-operations.go
+++ b/extensions/fluxninja/extconfig/config-operations.go
@@ -1,6 +1,6 @@
 package extconfig
 
-// swagger:operation POST /fluxninja extension-configuration FluxNinjaExtension
+//swagger:operation POST /fluxninja extension-configuration FluxNinjaExtension
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -15,8 +15,9 @@ const (
 )
 
 // FluxNinjaExtensionConfig is the configuration for FluxNinja ARC integration.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type FluxNinjaExtensionConfig struct {
 	// Interval between each heartbeat.
 	HeartbeatInterval config.Duration `json:"heartbeat_interval" validate:"gte=0s" default:"5s"`
@@ -29,8 +30,9 @@ type FluxNinjaExtensionConfig struct {
 }
 
 // ClientConfig is the client configuration.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ClientConfig struct {
 	// HTTP client settings.
 	HTTPClient http.HTTPClientConfig `json:"http"`

--- a/extensions/fluxninja/fluxninja.go
+++ b/extensions/fluxninja/fluxninja.go
@@ -3,7 +3,7 @@
 
 // FluxNinja ARC Extension
 //   BasePath: /aperture-controller
-// swagger:meta
+//swagger:meta
 
 package fluxninja
 

--- a/extensions/sentry/config-operations.go
+++ b/extensions/sentry/config-operations.go
@@ -1,6 +1,6 @@
 package sentry
 
-// swagger:operation POST /sentry extension-configuration SentryExtension
+//swagger:operation POST /sentry extension-configuration SentryExtension
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/extensions/sentry/provide.go
+++ b/extensions/sentry/provide.go
@@ -19,8 +19,9 @@ import (
 )
 
 // SentryConfig holds configuration for Sentry.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type SentryConfig struct {
 	// If DSN is not set, the client is effectively disabled
 	// You can set test project's dsn to send log events.

--- a/extensions/sentry/sentry.go
+++ b/extensions/sentry/sentry.go
@@ -3,7 +3,7 @@
 
 // Sentry Extension
 //   BasePath: /aperture-controller
-// swagger:meta
+//swagger:meta
 
 package sentry
 

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -960,7 +960,7 @@ spec:
                       clients:
                         items:
                           description: AlertManagerClientConfig config for single
-                            alertmanager client. swagger:model AlertManagerClientConfig
+                            alertmanager client.
                           properties:
                             address:
                               type: string
@@ -968,7 +968,7 @@ spec:
                               type: string
                             http_client:
                               description: HTTPClientConfig holds configuration for
-                                HTTP Client. swagger:model
+                                HTTP Client.
                               properties:
                                 disable_compression:
                                   description: Disable Compression
@@ -1424,7 +1424,7 @@ spec:
                         description: Log writers
                         items:
                           description: LogWriterConfig holds configuration for a log
-                            writer. swagger:model
+                            writer.
                           properties:
                             compress:
                               description: Compress
@@ -1525,7 +1525,7 @@ spec:
                         additionalProperties:
                           description: CustomMetricsConfig defines receivers, processors
                             and single metrics pipeline, which will be exported to
-                            the controller prometheus. swagger:model
+                            the controller prometheus.
                           properties:
                             pipeline:
                               description: Pipeline is an OTEL metrics pipeline definition,
@@ -1823,13 +1823,13 @@ spec:
                       cgroup:
                         description: WatchdogPolicyType holds configuration Watchdog
                           Policy algorithms. If both algorithms are configured then
-                          only watermark algorithm is used. swagger:model WatchdogPolicyType
+                          only watermark algorithm is used.
                         properties:
                           adaptive_policy:
                             description: AdaptivePolicy creates a policy that forces
                               GC when the usage surpasses the configured factor of
                               the available memory. This policy calculates next target
-                              as usage+(limit-usage)*factor. swagger:model
+                              as usage+(limit-usage)*factor.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1841,7 +1841,7 @@ spec:
                             type: object
                           watermarks_policy:
                             description: WatermarksPolicy creates a Watchdog policy
-                              that schedules GC at concrete watermarks. swagger:model
+                              that schedules GC at concrete watermarks.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1858,13 +1858,12 @@ spec:
                         type: object
                       heap:
                         description: HeapConfig holds configuration for heap Watchdog.
-                          swagger:model
                         properties:
                           adaptive_policy:
                             description: AdaptivePolicy creates a policy that forces
                               GC when the usage surpasses the configured factor of
                               the available memory. This policy calculates next target
-                              as usage+(limit-usage)*factor. swagger:model
+                              as usage+(limit-usage)*factor.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1886,7 +1885,7 @@ spec:
                             type: integer
                           watermarks_policy:
                             description: WatermarksPolicy creates a Watchdog policy
-                              that schedules GC at concrete watermarks. swagger:model
+                              that schedules GC at concrete watermarks.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1902,7 +1901,7 @@ spec:
                             type: object
                         type: object
                       job:
-                        description: JobConfig is config for Job swagger:model
+                        description: JobConfig is config for Job
                         properties:
                           execution_period:
                             description: Time period between job executions. Zero
@@ -1919,13 +1918,13 @@ spec:
                       system:
                         description: WatchdogPolicyType holds configuration Watchdog
                           Policy algorithms. If both algorithms are configured then
-                          only watermark algorithm is used. swagger:model WatchdogPolicyType
+                          only watermark algorithm is used.
                         properties:
                           adaptive_policy:
                             description: AdaptivePolicy creates a policy that forces
                               GC when the usage surpasses the configured factor of
                               the available memory. This policy calculates next target
-                              as usage+(limit-usage)*factor. swagger:model
+                              as usage+(limit-usage)*factor.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1937,7 +1936,7 @@ spec:
                             type: object
                           watermarks_policy:
                             description: WatermarksPolicy creates a Watchdog policy
-                              that schedules GC at concrete watermarks. swagger:model
+                              that schedules GC at concrete watermarks.
                             properties:
                               enabled:
                                 description: Flag to enable the policy

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -894,7 +894,7 @@ spec:
                       clients:
                         items:
                           description: AlertManagerClientConfig config for single
-                            alertmanager client. swagger:model AlertManagerClientConfig
+                            alertmanager client.
                           properties:
                             address:
                               type: string
@@ -902,7 +902,7 @@ spec:
                               type: string
                             http_client:
                               description: HTTPClientConfig holds configuration for
-                                HTTP Client. swagger:model
+                                HTTP Client.
                               properties:
                                 disable_compression:
                                   description: Disable Compression
@@ -1237,7 +1237,7 @@ spec:
                         description: Log writers
                         items:
                           description: LogWriterConfig holds configuration for a log
-                            writer. swagger:model
+                            writer.
                           properties:
                             compress:
                               description: Compress
@@ -1526,13 +1526,13 @@ spec:
                       cgroup:
                         description: WatchdogPolicyType holds configuration Watchdog
                           Policy algorithms. If both algorithms are configured then
-                          only watermark algorithm is used. swagger:model WatchdogPolicyType
+                          only watermark algorithm is used.
                         properties:
                           adaptive_policy:
                             description: AdaptivePolicy creates a policy that forces
                               GC when the usage surpasses the configured factor of
                               the available memory. This policy calculates next target
-                              as usage+(limit-usage)*factor. swagger:model
+                              as usage+(limit-usage)*factor.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1544,7 +1544,7 @@ spec:
                             type: object
                           watermarks_policy:
                             description: WatermarksPolicy creates a Watchdog policy
-                              that schedules GC at concrete watermarks. swagger:model
+                              that schedules GC at concrete watermarks.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1561,13 +1561,12 @@ spec:
                         type: object
                       heap:
                         description: HeapConfig holds configuration for heap Watchdog.
-                          swagger:model
                         properties:
                           adaptive_policy:
                             description: AdaptivePolicy creates a policy that forces
                               GC when the usage surpasses the configured factor of
                               the available memory. This policy calculates next target
-                              as usage+(limit-usage)*factor. swagger:model
+                              as usage+(limit-usage)*factor.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1589,7 +1588,7 @@ spec:
                             type: integer
                           watermarks_policy:
                             description: WatermarksPolicy creates a Watchdog policy
-                              that schedules GC at concrete watermarks. swagger:model
+                              that schedules GC at concrete watermarks.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1605,7 +1604,7 @@ spec:
                             type: object
                         type: object
                       job:
-                        description: JobConfig is config for Job swagger:model
+                        description: JobConfig is config for Job
                         properties:
                           execution_period:
                             description: Time period between job executions. Zero
@@ -1622,13 +1621,13 @@ spec:
                       system:
                         description: WatchdogPolicyType holds configuration Watchdog
                           Policy algorithms. If both algorithms are configured then
-                          only watermark algorithm is used. swagger:model WatchdogPolicyType
+                          only watermark algorithm is used.
                         properties:
                           adaptive_policy:
                             description: AdaptivePolicy creates a policy that forces
                               GC when the usage surpasses the configured factor of
                               the available memory. This policy calculates next target
-                              as usage+(limit-usage)*factor. swagger:model
+                              as usage+(limit-usage)*factor.
                             properties:
                               enabled:
                                 description: Flag to enable the policy
@@ -1640,7 +1639,7 @@ spec:
                             type: object
                           watermarks_policy:
                             description: WatermarksPolicy creates a Watchdog policy
-                              that schedules GC at concrete watermarks. swagger:model
+                              that schedules GC at concrete watermarks.
                             properties:
                               enabled:
                                 description: Flag to enable the policy

--- a/pkg/agentfunctions/provide.go
+++ b/pkg/agentfunctions/provide.go
@@ -33,8 +33,9 @@ var Module = fx.Options(
 )
 
 // Config is configuration for agent functions.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type Config struct {
 	// RPC servers to connect to (which will be able to call agent functions)
 	Endpoints []string `json:"endpoints,omitempty" validate:"omitempty,dive,omitempty"`
@@ -44,8 +45,9 @@ type Config struct {
 }
 
 // ClientConfig is configuration for network clients used by agent-functions.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ClientConfig struct {
 	// GRPC client settings.
 	GRPCClient grpcclient.GRPCClientConfig `json:"grpc"`

--- a/pkg/agentinfo/agent-info.go
+++ b/pkg/agentinfo/agent-info.go
@@ -7,7 +7,7 @@ const (
 	configKey = "agent_info"
 )
 
-// swagger:operation POST /agent_info common-configuration AgentInfo
+//swagger:operation POST /agent_info common-configuration AgentInfo
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -16,8 +16,9 @@ const (
 //     "$ref": "#/definitions/AgentInfoConfig"
 
 // AgentInfoConfig is the configuration for the agent group and other agent attributes.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type AgentInfoConfig struct {
 	// All agents within an agent_group receive the same data-plane configuration (e.g. Flux Meters, Rate Limiters etc).
 	//

--- a/pkg/alertmanager/client/client.go
+++ b/pkg/alertmanager/client/client.go
@@ -20,15 +20,17 @@ import (
 var configKey = "alertmanagers"
 
 // AlertManagerConfig main level config for alertmanager.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type AlertManagerConfig struct {
 	Clients []AlertManagerClientConfig `json:"clients,omitempty"`
 }
 
 // AlertManagerClientConfig config for single alertmanager client.
-// swagger:model AlertManagerClientConfig
 // +kubebuilder:object:generate=true
+//
+//swagger:model AlertManagerClientConfig
 type AlertManagerClientConfig struct {
 	Name       string                      `json:"name"`
 	Address    string                      `json:"address" validate:"hostname_port|url|fqdn"`

--- a/pkg/alerts/provide.go
+++ b/pkg/alerts/provide.go
@@ -10,8 +10,9 @@ import (
 const configKey = "alerter"
 
 // AlerterConfig for alerter.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type AlerterConfig struct {
 	// ChannelSize size of the alerts channel in the alerter. Alerts should be
 	// consumed from it quickly, so no big sizes are needed.

--- a/pkg/config/duration.go
+++ b/pkg/config/duration.go
@@ -12,8 +12,9 @@ import (
 
 // Duration is encoded as a string message which represents a signed span of time.
 // It holds *durationpb.Duration which is generated type for google/protobuf/duration.proto.
-// swagger:strfmt string
 // +kubebuilder:validation:Type=string
+//
+//swagger:strfmt string
 type Duration struct {
 	// swagger:ignore
 	duration *durationpb.Duration

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -38,7 +38,7 @@ func LogModule() fx.Option {
 	)
 }
 
-// swagger:operation POST /log common-configuration Log
+//swagger:operation POST /log common-configuration Log
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -47,8 +47,9 @@ func LogModule() fx.Option {
 //     "$ref": "#/definitions/LogConfig"
 
 // LogConfig holds configuration for a logger and log writers.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type LogConfig struct {
 	// Log level
 	LogLevel string `json:"level" validate:"oneof=debug DEBUG info INFO warn WARN error ERROR fatal FATAL panic PANIC trace TRACE disabled DISABLED" default:"info"`
@@ -64,8 +65,9 @@ type LogConfig struct {
 }
 
 // LogWriterConfig holds configuration for a log writer.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type LogWriterConfig struct {
 	// Output file for logs. Keywords allowed - ["stderr", "default"]. "default" maps to `/var/log/fluxninja/<service>.log`
 	File string `json:"file" default:"stderr"`

--- a/pkg/config/timestamp.go
+++ b/pkg/config/timestamp.go
@@ -12,7 +12,8 @@ import (
 
 // Time is encoded as a string message which represents a point in time independent of any time zone.
 // It holds *timestamppb.Time which is generated types for google/protobuf/timestamp.proto.
-// swagger:strfmt string
+//
+//swagger:strfmt string
 type Time struct {
 	// swagger:ignore
 	timestamp *timestamppb.Timestamp

--- a/pkg/discovery/config-operations.go
+++ b/pkg/discovery/config-operations.go
@@ -1,6 +1,6 @@
 package discovery
 
-// swagger:operation POST /service_discovery common-configuration ServiceDiscovery
+//swagger:operation POST /service_discovery common-configuration ServiceDiscovery
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/pkg/discovery/kubernetes/provide.go
+++ b/pkg/discovery/kubernetes/provide.go
@@ -18,8 +18,9 @@ import (
 var ConfigKey = common.DiscoveryConfigKey + ".kubernetes"
 
 // KubernetesDiscoveryConfig for Kubernetes service discovery.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type KubernetesDiscoveryConfig struct {
 	Enabled bool `json:"enabled" default:"true"`
 }

--- a/pkg/discovery/static/provide.go
+++ b/pkg/discovery/static/provide.go
@@ -19,8 +19,9 @@ const (
 )
 
 // StaticDiscoveryConfig for pre-determined list of services.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type StaticDiscoveryConfig struct {
 	Entities []entitiesv1.Entity `json:"entities,omitempty"`
 }

--- a/pkg/distcache/provider.go
+++ b/pkg/distcache/provider.go
@@ -45,7 +45,7 @@ func Module() fx.Option {
 	)
 }
 
-// swagger:operation POST /dist_cache common-configuration DistCache
+//swagger:operation POST /dist_cache common-configuration DistCache
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -54,8 +54,9 @@ func Module() fx.Option {
 //     "$ref": "#/definitions/DistCacheConfig"
 
 // DistCacheConfig configures distributed cache that holds per-label counters in distributed rate limiters.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type DistCacheConfig struct {
 	// BindAddr denotes the address that DistCache will bind to for communication with other peer nodes.
 	BindAddr string `json:"bind_addr" default:":3320" validate:"hostname_port"`

--- a/pkg/etcd/client/client.go
+++ b/pkg/etcd/client/client.go
@@ -36,8 +36,9 @@ const (
 )
 
 // EtcdConfig holds configuration for etcd client.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type EtcdConfig struct {
 	// Lease time-to-live
 	LeaseTTL config.Duration `json:"lease_ttl" validate:"gte=1s" default:"60s"`

--- a/pkg/jobs/job-group.go
+++ b/pkg/jobs/job-group.go
@@ -20,15 +20,17 @@ const (
 )
 
 // JobGroupConfig holds configuration for JobGroup.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type JobGroupConfig struct {
 	SchedulerConfig `json:",inline"`
 }
 
 // SchedulerConfig holds configuration for job Scheduler.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type SchedulerConfig struct {
 	// When true, the scheduler will run jobs synchronously,
 	// waiting for each execution instance of the job to return

--- a/pkg/jobs/job.go
+++ b/pkg/jobs/job.go
@@ -47,8 +47,9 @@ func (job JobBase) JobWatchers() JobWatchers {
 }
 
 // JobConfig is config for Job
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type JobConfig struct {
 	// Time period between job executions. Zero or negative value means that the job will never execute periodically.
 	ExecutionPeriod config.Duration `json:"execution_period" default:"10s"`

--- a/pkg/jobs/multi-job.go
+++ b/pkg/jobs/multi-job.go
@@ -15,7 +15,8 @@ import (
 )
 
 // MultiJobConfig holds configuration for MultiJob.
-// swagger:model
+//
+//swagger:model
 type MultiJobConfig struct {
 	JobConfig
 }

--- a/pkg/jobs/provide.go
+++ b/pkg/jobs/provide.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/log"
 )
 
-// swagger:operation POST /liveness common-configuration Liveness
+//swagger:operation POST /liveness common-configuration Liveness
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -23,7 +23,7 @@ import (
 //   schema:
 //     "$ref": "#/definitions/JobGroupConfig"
 
-// swagger:operation POST /readiness common-configuration Readiness
+//swagger:operation POST /readiness common-configuration Readiness
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -27,7 +27,7 @@ const (
 	metricsEndpoint = "/metrics"
 )
 
-// swagger:operation POST /metrics common-configuration Metrics
+//swagger:operation POST /metrics common-configuration Metrics
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -36,8 +36,9 @@ const (
 //     "$ref": "#/definitions/MetricsConfig"
 
 // MetricsConfig holds configuration for service metrics.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type MetricsConfig struct {
 	// Pedantic controls whether a pedantic Registerer is used as the prometheus backend. See <https://godoc.org/github.com/prometheus/client_golang/prometheus#NewPedanticRegistry>
 	Pedantic bool `json:"pedantic" default:"false"`

--- a/pkg/net/config-operations.go
+++ b/pkg/net/config-operations.go
@@ -2,7 +2,7 @@ package net
 
 // Dummy Swagger operations that represent yaml based configuration. For use with markdown generator only.
 
-// swagger:operation POST /server common-configuration Server
+//swagger:operation POST /server common-configuration Server
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -27,7 +27,7 @@ package net
 //   schema:
 //     "$ref": "#/definitions/ServerTLSConfig"
 
-// swagger:operation POST /client common-configuration Client
+//swagger:operation POST /client common-configuration Client
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/pkg/net/grpc/client.go
+++ b/pkg/net/grpc/client.go
@@ -28,8 +28,9 @@ type ClientConstructor struct {
 }
 
 // GRPCClientConfig holds configuration for GRPC Client.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type GRPCClientConfig struct {
 	// Minimum connection timeout
 	MinConnectionTimeout config.Duration `json:"min_connection_timeout" validate:"gte=0" default:"20s"`
@@ -44,8 +45,9 @@ type GRPCClientConfig struct {
 }
 
 // BackoffConfig holds configuration for GRPC Client Backoff.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type BackoffConfig struct {
 	// Base Delay
 	BaseDelay config.Duration `json:"base_delay" validate:"gte=0" default:"1s"`

--- a/pkg/net/grpc/server.go
+++ b/pkg/net/grpc/server.go
@@ -41,8 +41,9 @@ func GMuxServerModule() fx.Option {
 }
 
 // GRPCServerConfig holds configuration for GRPC Server.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type GRPCServerConfig struct {
 	// Connection timeout
 	ConnectionTimeout config.Duration `json:"connection_timeout" validate:"gte=0s" default:"120s"`

--- a/pkg/net/grpcgateway/grpcgateway.go
+++ b/pkg/net/grpcgateway/grpcgateway.go
@@ -45,7 +45,8 @@ type Constructor struct {
 }
 
 // GRPCGatewayConfig holds configuration for grpc-http gateway
-// swagger:model
+//
+//swagger:model
 type GRPCGatewayConfig struct {
 	// GRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs GRPC and HTTP servers on the same port
 	GRPCAddr string `json:"grpc_server_address" validate:"hostname_port" default:"0.0.0.0:1"`

--- a/pkg/net/http/client.go
+++ b/pkg/net/http/client.go
@@ -27,8 +27,9 @@ type ClientConstructor struct {
 }
 
 // HTTPClientConfig holds configuration for HTTP Client.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type HTTPClientConfig struct {
 	// Network level keep-alive duration
 	NetworkKeepAlive config.Duration `json:"network_keep_alive" validate:"gte=0s" default:"30s"`

--- a/pkg/net/http/proxy.go
+++ b/pkg/net/http/proxy.go
@@ -29,8 +29,9 @@ type ProxyConstructor struct {
 
 // ProxyConfig holds proxy configuration.
 // This configuration has preference over environment variables HTTP_PROXY, HTTPS_PROXY or NO_PROXY. See <https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config>
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ProxyConfig struct {
 	HTTPProxy string `json:"http" validate:"omitempty,url|hostname_port"`
 

--- a/pkg/net/http/server.go
+++ b/pkg/net/http/server.go
@@ -37,8 +37,9 @@ func ServerModule() fx.Option {
 }
 
 // HTTPServerConfig holds configuration for HTTP Server.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type HTTPServerConfig struct {
 	// Idle timeout
 	IdleTimeout config.Duration `json:"idle_timeout" validate:"gte=0s" default:"30s"`

--- a/pkg/net/listener/listener.go
+++ b/pkg/net/listener/listener.go
@@ -10,8 +10,9 @@ import (
 )
 
 // ListenerConfig holds configuration for socket listeners.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ListenerConfig struct {
 	// Keep-alive period - 0 = enabled if supported by protocol or OS. If negative then keep-alive is disabled.
 	KeepAlive config.Duration `json:"keep_alive" validate:"gte=0s" default:"180s"`

--- a/pkg/net/tlsconfig/client.go
+++ b/pkg/net/tlsconfig/client.go
@@ -13,8 +13,9 @@ import (
 )
 
 // ClientTLSConfig is the config for client TLS.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ClientTLSConfig struct {
 	CertFile           string `json:"cert_file"`
 	KeyFile            string `json:"key_file"`

--- a/pkg/net/tlsconfig/server.go
+++ b/pkg/net/tlsconfig/server.go
@@ -26,8 +26,9 @@ func Module() fx.Option {
 }
 
 // ServerTLSConfig holds configuration for setting up server TLS support.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ServerTLSConfig struct {
 	// Server Cert file path
 	CertFile string `json:"cert_file"`

--- a/pkg/otelcollector/config/user_config.go
+++ b/pkg/otelcollector/config/user_config.go
@@ -16,8 +16,9 @@ func NewDefaultCommonOTELConfig() *CommonOTELConfig {
 }
 
 // CommonOTELConfig is the configuration for the OTEL collector.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type CommonOTELConfig struct {
 	// BatchAlerts configures batch alerts processor.
 	BatchAlerts BatchAlertsConfig `json:"batch_alerts"`
@@ -26,8 +27,9 @@ type CommonOTELConfig struct {
 }
 
 // PortsConfig defines configuration for OTEL debug and extension ports.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type PortsConfig struct {
 	// Port on which otel collector exposes prometheus metrics on /metrics path.
 	DebugPort uint32 `json:"debug_port" validate:"gte=0" default:"8888"`
@@ -40,8 +42,9 @@ type PortsConfig struct {
 }
 
 // BatchAlertsConfig defines configuration for OTEL batch processor.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type BatchAlertsConfig struct {
 	// Timeout sets the time after which a batch will be sent regardless of size.
 	Timeout config.Duration `json:"timeout" validate:"gt=0" default:"1s"`

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -46,8 +46,9 @@ var (
 )
 
 // PeerDiscoveryConfig holds configuration for Agent Peer Discovery.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type PeerDiscoveryConfig struct {
 	// Network address of aperture server to advertise to peers - this address should be reachable from other agents. Used for nat traversal when provided.
 	AdvertisementAddr string `json:"advertisement_addr" validate:"omitempty,hostname_port"`

--- a/pkg/policies/autoscale/config-operations.go
+++ b/pkg/policies/autoscale/config-operations.go
@@ -1,6 +1,6 @@
 package autoscale
 
-// swagger:operation POST /auto_scale common-configuration AutoScaleConfig
+//swagger:operation POST /auto_scale common-configuration AutoScaleConfig
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/pkg/policies/autoscale/kubernetes/config/config.go
+++ b/pkg/policies/autoscale/kubernetes/config/config.go
@@ -15,8 +15,9 @@ func Module() fx.Option {
 const ConfigKey = "auto_scale.kubernetes"
 
 // AutoScaleKubernetesConfig is the configuration for the flow preview service.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type AutoScaleKubernetesConfig struct {
 	// Enables the Kubernetes autoscale capability.
 	Enabled bool `json:"enabled" default:"true"`

--- a/pkg/policies/controlplane/provider.go
+++ b/pkg/policies/controlplane/provider.go
@@ -10,7 +10,7 @@ const (
 	policiesDynamicConfigFxTag = "PoliciesDynamicConfig"
 )
 
-// swagger:operation POST /policies common-configuration PoliciesConfig
+//swagger:operation POST /policies common-configuration PoliciesConfig
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/pkg/policies/flowcontrol/config-operations.go
+++ b/pkg/policies/flowcontrol/config-operations.go
@@ -1,6 +1,6 @@
 package flowcontrol
 
-// swagger:operation POST /flow_control common-configuration FlowControl
+//swagger:operation POST /flow_control common-configuration FlowControl
 // ---
 // x-fn-config-env: true
 // parameters:

--- a/pkg/policies/flowcontrol/service/preview/provide.go
+++ b/pkg/policies/flowcontrol/service/preview/provide.go
@@ -25,8 +25,9 @@ func Module() fx.Option {
 const ConfigKey = "flow_control.preview_service"
 
 // FlowPreviewConfig is the configuration for the flow control preview service.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type FlowPreviewConfig struct {
 	// Enables the flow preview service.
 	Enabled bool `json:"enabled" default:"true"`

--- a/pkg/profilers/profilers.go
+++ b/pkg/profilers/profilers.go
@@ -36,7 +36,7 @@ func Module() fx.Option {
 	)
 }
 
-// swagger:operation POST /profilers common-configuration Profilers
+//swagger:operation POST /profilers common-configuration Profilers
 // ---
 // x-fn-config-env: true
 // parameters:
@@ -45,8 +45,9 @@ func Module() fx.Option {
 //     "$ref": "#/definitions/ProfilersConfig"
 
 // ProfilersConfig holds configuration for profilers.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type ProfilersConfig struct {
 	// Path to save performance profiles. "default" path is `/var/log/aperture/<service>/profiles`.
 	ProfilesPath string `json:"profiles_path" default:"default"`

--- a/pkg/prometheus/client.go
+++ b/pkg/prometheus/client.go
@@ -35,8 +35,9 @@ var (
 )
 
 // PrometheusConfig holds configuration for Prometheus Server.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type PrometheusConfig struct {
 	// Address of the prometheus server
 	Address string `json:"address" validate:"required,hostname_port|url|fqdn"`

--- a/pkg/watchdog/policy.go
+++ b/pkg/watchdog/policy.go
@@ -16,8 +16,9 @@ import (
 )
 
 // WatchdogConfig holds configuration for Watchdog Policy. For each policy, either watermark or adaptive should be configured.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type WatchdogConfig struct {
 	Job jobs.JobConfig `json:"job"`
 
@@ -29,8 +30,9 @@ type WatchdogConfig struct {
 }
 
 // WatchdogPolicyType holds configuration Watchdog Policy algorithms. If both algorithms are configured then only watermark algorithm is used.
-// swagger:model WatchdogPolicyType
 // +kubebuilder:object:generate=true
+//
+//swagger:model WatchdogPolicyType
 type WatchdogPolicyType struct {
 	WatermarksPolicy WatermarksPolicy `json:"watermarks_policy"`
 
@@ -38,8 +40,9 @@ type WatchdogPolicyType struct {
 }
 
 // HeapLimit holds configuration for Watchdog heap limit.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type HeapLimit struct {
 	// Minimum GoGC sets the minimum garbage collection target percentage for heap driven Watchdogs. This setting helps avoid overscheduling.
 	MinGoGC int `json:"min_gogc" validate:"gt=0,lte=100" default:"25"`
@@ -49,8 +52,9 @@ type HeapLimit struct {
 }
 
 // HeapConfig holds configuration for heap Watchdog.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type HeapConfig struct {
 	WatchdogPolicyType `json:",inline"`
 
@@ -58,8 +62,9 @@ type HeapConfig struct {
 }
 
 // PolicyCommon holds common configuration for Watchdog policies.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type PolicyCommon struct {
 	// Flag to enable the policy
 	Enabled bool `json:"enabled" default:"false"`
@@ -76,8 +81,9 @@ type policyInterface interface {
 }
 
 // WatermarksPolicy creates a Watchdog policy that schedules GC at concrete watermarks.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type WatermarksPolicy struct {
 	// Watermarks are increasing limits on which to trigger GC. Watchdog disarms when the last watermark is surpassed. It is recommended to set an extreme watermark for the last element (e.g. 0.99).
 	Watermarks []float64 `json:"watermarks,omitempty" validate:"omitempty,dive,gte=0,lte=1" default:"[0.50,0.75,0.80,0.85,0.90,0.95,0.99]"`
@@ -113,8 +119,9 @@ func (policy *WatermarksPolicy) nextThreshold(total, used uint64) uint64 {
 }
 
 // AdaptivePolicy creates a policy that forces GC when the usage surpasses the configured factor of the available memory. This policy calculates next target as usage+(limit-usage)*factor.
-// swagger:model
 // +kubebuilder:object:generate=true
+//
+//swagger:model
 type AdaptivePolicy struct {
 	PolicyCommon `json:",inline"`
 

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -23,7 +23,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/status"
 )
 
-// swagger:operation POST /watchdog common-configuration Watchdog
+//swagger:operation POST /watchdog common-configuration Watchdog
 // ---
 // x-fn-config-env: true
 // parameters:


### PR DESCRIPTION
### Description of change

...by removing space after `//`

See https://tip.golang.org/doc/comment#syntax

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:** This pull request updates comments and removes Swagger directives from various files to improve documentation and formatting. It also adds `kubebuilder` directives to some structs and generates Kubernetes objects.

> 🎉 Code is clean, docs are neat,  
> 📝 Formatting's now complete!  
> 🚀 With Swagger gone, we're feeling light,  
> 🌟 Ready to launch with all our might!
<!-- end of auto-generated comment: release notes by openai -->