### PR TITLE
Add TLS configurability to Java SDK

### DIFF
--- a/cmd/sdk-validator/main.go
+++ b/cmd/sdk-validator/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"google.golang.org/grpc/credentials"
 	"net"
 	"net/http"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"google.golang.org/grpc/credentials"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -86,11 +87,11 @@ func main() {
 	// setup grpc server and register various server instances to it
 	var grpcServer *grpc.Server
 	if *sslCertFilepath != "" && *sslKeyFilepath != "" {
-		creds, err := credentials.NewServerTLSFromFile(*sslCertFilepath, *sslKeyFilepath)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to create TLS creds from provided files")
+		creds, err2 := credentials.NewServerTLSFromFile(*sslCertFilepath, *sslKeyFilepath)
+		if err2 != nil {
+			log.Fatal().Err(err2).Msg("Failed to create TLS creds from provided files")
 		}
-		log.Info().Msg("Starting TLS-ed grpc server")
+		log.Info().Msg("Starting TLS-secured grpc server")
 		grpcServer = grpc.NewServer(grpc.UnaryInterceptor(serverInterceptor), grpc.Creds(creds))
 	} else {
 		log.Info().Msg("Starting insecure grpc server")

--- a/sdks/aperture-java/dockerfiles/javaagent/armeria/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/javaagent/armeria/Dockerfile
@@ -3,4 +3,6 @@
 ARG IMAGE_TAG
 FROM aperture-java-all:$IMAGE_TAG
 
+ENV APERTURE_JAVAAGENT_INSECURE_GRPC=true
+
 CMD ["java", "-javaagent:/javaagent.jar", "-jar", "/armeria.jar"]

--- a/sdks/aperture-java/dockerfiles/javaagent/netty/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/javaagent/netty/Dockerfile
@@ -3,4 +3,6 @@
 ARG IMAGE_TAG
 FROM aperture-java-all:$IMAGE_TAG
 
+ENV APERTURE_JAVAAGENT_INSECURE_GRPC=true
+
 CMD ["java", "-javaagent:/javaagent.jar", "-jar", "/netty.jar"]

--- a/sdks/aperture-java/dockerfiles/middlewares/armeria-tls/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/middlewares/armeria-tls/Dockerfile
@@ -4,10 +4,10 @@ ARG IMAGE_TAG
 
 FROM aperture-java-all:$IMAGE_TAG
 
-ARG SSL_CERT
-COPY --link ${SSL_CERT} /ssl-cert
+ARG CA_CERT
+COPY --link ${CA_CERT} /ca-cert
 
-ENV FN_SSL_CERTIFICATE_FILE=/ssl-cert
+ENV FN_CA_CERTIFICATE_FILE=/ca-cert
 ENV FN_INSECURE_GRPC=false
 
 CMD ["java", "-jar", "/armeria-example.jar"]

--- a/sdks/aperture-java/dockerfiles/middlewares/armeria-tls/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/middlewares/armeria-tls/Dockerfile
@@ -4,10 +4,10 @@ ARG IMAGE_TAG
 
 FROM aperture-java-all:$IMAGE_TAG
 
-ARG CA_CERT
-COPY --link ${CA_CERT} /ca-cert
+ARG ROOT_CERT
+COPY --link ${ROOT_CERT} /root-cert
 
-ENV FN_CA_CERTIFICATE_FILE=/ca-cert
+ENV FN_ROOT_CERTIFICATE_FILE=/root-cert
 ENV FN_INSECURE_GRPC=false
 
 CMD ["java", "-jar", "/armeria-example.jar"]

--- a/sdks/aperture-java/dockerfiles/middlewares/armeria-tls/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/middlewares/armeria-tls/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.4
+
+ARG IMAGE_TAG
+
+FROM aperture-java-all:$IMAGE_TAG
+
+ARG SSL_CERT
+COPY --link ${SSL_CERT} /ssl-cert
+
+ENV FN_SSL_CERTIFICATE_FILE=/ssl-cert
+ENV FN_INSECURE_GRPC=false
+
+CMD ["java", "-jar", "/armeria-example.jar"]

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
@@ -14,7 +14,7 @@ public class ArmeriaClient {
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
     public static final String DEFAULT_INSECURE_GRPC = "true";
-    public static final String DEFAULT_SSL_CERT = "";
+    public static final String DEFAULT_ROOT_CERT = "";
 
     public static void main(String[] args) {
         String agentHost = System.getenv("FN_AGENT_HOST");
@@ -31,9 +31,9 @@ public class ArmeriaClient {
         }
         boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
 
-        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
-        if (sslCertFile == null) {
-            sslCertFile = DEFAULT_SSL_CERT;
+        String rootCertFile = System.getenv("FN_ROOT_CERTIFICATE_FILE");
+        if (rootCertFile == null) {
+            rootCertFile = DEFAULT_ROOT_CERT;
         }
 
         ApertureSDK apertureSDK;
@@ -44,7 +44,7 @@ public class ArmeriaClient {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setCACertificateFile(sslCertFile)
+                            .setRootCertificateFile(rootCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
@@ -44,7 +44,7 @@ public class ArmeriaClient {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setSslCertificateFile(sslCertFile)
+                            .setCACertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
@@ -13,6 +13,8 @@ public class ArmeriaClient {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_INSECURE_GRPC = "true";
+    public static final String DEFAULT_SSL_CERT = "";
 
     public static void main(String[] args) {
         String agentHost = System.getenv("FN_AGENT_HOST");
@@ -23,6 +25,16 @@ public class ArmeriaClient {
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }
+        String insecureGrpcString = System.getenv("FN_INSECURE_GRPC");
+        if (insecureGrpcString == null) {
+            insecureGrpcString = DEFAULT_INSECURE_GRPC;
+        }
+        boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
+
+        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
+        if (sslCertFile == null) {
+            sslCertFile = DEFAULT_SSL_CERT;
+        }
 
         ApertureSDK apertureSDK;
         try {
@@ -31,7 +43,8 @@ public class ArmeriaClient {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
-                            .useInsecureGrpc()
+                            .useInsecureGrpc(insecureGrpc)
+                            .setSslCertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
@@ -31,6 +31,7 @@ public class ArmeriaClient {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
+                            .useInsecureGrpc()
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
@@ -15,7 +15,7 @@ public class ArmeriaServer {
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
     public static final String DEFAULT_INSECURE_GRPC = "true";
-    public static final String DEFAULT_SSL_CERT = "";
+    public static final String DEFAULT_ROOT_CERT = "";
 
     public static HttpService createHelloHTTPService() {
         return new AbstractHttpService() {
@@ -63,9 +63,9 @@ public class ArmeriaServer {
         }
         boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
 
-        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
-        if (sslCertFile == null) {
-            sslCertFile = DEFAULT_SSL_CERT;
+        String rootCertFile = System.getenv("FN_ROOT_CERTIFICATE_FILE");
+        if (rootCertFile == null) {
+            rootCertFile = DEFAULT_ROOT_CERT;
         }
 
         ApertureSDK apertureSDK;
@@ -76,7 +76,7 @@ public class ArmeriaServer {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setCACertificateFile(sslCertFile)
+                            .setRootCertificateFile(rootCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
@@ -14,6 +14,8 @@ public class ArmeriaServer {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_INSECURE_GRPC = "true";
+    public static final String DEFAULT_SSL_CERT = "";
 
     public static HttpService createHelloHTTPService() {
         return new AbstractHttpService() {
@@ -55,6 +57,16 @@ public class ArmeriaServer {
         if (appPort == null) {
             appPort = DEFAULT_APP_PORT;
         }
+        String insecureGrpcString = System.getenv("FN_INSECURE_GRPC");
+        if (insecureGrpcString == null) {
+            insecureGrpcString = DEFAULT_INSECURE_GRPC;
+        }
+        boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
+
+        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
+        if (sslCertFile == null) {
+            sslCertFile = DEFAULT_SSL_CERT;
+        }
 
         ApertureSDK apertureSDK;
         try {
@@ -63,7 +75,8 @@ public class ArmeriaServer {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
-                            .useInsecureGrpc()
+                            .useInsecureGrpc(insecureGrpc)
+                            .setSslCertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
@@ -76,7 +76,7 @@ public class ArmeriaServer {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setSslCertificateFile(sslCertFile)
+                            .setCACertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
@@ -63,6 +63,7 @@ public class ArmeriaServer {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
+                            .useInsecureGrpc()
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
@@ -12,6 +12,8 @@ public class NettyServer {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_INSECURE_GRPC = "true";
+    public static final String DEFAULT_SSL_CERT = "";
 
     public static void main(String[] args) throws Exception {
         String agentHost = System.getenv("FN_AGENT_HOST");
@@ -26,6 +28,16 @@ public class NettyServer {
         if (appPort == null) {
             appPort = DEFAULT_APP_PORT;
         }
+        String insecureGrpcString = System.getenv("FN_INSECURE_GRPC");
+        if (insecureGrpcString == null) {
+            insecureGrpcString = DEFAULT_INSECURE_GRPC;
+        }
+        boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
+
+        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
+        if (sslCertFile == null) {
+            sslCertFile = DEFAULT_SSL_CERT;
+        }
 
         EventLoopGroup bossGroup = new NioEventLoopGroup();
         EventLoopGroup workerGroup = new NioEventLoopGroup();
@@ -37,7 +49,8 @@ public class NettyServer {
             httpBootstrap
                     .group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
-                    .childHandler(new ServerInitializer(agentHost, agentPort))
+                    .childHandler(
+                            new ServerInitializer(agentHost, agentPort, insecureGrpc, sslCertFile))
                     .option(ChannelOption.SO_BACKLOG, 128)
                     .childOption(ChannelOption.SO_KEEPALIVE, true);
 

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
@@ -13,7 +13,7 @@ public class NettyServer {
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
     public static final String DEFAULT_INSECURE_GRPC = "true";
-    public static final String DEFAULT_SSL_CERT = "";
+    public static final String DEFAULT_ROOT_CERT = "";
 
     public static void main(String[] args) throws Exception {
         String agentHost = System.getenv("FN_AGENT_HOST");
@@ -34,9 +34,9 @@ public class NettyServer {
         }
         boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
 
-        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
-        if (sslCertFile == null) {
-            sslCertFile = DEFAULT_SSL_CERT;
+        String rootCertFile = System.getenv("FN_ROOT_CERTIFICATE_FILE");
+        if (rootCertFile == null) {
+            rootCertFile = DEFAULT_ROOT_CERT;
         }
 
         EventLoopGroup bossGroup = new NioEventLoopGroup();
@@ -50,7 +50,7 @@ public class NettyServer {
                     .group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
                     .childHandler(
-                            new ServerInitializer(agentHost, agentPort, insecureGrpc, sslCertFile))
+                            new ServerInitializer(agentHost, agentPort, insecureGrpc, rootCertFile))
                     .option(ChannelOption.SO_BACKLOG, 128)
                     .childOption(ChannelOption.SO_KEEPALIVE, true);
 

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
@@ -14,10 +14,15 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
     ApertureSDK sdk;
     String agentHost;
     int agentPort;
+    boolean insecureGrpc;
+    String sslCertFile;
 
-    public ServerInitializer(String agentHost, String agentPort) {
+    public ServerInitializer(
+            String agentHost, String agentPort, boolean insecureGrpc, String sslCertFile) {
         this.agentHost = agentHost;
         this.agentPort = Integer.parseInt(agentPort);
+        this.insecureGrpc = insecureGrpc;
+        this.sslCertFile = sslCertFile;
     }
 
     @Override
@@ -27,7 +32,8 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
                     ApertureSDK.builder()
                             .setHost(this.agentHost)
                             .setPort(this.agentPort)
-                            .useInsecureGrpc()
+                            .useInsecureGrpc(insecureGrpc)
+                            .setSslCertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException ex) {
             throw new RuntimeException(ex);

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
@@ -23,7 +23,12 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
     @Override
     protected void initChannel(Channel ch) {
         try {
-            sdk = ApertureSDK.builder().setHost(this.agentHost).setPort(this.agentPort).build();
+            sdk =
+                    ApertureSDK.builder()
+                            .setHost(this.agentHost)
+                            .setPort(this.agentPort)
+                            .useInsecureGrpc()
+                            .build();
         } catch (ApertureSDKException ex) {
             throw new RuntimeException(ex);
         }

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
@@ -15,14 +15,14 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
     String agentHost;
     int agentPort;
     boolean insecureGrpc;
-    String sslCertFile;
+    String rootCertFile;
 
     public ServerInitializer(
-            String agentHost, String agentPort, boolean insecureGrpc, String sslCertFile) {
+            String agentHost, String agentPort, boolean insecureGrpc, String rootCertFile) {
         this.agentHost = agentHost;
         this.agentPort = Integer.parseInt(agentPort);
         this.insecureGrpc = insecureGrpc;
-        this.sslCertFile = sslCertFile;
+        this.rootCertFile = rootCertFile;
     }
 
     @Override
@@ -33,7 +33,7 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
                             .setHost(this.agentHost)
                             .setPort(this.agentPort)
                             .useInsecureGrpc(insecureGrpc)
-                            .setCACertificateFile(sslCertFile)
+                            .setRootCertificateFile(rootCertFile)
                             .build();
         } catch (ApertureSDKException ex) {
             throw new RuntimeException(ex);

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
@@ -33,7 +33,7 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
                             .setHost(this.agentHost)
                             .setPort(this.agentPort)
                             .useInsecureGrpc(insecureGrpc)
-                            .setSslCertificateFile(sslCertFile)
+                            .setCACertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException ex) {
             throw new RuntimeException(ex);

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
@@ -10,6 +10,8 @@ public class SpringBootApp {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_INSECURE_GRPC = "true";
+    public static final String DEFAULT_SSL_CERT = "";
 
     public static void main(String[] args) {
         String agentHost = System.getenv("FN_AGENT_HOST");
@@ -27,6 +29,17 @@ public class SpringBootApp {
             appPort = DEFAULT_APP_PORT;
         }
         System.setProperty("FN_APP_PORT", appPort);
+        String insecureGrpcString = System.getenv("FN_INSECURE_GRPC");
+        if (insecureGrpcString == null) {
+            insecureGrpcString = DEFAULT_INSECURE_GRPC;
+        }
+        System.setProperty("FN_INSECURE_GRPC", insecureGrpcString);
+
+        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
+        if (sslCertFile == null) {
+            sslCertFile = DEFAULT_SSL_CERT;
+        }
+        System.setProperty("FN_SSL_CERTIFICATE_FILE", sslCertFile);
 
         SpringApplication.run(SpringBootApp.class, args);
     }

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
@@ -11,7 +11,7 @@ public class SpringBootApp {
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
     public static final String DEFAULT_INSECURE_GRPC = "true";
-    public static final String DEFAULT_SSL_CERT = "";
+    public static final String DEFAULT_ROOT_CERT = "";
 
     public static void main(String[] args) {
         String agentHost = System.getenv("FN_AGENT_HOST");
@@ -35,11 +35,11 @@ public class SpringBootApp {
         }
         System.setProperty("FN_INSECURE_GRPC", insecureGrpcString);
 
-        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
-        if (sslCertFile == null) {
-            sslCertFile = DEFAULT_SSL_CERT;
+        String rootCertFile = System.getenv("FN_ROOT_CERTIFICATE_FILE");
+        if (rootCertFile == null) {
+            rootCertFile = DEFAULT_ROOT_CERT;
         }
-        System.setProperty("FN_SSL_CERTIFICATE_FILE", sslCertFile);
+        System.setProperty("FN_ROOT_CERTIFICATE_FILE", rootCertFile);
 
         SpringApplication.run(SpringBootApp.class, args);
     }

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
@@ -47,8 +47,8 @@ public class AppController {
         registrationBean.addInitParameter("agent_port", agentPort);
         String insecureGrpc = env.getProperty("FN_INSECURE_GRPC");
         registrationBean.addInitParameter("insecure_grpc", insecureGrpc);
-        String sslCertificateFile = env.getProperty("FN_SSL_CERTIFICATE_FILE");
-        registrationBean.addInitParameter("ssl_certificate_file", sslCertificateFile);
+        String rootCertificateFile = env.getProperty("FN_ROOT_CERTIFICATE_FILE");
+        registrationBean.addInitParameter("root_certificate_file", rootCertificateFile);
 
         return registrationBean;
     }
@@ -68,8 +68,8 @@ public class AppController {
         registrationBean.addInitParameter("agent_port", agentPort);
         String insecureGrpc = env.getProperty("FN_INSECURE_GRPC");
         registrationBean.addInitParameter("insecure_grpc", insecureGrpc);
-        String sslCertificateFile = env.getProperty("FN_SSL_CERTIFICATE_FILE");
-        registrationBean.addInitParameter("ssl_certificate_file", sslCertificateFile);
+        String rootCertificateFile = env.getProperty("FN_ROOT_CERTIFICATE_FILE");
+        registrationBean.addInitParameter("root_certificate_file", rootCertificateFile);
 
         return registrationBean;
     }

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
@@ -42,9 +42,13 @@ public class AppController {
         registrationBean.addUrlPatterns("/super");
 
         String agentHost = env.getProperty("FN_AGENT_HOST");
-        String agentPort = env.getProperty("FN_AGENT_PORT");
         registrationBean.addInitParameter("agent_host", agentHost);
+        String agentPort = env.getProperty("FN_AGENT_PORT");
         registrationBean.addInitParameter("agent_port", agentPort);
+        String insecureGrpc = env.getProperty("FN_INSECURE_GRPC");
+        registrationBean.addInitParameter("insecure_grpc", insecureGrpc);
+        String sslCertificateFile = env.getProperty("FN_SSL_CERTIFICATE_FILE");
+        registrationBean.addInitParameter("ssl_certificate_file", sslCertificateFile);
 
         return registrationBean;
     }
@@ -59,9 +63,13 @@ public class AppController {
         registrationBean.addUrlPatterns("/super2");
 
         String agentHost = env.getProperty("FN_AGENT_HOST");
-        String agentPort = env.getProperty("FN_AGENT_PORT");
         registrationBean.addInitParameter("agent_host", agentHost);
+        String agentPort = env.getProperty("FN_AGENT_PORT");
         registrationBean.addInitParameter("agent_port", agentPort);
+        String insecureGrpc = env.getProperty("FN_INSECURE_GRPC");
+        registrationBean.addInitParameter("insecure_grpc", insecureGrpc);
+        String sslCertificateFile = env.getProperty("FN_SSL_CERTIFICATE_FILE");
+        registrationBean.addInitParameter("ssl_certificate_file", sslCertificateFile);
 
         return registrationBean;
     }

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -55,12 +55,12 @@ public class ApertureFeatureFilter implements Filter {
         String agentHost;
         String agentPort;
         boolean insecureGrpc;
-        String sslCertificateFile;
+        String rootCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
-            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
+            rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -72,7 +72,7 @@ public class ApertureFeatureFilter implements Filter {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setCACertificateFile(sslCertificateFile)
+                            .setRootCertificateFile(rootCertificateFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -72,7 +72,7 @@ public class ApertureFeatureFilter implements Filter {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setSslCertificateFile(sslCertificateFile)
+                            .setCACertificateFile(sslCertificateFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -71,6 +71,7 @@ public class ApertureFeatureFilter implements Filter {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
+                            .useInsecureGrpc()
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -54,15 +54,15 @@ public class ApertureFeatureFilter implements Filter {
     public void init(FilterConfig filterConfig) throws ServletException {
         String agentHost;
         String agentPort;
+        boolean insecureGrpc;
+        String sslCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
+            insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
+            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
         } catch (Exception e) {
-            throw new ServletException(
-                    "Invalid agent connection information "
-                            + filterConfig.getInitParameter("agent_host")
-                            + ":"
-                            + filterConfig.getInitParameter("agent_port"));
+            throw new ServletException("Could not read config parameters", e);
         }
 
         try {
@@ -71,7 +71,8 @@ public class ApertureFeatureFilter implements Filter {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
-                            .useInsecureGrpc()
+                            .useInsecureGrpc(insecureGrpc)
+                            .setSslCertificateFile(sslCertificateFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -61,7 +61,7 @@ public class App {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setSslCertificateFile(sslCertFile)
+                            .setCACertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -18,7 +18,7 @@ public class App {
     public static final String DEFAULT_AGENT_PORT = "8089";
     public static final String DEFAULT_FEATURE_NAME = "awesome_feature";
     public static final String DEFAULT_INSECURE_GRPC = "true";
-    public static final String DEFAULT_SSL_CERT = "";
+    public static final String DEFAULT_ROOT_CERT = "";
 
     private final ApertureSDK apertureSDK;
     private final ManagedChannel channel;
@@ -45,9 +45,9 @@ public class App {
         }
         boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
 
-        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
-        if (sslCertFile == null) {
-            sslCertFile = DEFAULT_SSL_CERT;
+        String rootCertFile = System.getenv("FN_ROOT_CERTIFICATE_FILE");
+        if (rootCertFile == null) {
+            rootCertFile = DEFAULT_ROOT_CERT;
         }
 
         String target = String.format("%s:%s", agentHost, agentPort);
@@ -61,7 +61,7 @@ public class App {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setCACertificateFile(sslCertFile)
+                            .setRootCertificateFile(rootCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -48,6 +48,7 @@ public class App {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
+                            .useInsecureGrpc()
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -17,6 +17,8 @@ public class App {
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
     public static final String DEFAULT_FEATURE_NAME = "awesome_feature";
+    public static final String DEFAULT_INSECURE_GRPC = "true";
+    public static final String DEFAULT_SSL_CERT = "";
 
     private final ApertureSDK apertureSDK;
     private final ManagedChannel channel;
@@ -37,6 +39,16 @@ public class App {
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }
+        String insecureGrpcString = System.getenv("FN_INSECURE_GRPC");
+        if (insecureGrpcString == null) {
+            insecureGrpcString = DEFAULT_INSECURE_GRPC;
+        }
+        boolean insecureGrpc = Boolean.parseBoolean(insecureGrpcString);
+
+        String sslCertFile = System.getenv("FN_SSL_CERTIFICATE_FILE");
+        if (sslCertFile == null) {
+            sslCertFile = DEFAULT_SSL_CERT;
+        }
 
         String target = String.format("%s:%s", agentHost, agentPort);
         final ManagedChannel channel = ManagedChannelBuilder.forTarget(target).build();
@@ -48,7 +60,8 @@ public class App {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
-                            .useInsecureGrpc()
+                            .useInsecureGrpc(insecureGrpc)
+                            .setSslCertificateFile(sslCertFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -55,12 +55,12 @@ public class ApertureFeatureFilter implements Filter {
         String agentHost;
         String agentPort;
         boolean insecureGrpc;
-        String sslCertificateFile;
+        String rootCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
-            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
+            rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -72,7 +72,7 @@ public class ApertureFeatureFilter implements Filter {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setCACertificateFile(sslCertificateFile)
+                            .setRootCertificateFile(rootCertificateFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -72,7 +72,7 @@ public class ApertureFeatureFilter implements Filter {
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
-                            .setSslCertificateFile(sslCertificateFile)
+                            .setCACertificateFile(sslCertificateFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -71,6 +71,7 @@ public class ApertureFeatureFilter implements Filter {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
+                            .useInsecureGrpc()
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -54,15 +54,15 @@ public class ApertureFeatureFilter implements Filter {
     public void init(FilterConfig filterConfig) throws ServletException {
         String agentHost;
         String agentPort;
+        boolean insecureGrpc;
+        String sslCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
+            insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
+            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
         } catch (Exception e) {
-            throw new ServletException(
-                    "Invalid agent connection information "
-                            + filterConfig.getInitParameter("agent_host")
-                            + ":"
-                            + filterConfig.getInitParameter("agent_port"));
+            throw new ServletException("Could not read config parameters", e);
         }
 
         try {
@@ -71,7 +71,8 @@ public class ApertureFeatureFilter implements Filter {
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
                             .setDuration(Duration.ofMillis(1000))
-                            .useInsecureGrpc()
+                            .useInsecureGrpc(insecureGrpc)
+                            .setSslCertificateFile(sslCertificateFile)
                             .build();
         } catch (ApertureSDKException e) {
             e.printStackTrace();

--- a/sdks/aperture-java/javaagent/README.md
+++ b/sdks/aperture-java/javaagent/README.md
@@ -54,8 +54,8 @@ system properties or environment variables:
 | aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                |
 | aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                          |
 | aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                              |
-| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | false         | Whether GRPC connection to Aperture Agent should be over plaintext                                |
-| aperture.javaagent.ssl.certificate     | APERTURE_JAVAAGENT_SSL_CERTIFICATE     |               | Path to a file containing SL certificate to be used <br /> (insecure connection must be disabled) |
+| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether GRPC connection to Aperture Agent should be over plaintext                                |
+| aperture.javaagent.ca.certificate      | APERTURE_JAVAAGENT_CA_CERTIFICATE      |               | Path to a file containing CA certificate to be used <br /> (insecure connection must be disabled) |
 | aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                 |
 | aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                                        |
 | aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions                        |

--- a/sdks/aperture-java/javaagent/README.md
+++ b/sdks/aperture-java/javaagent/README.md
@@ -50,15 +50,16 @@ Aperture Java Instrumentation Agent can be configured using a properties file,
 system properties or environment variables:
 
 | Property name                          | Environment variable name              | Default value | Description                                                                                       |
-|:---------------------------------------|:---------------------------------------|:--------------|:--------------------------------------------------------------------------------------------------|
+| :------------------------------------- | :------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------ |
 | aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                |
 | aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                          |
 | aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                              |
-| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | false         | Whether GRPC connection to Aperture Agent shoud be over plaintext                                 |
+| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | false         | Whether GRPC connection to Aperture Agent should be over plaintext                                |
 | aperture.javaagent.ssl.certificate     | APERTURE_JAVAAGENT_SSL_CERTIFICATE     |               | Path to a file containing SL certificate to be used <br /> (insecure connection must be disabled) |
 | aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                 |
 | aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                                        |
 | aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions                        |
+
 The priority order is `system.property` > `ENV_VARIABLE` > `properties file`.
 
 Example invocation with commandline-set properties:

--- a/sdks/aperture-java/javaagent/README.md
+++ b/sdks/aperture-java/javaagent/README.md
@@ -49,16 +49,16 @@ following command:
 Aperture Java Instrumentation Agent can be configured using a properties file,
 system properties or environment variables:
 
-| Property name                          | Environment variable name              | Default value | Description                                                                                       |
-| :------------------------------------- | :------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------ |
-| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                |
-| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                          |
-| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                              |
-| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether GRPC connection to Aperture Agent should be over plaintext                                |
-| aperture.javaagent.ca.certificate      | APERTURE_JAVAAGENT_CA_CERTIFICATE      |               | Path to a file containing CA certificate to be used <br /> (insecure connection must be disabled) |
-| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                 |
-| aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                                        |
-| aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions                        |
+| Property name                          | Environment variable name              | Default value | Description                                                                                         |
+| :------------------------------------- | :------------------------------------- | :------------ | :-------------------------------------------------------------------------------------------------- |
+| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                  |
+| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                            |
+| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                                |
+| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether GRPC connection to Aperture Agent should be over plaintext                                  |
+| aperture.javaagent.root.certificate    | APERTURE_JAVAAGENT_ROOT_CERTIFICATE    |               | Path to a file containing root certificate to be used <br /> (insecure connection must be disabled) |
+| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                   |
+| aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                                          |
+| aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions                          |
 
 The priority order is `system.property` > `ENV_VARIABLE` > `properties file`.
 

--- a/sdks/aperture-java/javaagent/README.md
+++ b/sdks/aperture-java/javaagent/README.md
@@ -49,15 +49,16 @@ following command:
 Aperture Java Instrumentation Agent can be configured using a properties file,
 system properties or environment variables:
 
-| Property name                          | Environment variable name              | Default value | Description                                                                |
-| :------------------------------------- | :------------------------------------- | :------------ | :------------------------------------------------------------------------- |
-| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                         |
-| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                   |
-| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                       |
-| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                          |
-| aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                 |
-| aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions |
-
+| Property name                          | Environment variable name              | Default value | Description                                                                                       |
+|:---------------------------------------|:---------------------------------------|:--------------|:--------------------------------------------------------------------------------------------------|
+| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                |
+| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                          |
+| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                              |
+| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | false         | Whether GRPC connection to Aperture Agent shoud be over plaintext                                 |
+| aperture.javaagent.ssl.certificate     | APERTURE_JAVAAGENT_SSL_CERTIFICATE     |               | Path to a file containing SL certificate to be used <br /> (insecure connection must be disabled) |
+| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                 |
+| aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                                        |
+| aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions                        |
 The priority order is `system.property` > `ENV_VARIABLE` > `properties file`.
 
 Example invocation with commandline-set properties:

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -21,15 +21,15 @@ public class Config {
     public static final String BLOCKED_PATHS_REGEX_PROPERTY =
             "aperture.javaagent.blocked.paths.regex";
     public static final String INSECURE_GRPC_PROPERTY = "aperture.javaagent.insecure.grpc";
-    public static final String SSL_CERTIFICATE_FILE_PROPERTY = "aperture.javaagent.ssl.certificate";
+    public static final String CA_CERTIFICATE_FILE_PROPERTY = "aperture.javaagent.ca.certificate";
 
     private static final String AGENT_HOST_DEFAULT_VALUE = "localhost";
     private static final String AGENT_PORT_DEFAULT_VALUE = "8089";
     private static final String CONNECTION_TIMEOUT_MILLIS_DEFAULT_VALUE = "1000";
     private static final String BLOCKED_PATHS_DEFAULT_VALUE = "";
     private static final String BLOCKED_PATHS_REGEX_DEFAULT_VALUE = "false";
-    private static final String INSECURE_GRPC_DEFAULT_VALUE = "false";
-    private static final String SSL_CERTIFICATE_FILE_DEFAULT_VALUE = "";
+    private static final String INSECURE_GRPC_DEFAULT_VALUE = "true";
+    private static final String CA_CERTIFICATE_FILE_DEFAULT_VALUE = "";
 
     private static final List<String> allProperties =
             new ArrayList<String>() {
@@ -109,13 +109,13 @@ public class Config {
                     Boolean.parseBoolean(
                             config.getProperty(
                                     INSECURE_GRPC_PROPERTY, INSECURE_GRPC_DEFAULT_VALUE));
-            String sslCertificateFile =
+            String caCertificateFile =
                     config.getProperty(
-                            SSL_CERTIFICATE_FILE_PROPERTY, SSL_CERTIFICATE_FILE_DEFAULT_VALUE);
+                            CA_CERTIFICATE_FILE_PROPERTY, CA_CERTIFICATE_FILE_DEFAULT_VALUE);
 
             sdkBuilder.useInsecureGrpc(insecureGrpc);
-            if (!sslCertificateFile.isEmpty()) {
-                sdkBuilder.setSslCertificateFile(sslCertificateFile);
+            if (!caCertificateFile.isEmpty()) {
+                sdkBuilder.setCACertificateFile(caCertificateFile);
             }
 
             sdk = sdkBuilder.build();

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -21,7 +21,8 @@ public class Config {
     public static final String BLOCKED_PATHS_REGEX_PROPERTY =
             "aperture.javaagent.blocked.paths.regex";
     public static final String INSECURE_GRPC_PROPERTY = "aperture.javaagent.insecure.grpc";
-    public static final String CA_CERTIFICATE_FILE_PROPERTY = "aperture.javaagent.ca.certificate";
+    public static final String ROOT_CERTIFICATE_FILE_PROPERTY =
+            "aperture.javaagent.root.certificate";
 
     private static final String AGENT_HOST_DEFAULT_VALUE = "localhost";
     private static final String AGENT_PORT_DEFAULT_VALUE = "8089";
@@ -29,7 +30,7 @@ public class Config {
     private static final String BLOCKED_PATHS_DEFAULT_VALUE = "";
     private static final String BLOCKED_PATHS_REGEX_DEFAULT_VALUE = "false";
     private static final String INSECURE_GRPC_DEFAULT_VALUE = "true";
-    private static final String CA_CERTIFICATE_FILE_DEFAULT_VALUE = "";
+    private static final String ROOT_CERTIFICATE_FILE_DEFAULT_VALUE = "";
 
     private static final List<String> allProperties =
             new ArrayList<String>() {
@@ -111,11 +112,11 @@ public class Config {
                                     INSECURE_GRPC_PROPERTY, INSECURE_GRPC_DEFAULT_VALUE));
             String caCertificateFile =
                     config.getProperty(
-                            CA_CERTIFICATE_FILE_PROPERTY, CA_CERTIFICATE_FILE_DEFAULT_VALUE);
+                            ROOT_CERTIFICATE_FILE_PROPERTY, ROOT_CERTIFICATE_FILE_DEFAULT_VALUE);
 
             sdkBuilder.useInsecureGrpc(insecureGrpc);
             if (!caCertificateFile.isEmpty()) {
-                sdkBuilder.setCACertificateFile(caCertificateFile);
+                sdkBuilder.setRootCertificateFile(caCertificateFile);
             }
 
             sdk = sdkBuilder.build();

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -113,9 +113,8 @@ public class Config {
                     config.getProperty(
                             SSL_CERTIFICATE_FILE_PROPERTY, SSL_CERTIFICATE_FILE_DEFAULT_VALUE);
 
-            if (insecureGrpc) {
-                sdkBuilder.useInsecureGrpc();
-            } else if (!sslCertificateFile.isEmpty()) {
+            sdkBuilder.useInsecureGrpc(insecureGrpc);
+            if (!sslCertificateFile.isEmpty()) {
                 sdkBuilder.setSslCertificateFile(sslCertificateFile);
             }
 

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -20,12 +20,16 @@ public class Config {
     public static final String BLOCKED_PATHS_PROPERTY = "aperture.javaagent.blocked.paths";
     public static final String BLOCKED_PATHS_REGEX_PROPERTY =
             "aperture.javaagent.blocked.paths.regex";
+    public static final String INSECURE_GRPC_PROPERTY = "aperture.javaagent.insecure.grpc";
+    public static final String SSL_CERTIFICATE_FILE_PROPERTY = "aperture.javaagent.ssl.certificate";
 
     private static final String AGENT_HOST_DEFAULT_VALUE = "localhost";
     private static final String AGENT_PORT_DEFAULT_VALUE = "8089";
     private static final String CONNECTION_TIMEOUT_MILLIS_DEFAULT_VALUE = "1000";
     private static final String BLOCKED_PATHS_DEFAULT_VALUE = "";
     private static final String BLOCKED_PATHS_REGEX_DEFAULT_VALUE = "false";
+    private static final String INSECURE_GRPC_DEFAULT_VALUE = "false";
+    private static final String SSL_CERTIFICATE_FILE_DEFAULT_VALUE = "";
 
     private static final List<String> allProperties =
             new ArrayList<String>() {
@@ -78,7 +82,7 @@ public class Config {
         Properties config = loadProperties();
         ApertureSDK sdk;
         try {
-            sdk =
+            ApertureSDKBuilder sdkBuilder =
                     builder.setHost(
                                     config.getProperty(
                                             AGENT_HOST_PROPERTY, AGENT_HOST_DEFAULT_VALUE))
@@ -99,8 +103,23 @@ public class Config {
                                     Boolean.parseBoolean(
                                             config.getProperty(
                                                     BLOCKED_PATHS_REGEX_PROPERTY,
-                                                    BLOCKED_PATHS_REGEX_DEFAULT_VALUE)))
-                            .build();
+                                                    BLOCKED_PATHS_REGEX_DEFAULT_VALUE)));
+
+            boolean insecureGrpc =
+                    Boolean.parseBoolean(
+                            config.getProperty(
+                                    INSECURE_GRPC_PROPERTY, INSECURE_GRPC_DEFAULT_VALUE));
+            String sslCertificateFile =
+                    config.getProperty(
+                            SSL_CERTIFICATE_FILE_PROPERTY, SSL_CERTIFICATE_FILE_DEFAULT_VALUE);
+
+            if (insecureGrpc) {
+                sdkBuilder.useInsecureGrpc();
+            } else if (!sslCertificateFile.isEmpty()) {
+                sdkBuilder.setSslCertificateFile(sslCertificateFile);
+            }
+
+            sdk = sdkBuilder.build();
         } catch (Exception e) {
             throw new RuntimeException("failed to create Aperture SDK from config", e);
         }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -63,14 +63,14 @@ public final class ApertureSDKBuilder {
         return this;
     }
 
-    public ApertureSDKBuilder setCACertificateFile(String filename) {
+    public ApertureSDKBuilder setRootCertificateFile(String filename) {
         this.certFile = filename;
         return this;
     }
 
     /**
      * Makes the SDK use plaintext if true, and SSL/TLS if false. Custom root CA certificates can be
-     * passes using {@link #setCACertificateFile(String)} method.
+     * passes using {@link #setRootCertificateFile(String)} method.
      *
      * @return the builder object.
      */

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -57,8 +57,8 @@ public final class ApertureSDKBuilder {
         return this;
     }
 
-    public ApertureSDKBuilder useInsecureGrpc() {
-        this.insecureGrpc = true;
+    public ApertureSDKBuilder useInsecureGrpc(boolean enabled) {
+        this.insecureGrpc = enabled;
         return this;
     }
 

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "1.0.2";
+    public static final String LIBRARY_VERSION = "1.1.0";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "1.0.0";
+    public static final String LIBRARY_VERSION = "1.0.2";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -89,7 +89,7 @@ public class ApertureFilter implements Filter {
             }
             builder.useInsecureGrpc(insecureGrpc);
             if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
-                builder.setSslCertificateFile(sslCertificateFile);
+                builder.setCACertificateFile(sslCertificateFile);
             }
 
             this.apertureSDK = builder.build();

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -68,16 +68,16 @@ public class ApertureFilter implements Filter {
         String agentHost;
         String agentPort;
         String timeoutMs;
+        boolean insecureGrpc;
+        String sslCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
+            insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
+            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
         } catch (Exception e) {
-            throw new ServletException(
-                    "Invalid agent connection information "
-                            + filterConfig.getInitParameter("agent_host")
-                            + ":"
-                            + filterConfig.getInitParameter("agent_port"));
+            throw new ServletException("Could not read config parameters", e);
         }
 
         try {
@@ -86,6 +86,11 @@ public class ApertureFilter implements Filter {
             builder.setPort(Integer.parseInt(agentPort));
             if (timeoutMs != null) {
                 builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
+            }
+            if (insecureGrpc) {
+                builder.useInsecureGrpc();
+            } else if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
+                builder.setSslCertificateFile(sslCertificateFile);
             }
 
             this.apertureSDK = builder.build();

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -69,13 +69,13 @@ public class ApertureFilter implements Filter {
         String agentPort;
         String timeoutMs;
         boolean insecureGrpc;
-        String sslCertificateFile;
+        String rootCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
-            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
+            rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -88,8 +88,8 @@ public class ApertureFilter implements Filter {
                 builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
             }
             builder.useInsecureGrpc(insecureGrpc);
-            if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
-                builder.setCACertificateFile(sslCertificateFile);
+            if (rootCertificateFile != null && !rootCertificateFile.isEmpty()) {
+                builder.setRootCertificateFile(rootCertificateFile);
             }
 
             this.apertureSDK = builder.build();

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -87,9 +87,8 @@ public class ApertureFilter implements Filter {
             if (timeoutMs != null) {
                 builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
             }
-            if (insecureGrpc) {
-                builder.useInsecureGrpc();
-            } else if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
+            builder.useInsecureGrpc(insecureGrpc);
+            if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
                 builder.setSslCertificateFile(sslCertificateFile);
             }
 

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -89,7 +89,7 @@ public class ApertureFilter implements Filter {
             }
             builder.useInsecureGrpc(insecureGrpc);
             if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
-                builder.setSslCertificateFile(sslCertificateFile);
+                builder.setCACertificateFile(sslCertificateFile);
             }
 
             this.apertureSDK = builder.build();

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -69,13 +69,13 @@ public class ApertureFilter implements Filter {
         String agentPort;
         String timeoutMs;
         boolean insecureGrpc;
-        String sslCertificateFile;
+        String rootCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
-            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
+            rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -88,8 +88,8 @@ public class ApertureFilter implements Filter {
                 builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
             }
             builder.useInsecureGrpc(insecureGrpc);
-            if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
-                builder.setCACertificateFile(sslCertificateFile);
+            if (rootCertificateFile != null && !rootCertificateFile.isEmpty()) {
+                builder.setRootCertificateFile(rootCertificateFile);
             }
 
             this.apertureSDK = builder.build();

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -87,9 +87,8 @@ public class ApertureFilter implements Filter {
             if (timeoutMs != null) {
                 builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
             }
-            if (insecureGrpc) {
-                builder.useInsecureGrpc();
-            } else if (sslCertificateFile != null) {
+            builder.useInsecureGrpc(insecureGrpc);
+            if (sslCertificateFile != null && !sslCertificateFile.isEmpty()) {
                 builder.setSslCertificateFile(sslCertificateFile);
             }
 

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -68,16 +68,16 @@ public class ApertureFilter implements Filter {
         String agentHost;
         String agentPort;
         String timeoutMs;
+        boolean insecureGrpc;
+        String sslCertificateFile;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
+            insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
+            sslCertificateFile = filterConfig.getInitParameter("ssl_certificate_file");
         } catch (Exception e) {
-            throw new ServletException(
-                    "Invalid agent connection information "
-                            + filterConfig.getInitParameter("agent_host")
-                            + ":"
-                            + filterConfig.getInitParameter("agent_port"));
+            throw new ServletException("Could not read config parameters", e);
         }
 
         try {
@@ -86,6 +86,11 @@ public class ApertureFilter implements Filter {
             builder.setPort(Integer.parseInt(agentPort));
             if (timeoutMs != null) {
                 builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
+            }
+            if (insecureGrpc) {
+                builder.useInsecureGrpc();
+            } else if (sslCertificateFile != null) {
+                builder.setSslCertificateFile(sslCertificateFile);
             }
 
             this.apertureSDK = builder.build();

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "1.0.2"
+  var ver = "1.1.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "1.0.0"
+  var ver = "1.0.2"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes





<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Adds TLS configurability to the Java SDK, allowing users to provide SSL certificate and key files.
- Documentation: Updates various Dockerfiles, examples, and documentation files to support this change.

> "Secure connections now abound,
> With TLS configurability newly found.
> No more worries of data theft,
> Our Java SDK is now top-notch."
<!-- end of auto-generated comment: release notes by openai -->