### PR TITLE
Export metrics with pod count

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -17,7 +17,7 @@ executors:
         user: root
   python-cimg-executor:
     docker:
-      - image: cimg/python:3.10.6
+      - image: cimg/python:3.11
   base-machine-executor:
     machine:
       image: ubuntu-2204:2022.10.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         pass_filenames: false
         description: "Protobuf generation"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         exclude: ^(manifests/charts/.*/README*)|\.*svg$|\.*dot|api/gen/.*|sdks/aperture-java/lib/core/src/main/java/com/fluxninja/generated/.*$
@@ -42,7 +42,7 @@ repos:
         exclude: ^certs/(ca.key|key.pem)$
       - id: mixed-line-ending
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17
+    rev: v0.1.20
     hooks:
       - id: shellcheck
         exclude: ^(sdks/aperture-java/gradlew)$
@@ -82,13 +82,13 @@ repos:
           - black
         exclude: *py_exclude
   - repo: https://github.com/ambv/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.11
         exclude: *py_exclude
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.7.1"
+    rev: "v3.0.0-alpha.6"
     hooks:
       - id: prettier
         exclude: ^(docs/content/reference/.*|docs/content/reference/aperturectl/.*|manifests/charts/.*/README*|.github/.*/.*.md)
@@ -227,7 +227,7 @@ repos:
         language: script
         pass_filenames: false
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.1
+    rev: v2.2.4
     hooks:
       - id: codespell
         args:

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -161,4 +161,12 @@ const (
 	K8sNamespaceName = "k8s_namespace_name"
 	// K8sNodeName - name of a node.
 	K8sNodeName = "k8s_node_name"
+	// K8sReplicasetName - name of a replicaset.
+	K8sReplicasetName = "k8s_replicaset_name"
+	// K8sDaemonsetName - name of a daemonset.
+	K8sDaemonsetName = "k8s_daemonset_name"
+	// K8sStatefulsetName - name of a statefulset.
+	K8sStatefulsetName = "k8s_statefulset_name"
+	// K8sDeploymentName - name of a deployment.
+	K8sDeploymentName = "k8s_deployment_name"
 )

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -152,4 +152,13 @@ const (
 	DefaultWorkloadIndex = "default"
 	// DefaultAgentGroup - default agent group.
 	DefaultAgentGroup = "default"
+
+	// K8S METRICS.
+
+	// K8sPodCount - number of pods in the cluster.
+	K8sPodCount = "k8s_pod_count"
+	// K8sNamespaceName - namespace of a resource.
+	K8sNamespaceName = "k8s_namespace_name"
+	// K8sNodeName - name of a node.
+	K8sNodeName = "k8s_node_name"
 )

--- a/pkg/policies/autoscale/kubernetes/discovery/provide.go
+++ b/pkg/policies/autoscale/kubernetes/discovery/provide.go
@@ -39,13 +39,14 @@ type FxIn struct {
 	KubernetesClient   k8s.K8sClient      `optional:"true"`
 	Trackers           notifiers.Trackers `name:"kubernetes_control_points"`
 	Election           *election.Election
+	ElectionTrackers   notifiers.Trackers `name:"etcd_election"`
 	Config             autoscalek8sconfig.AutoScaleKubernetesConfig
 	PrometheusRegistry *prometheus.Registry
 }
 
 // provideAutoScaleControlPoints provides Kubernetes AutoScaler and starts Kubernetes control point discovery if enabled.
 func provideAutoScaleControlPoints(in FxIn) (AutoScaleControlPoints, error) {
-	controlPointCache, err := newAutoScaleControlPoints(in.Trackers, in.KubernetesClient, in.PrometheusRegistry, in.Election)
+	controlPointCache, err := newAutoScaleControlPoints(in.Trackers, in.KubernetesClient, in.PrometheusRegistry, in.ElectionTrackers, in.Lifecycle)
 	if err != nil {
 		return nil, fmt.Errorf("could not create auto sclae control points: %w", err)
 	}

--- a/pkg/policies/autoscale/kubernetes/discovery/provide.go
+++ b/pkg/policies/autoscale/kubernetes/discovery/provide.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/etcd/election"
@@ -10,6 +11,7 @@ import (
 	"github.com/fluxninja/aperture/pkg/notifiers"
 	autoscalek8sconfig "github.com/fluxninja/aperture/pkg/policies/autoscale/kubernetes/config"
 	"github.com/fluxninja/aperture/pkg/status"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 )
 
@@ -31,18 +33,22 @@ func Module() fx.Option {
 // FxIn is the input for the ProvideKuberetesControlPointsCache function.
 type FxIn struct {
 	fx.In
-	Unmarshaller     config.Unmarshaller
-	Lifecycle        fx.Lifecycle
-	StatusRegistry   status.Registry
-	KubernetesClient k8s.K8sClient      `optional:"true"`
-	Trackers         notifiers.Trackers `name:"kubernetes_control_points"`
-	Election         *election.Election
-	Config           autoscalek8sconfig.AutoScaleKubernetesConfig
+	Unmarshaller       config.Unmarshaller
+	Lifecycle          fx.Lifecycle
+	StatusRegistry     status.Registry
+	KubernetesClient   k8s.K8sClient      `optional:"true"`
+	Trackers           notifiers.Trackers `name:"kubernetes_control_points"`
+	Election           *election.Election
+	Config             autoscalek8sconfig.AutoScaleKubernetesConfig
+	PrometheusRegistry *prometheus.Registry
 }
 
 // provideAutoScaleControlPoints provides Kubernetes AutoScaler and starts Kubernetes control point discovery if enabled.
 func provideAutoScaleControlPoints(in FxIn) (AutoScaleControlPoints, error) {
-	controlPointCache := newAutoScaleControlPoints(in.Trackers, in.KubernetesClient)
+	controlPointCache, err := newAutoScaleControlPoints(in.Trackers, in.KubernetesClient, in.PrometheusRegistry, in.Election)
+	if err != nil {
+		return nil, fmt.Errorf("could not create auto sclae control points: %w", err)
+	}
 
 	if !in.Config.Enabled {
 		log.Info().Msg("Skipping Kubernetes Control Point Discovery since AutoScale is disabled")


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added Prometheus metrics and improved error handling to the Kubernetes Control Point Discovery module
- Introduced a `podNotifier` struct for leader change notifications

**Chore:**
- Updated Python version in CircleCI workflows
- Updated pre-commit hook versions and added codespell hook

> 🎉 A new dawn rises, metrics now gleam,
> 🌟 With pod notifiers, our code's a dream.
> 🐍 Python updated, hooks refined,
> 🚀 This PR's changes, truly shine!
<!-- end of auto-generated comment: release notes by openai -->