### PR TITLE
Log received signal before stopping app

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -167,7 +167,8 @@ func Run(app *fx.App) {
 	platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath).SetStatus(status.NewStatus(wrapperspb.String("platform running"), nil))
 
 	// Wait for os.Signal
-	<-app.Done()
+	signal := <-app.Done()
+	log.Info().Str("signal", signal.String()).Msg("Received signal. Stopping application")
 	platform.statusRegistry.Child("system", readinessStatusPath).Child("component", platformStatusPath).SetStatus(status.NewStatus(nil, errors.New("platform stopping")))
 }
 


### PR DESCRIPTION
### Description of change
This change allows easier debugging when app is being stopped because of received signal like SIGTERM.

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Log received signals before stopping the app for improved debugging 🛠️

> Oh, signals we receive, 📡
> In logs, we now believe. 📚
> Debugging made a breeze, 💨
> With this PR, we're pleased! 😊
<!-- end of auto-generated comment: release notes by openai -->