### PR TITLE
Deprecated warnings/errors in aperturectl and docs

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -265,7 +265,7 @@ message Classifier {
   // A map of {key, value} pairs mapping from
   // [flow label](/concepts/integrations/flow-control/flow-label.md) keys to rules that define
   // how to extract and propagate flow labels with that key.
-  map<string, Rule> rules = 2;
+  map<string, Rule> rules = 2; // @gotags: validate:"dive,keys,required,endkeys,required"
 
   // Rego based classification
   //
@@ -294,12 +294,12 @@ message Rule {
     // Source code of the rego module.
     //
     // Note: Must include a "package" declaration.
-    string source = 1; // @gotags: validate:"required"
+    string source = 1; // @gotags: validate:"deprecated,required"
 
     // Query string to extract a value (eg. `data.<mymodulename>.<variablename>`).
     //
     // Note: The module name must match the package name from the "source".
-    string query = 2; // @gotags: validate:"required"
+    string query = 2; // @gotags: validate:"deprecated,required"
   }
 
   oneof source {

--- a/api/aperture/policy/language/v1/policy.proto
+++ b/api/aperture/policy/language/v1/policy.proto
@@ -98,13 +98,13 @@ message Resources {
   // Flux Meter created metrics can be consumed as input to the circuit via the PromQL component.
   //
   // Deprecated: v1.5.0. Use `flow_control.flux_meters` instead.
-  map<string, FluxMeter> flux_meters = 1; // @gotags: validate:"dive"
+  map<string, FluxMeter> flux_meters = 1; // @gotags: validate:"deprecated,dive"
   // Classifiers are installed in the data-plane and are used to label the requests based on payload content.
   //
   // The flow labels created by Classifiers can be matched by Flux Meters to create metrics for control purposes.
   //
   // Deprecated: v1.5.0. Use `flow_control.classifiers` instead.
-  repeated Classifier classifiers = 2; // @gotags: validate:"dive"
+  repeated Classifier classifiers = 2; // @gotags: validate:"deprecated,dive"
 
   // FlowControlResources are resources that are provided by flow control integration.
   FlowControlResources flow_control = 101;

--- a/api/buf.lock
+++ b/api/buf.lock
@@ -8,7 +8,7 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: 98b2c044ebc341ff81d54493c5e4b340
+    commit: b2a7decf9b844786ba1c2f4ed210f329
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
@@ -32,4 +32,4 @@ deps:
   - remote: buf.build
     owner: prometheus
     repository: client-model
-    commit: 1d56a02d481a412a83b3c4984eb90c2e
+    commit: 55bcfe88c9e54edc9048a91656832525

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -556,7 +556,7 @@ type Classifier struct {
 	// A map of {key, value} pairs mapping from
 	// [flow label](/concepts/integrations/flow-control/flow-label.md) keys to rules that define
 	// how to extract and propagate flow labels with that key.
-	Rules map[string]*Rule `protobuf:"bytes,2,rep,name=rules,proto3" json:"rules,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Rules map[string]*Rule `protobuf:"bytes,2,rep,name=rules,proto3" json:"rules,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3" validate:"dive,keys,required,endkeys,required"` // @gotags: validate:"dive,keys,required,endkeys,required"
 	// Rego based classification
 	//
 	// Rego is a policy language used to express complex policies in a concise and declarative way.
@@ -2087,11 +2087,11 @@ type Rule_Rego struct {
 	// Source code of the rego module.
 	//
 	// Note: Must include a "package" declaration.
-	Source string `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty" validate:"required"` // @gotags: validate:"required"
+	Source string `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty" validate:"deprecated,required"` // @gotags: validate:"deprecated,required"
 	// Query string to extract a value (eg. `data.<mymodulename>.<variablename>`).
 	//
 	// Note: The module name must match the package name from the "source".
-	Query string `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty" validate:"required"` // @gotags: validate:"required"
+	Query string `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty" validate:"deprecated,required"` // @gotags: validate:"deprecated,required"
 }
 
 func (x *Rule_Rego) Reset() {

--- a/api/gen/proto/go/aperture/policy/language/v1/policy.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/policy.pb.go
@@ -290,13 +290,13 @@ type Resources struct {
 	// Flux Meter created metrics can be consumed as input to the circuit via the PromQL component.
 	//
 	// Deprecated: v1.5.0. Use `flow_control.flux_meters` instead.
-	FluxMeters map[string]*FluxMeter `protobuf:"bytes,1,rep,name=flux_meters,json=fluxMeters,proto3" json:"flux_meters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3" validate:"dive"` // @gotags: validate:"dive"
+	FluxMeters map[string]*FluxMeter `protobuf:"bytes,1,rep,name=flux_meters,json=fluxMeters,proto3" json:"flux_meters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3" validate:"deprecated,dive"` // @gotags: validate:"deprecated,dive"
 	// Classifiers are installed in the data-plane and are used to label the requests based on payload content.
 	//
 	// The flow labels created by Classifiers can be matched by Flux Meters to create metrics for control purposes.
 	//
 	// Deprecated: v1.5.0. Use `flow_control.classifiers` instead.
-	Classifiers []*Classifier `protobuf:"bytes,2,rep,name=classifiers,proto3" json:"classifiers,omitempty" validate:"dive"` // @gotags: validate:"dive"
+	Classifiers []*Classifier `protobuf:"bytes,2,rep,name=classifiers,proto3" json:"classifiers,omitempty" validate:"deprecated,dive"` // @gotags: validate:"deprecated,dive"
 	// FlowControlResources are resources that are provided by flow control integration.
 	FlowControl *FlowControlResources `protobuf:"bytes,101,opt,name=flow_control,json=flowControl,proto3" json:"flow_control,omitempty"`
 }

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -2693,6 +2693,7 @@
             "type": "object"
           },
           "type": "array",
+          "x-deprecated": true,
           "x-go-tag-validate": "deprecated,dive",
           "x-order": 0
         },
@@ -2707,6 +2708,7 @@
           },
           "description": "Flux Meters are installed in the data-plane and form the observability leg of the feedback loop.\n\nFlux Meter created metrics can be consumed as input to the circuit via the PromQL component.\n\nDeprecated: v1.5.0. Use `flow_control.flux_meters` instead.\n\n",
           "type": "object",
+          "x-deprecated": true,
           "x-go-tag-validate": "deprecated,dive",
           "x-order": 2
         }
@@ -2747,12 +2749,14 @@
         "query": {
           "description": "Query string to extract a value (eg. `data.<mymodulename>.<variablename>`).\n\nNote: The module name must match the package name from the \"source\".\n\n",
           "type": "string",
+          "x-deprecated": true,
           "x-go-tag-validate": "deprecated,required",
           "x-order": 0
         },
         "source": {
           "description": "Source code of the rego module.\n\nNote: Must include a \"package\" declaration.\n\n",
           "type": "string",
+          "x-deprecated": true,
           "x-go-tag-validate": "deprecated,required",
           "x-order": 1
         }

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -687,8 +687,9 @@
           "additionalProperties": {
             "$ref": "#/definitions/Rule"
           },
-          "description": "A map of {key, value} pairs mapping from\n[flow label](/concepts/integrations/flow-control/flow-label.md) keys to rules that define\nhow to extract and propagate flow labels with that key.",
+          "description": "A map of {key, value} pairs mapping from\n[flow label](/concepts/integrations/flow-control/flow-label.md) keys to rules that define\nhow to extract and propagate flow labels with that key.\n\n",
           "type": "object",
+          "x-go-tag-validate": "dive,keys,required,endkeys,required",
           "x-order": 2
         }
       },
@@ -2692,7 +2693,7 @@
             "type": "object"
           },
           "type": "array",
-          "x-go-tag-validate": "dive",
+          "x-go-tag-validate": "deprecated,dive",
           "x-order": 0
         },
         "flow_control": {
@@ -2706,7 +2707,7 @@
           },
           "description": "Flux Meters are installed in the data-plane and form the observability leg of the feedback loop.\n\nFlux Meter created metrics can be consumed as input to the circuit via the PromQL component.\n\nDeprecated: v1.5.0. Use `flow_control.flux_meters` instead.\n\n",
           "type": "object",
-          "x-go-tag-validate": "dive",
+          "x-go-tag-validate": "deprecated,dive",
           "x-order": 2
         }
       },
@@ -2746,13 +2747,13 @@
         "query": {
           "description": "Query string to extract a value (eg. `data.<mymodulename>.<variablename>`).\n\nNote: The module name must match the package name from the \"source\".\n\n",
           "type": "string",
-          "x-go-tag-validate": "required",
+          "x-go-tag-validate": "deprecated,required",
           "x-order": 0
         },
         "source": {
           "description": "Source code of the rego module.\n\nNote: Must include a \"package\" declaration.\n\n",
           "type": "string",
-          "x-go-tag-validate": "required",
+          "x-go-tag-validate": "deprecated,required",
           "x-order": 1
         }
       },

--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -319,7 +319,7 @@ func generateGraphs(content []byte, outputDir string, policyPath string, depth i
 	}
 	defer os.Remove(policyFile)
 
-	circuit, err := utils.CompilePolicy(policyFile)
+	circuit, _, err := utils.CompilePolicy(policyFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -321,7 +321,7 @@ func generateGraphs(content []byte, outputDir string, policyPath string, depth i
 
 	circuit, err := utils.CompilePolicy(policyFile)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if err = utils.GenerateDotFile(circuit, dotFilePath, depth); err != nil {

--- a/cmd/aperturectl/cmd/compile.go
+++ b/cmd/aperturectl/cmd/compile.go
@@ -37,7 +37,7 @@ You can also generate the DOT and Mermaid graphs of the compiled Aperture Policy
 	Example: `aperturectl compile --cr=policy-cr.yaml --mermaid --dot
 
 aperturectl compile --policy=policy.yaml --mermaid --dot`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		// check if policy or cr is provided
 		if policy == "" && cr == "" || policy != "" && cr != "" {
 			errStr := "either --policy or --cr must be provided"
@@ -58,7 +58,7 @@ aperturectl compile --policy=policy.yaml --mermaid --dot`,
 			policyFile = policy
 		}
 
-		circuit, err := utils.CompilePolicy(policyFile)
+		circuit, _, err := utils.CompilePolicy(policyFile)
 		if err != nil {
 			log.Error().Err(err).Msg("error reading policy spec")
 			return err

--- a/cmd/aperturectl/cmd/root.go
+++ b/cmd/aperturectl/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/apply"
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/autoscale"
@@ -12,12 +13,17 @@ import (
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/discovery"
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/flowcontrol"
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/installation"
+	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/info"
 	"github.com/fluxninja/aperture/pkg/log"
 )
 
 // Version shows the version of ApertureCtl.
-var Version = info.Version
+var (
+	Version         = info.Version
+	allowDeprecated bool
+	verbose         bool
+)
 
 func init() {
 	RootCmd.AddCommand(blueprints.BlueprintsCmd)
@@ -48,6 +54,31 @@ aperturectl is a CLI tool which can be used to interact with Aperture seamlessly
 
 // Execute is the entrypoint for the CLI. It is called from the main package.
 func Execute() {
+	// Process the verbose and allowDeprecated flags before executing the command.
+	// Fun fact: PersistentPreRunE doesn't allow chaining.
+
+	// set flags manually using pflag and parse them
+	pflag.BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+	pflag.BoolVar(&allowDeprecated, "allow-deprecated", false, "Allow deprecated fields in the configuration")
+	// configure pflag to ignore unknown flags
+	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
+	pflag.Parse()
+	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = false
+
+	level := "info"
+	if verbose {
+		level = "debug"
+	}
+
+	logger := log.NewLogger(log.GetPrettyConsoleWriter(), level)
+	log.SetGlobalLogger(logger)
+
+	err := config.RegisterDeprecatedValidator(allowDeprecated)
+	if err != nil {
+		log.Error().Err(err).Msg("Error registering deprecated validator")
+		os.Exit(1)
+	}
+
 	if err := RootCmd.Execute(); err != nil {
 		log.Error().Err(err).Msg("Error executing aperturectl")
 		os.Exit(1)

--- a/cmd/aperturectl/cmd/utils/utils.go
+++ b/cmd/aperturectl/cmd/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	languagev1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/language/v1"
 	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/circuitfactory"
@@ -109,10 +110,10 @@ func GenerateMermaidFile(circuit *circuitfactory.Circuit, mermaidFile string, de
 }
 
 // CompilePolicy compiles the policy and returns the circuit.
-func CompilePolicy(path string) (*circuitfactory.Circuit, error) {
+func CompilePolicy(path string) (*circuitfactory.Circuit, *languagev1.Policy, error) {
 	yamlFile, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	ctx := context.Background()
 
@@ -121,11 +122,11 @@ func CompilePolicy(path string) (*circuitfactory.Circuit, error) {
 	// command is called "circuit-compiler" though, so it's bit... surprising.
 	// If we compiled just a circuit, we could drop dependency on
 	// `controlplane` package.
-	circuit, err := controlplane.ValidateAndCompile(ctx, filepath.Base(path), yamlFile)
+	circuit, policy, err := controlplane.ValidateAndCompile(ctx, filepath.Base(path), yamlFile)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return circuit, nil
+	return circuit, policy, nil
 }
 
 // FetchPolicyFromCR extracts the spec key from a CR and saves it to a temp file.

--- a/cmd/aperturectl/cmd/utils/utils.go
+++ b/cmd/aperturectl/cmd/utils/utils.go
@@ -121,12 +121,9 @@ func CompilePolicy(path string) (*circuitfactory.Circuit, error) {
 	// command is called "circuit-compiler" though, so it's bit... surprising.
 	// If we compiled just a circuit, we could drop dependency on
 	// `controlplane` package.
-	circuit, valid, msg, err := controlplane.ValidateAndCompile(ctx, filepath.Base(path), yamlFile)
+	circuit, err := controlplane.ValidateAndCompile(ctx, filepath.Base(path), yamlFile)
 	if err != nil {
 		return nil, err
-	}
-	if !valid {
-		return nil, fmt.Errorf("invalid circuit: %s", msg)
 	}
 	return circuit, nil
 }

--- a/cmd/aperturectl/main.go
+++ b/cmd/aperturectl/main.go
@@ -3,13 +3,9 @@ package main
 import (
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd"
 	"github.com/fluxninja/aperture/pkg/info"
-	"github.com/fluxninja/aperture/pkg/log"
 )
 
 func main() {
 	info.Service = "aperturectl"
-
-	logger := log.NewLogger(log.GetPrettyConsoleWriter(), "info")
-	log.SetGlobalLogger(logger)
 	cmd.Execute()
 }

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -698,13 +698,15 @@ definitions:
         title: Rego based classification
         $ref: '#/definitions/Rego'
       rules:
-        description: |-
+        description: |+
           A map of {key, value} pairs mapping from
           [flow label](/concepts/integrations/flow-control/flow-label.md) keys to rules that define
           how to extract and propagate flow labels with that key.
+
         type: object
         additionalProperties:
           $ref: '#/definitions/Rule'
+        x-go-tag-validate: dive,keys,required,endkeys,required
   Component:
     description: |-
       :::info
@@ -2719,7 +2721,7 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/Classifier'
-        x-go-tag-validate: dive
+        x-go-tag-validate: deprecated,dive
       flow_control:
         description: FlowControlResources are resources that are provided by flow
           control integration.
@@ -2735,7 +2737,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/FluxMeter'
-        x-go-tag-validate: dive
+        x-go-tag-validate: deprecated,dive
   Rule:
     description: |-
       Example of a JSON extractor:
@@ -2797,7 +2799,7 @@ definitions:
           Note: The module name must match the package name from the "source".
 
         type: string
-        x-go-tag-validate: required
+        x-go-tag-validate: deprecated,required
       source:
         description: |+
           Source code of the rego module.
@@ -2805,7 +2807,7 @@ definitions:
           Note: Must include a "package" declaration.
 
         type: string
-        x-go-tag-validate: required
+        x-go-tag-validate: deprecated,required
   Scheduler:
     description: |-
       :::note

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2721,6 +2721,7 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/Classifier'
+        x-deprecated: true
         x-go-tag-validate: deprecated,dive
       flow_control:
         description: FlowControlResources are resources that are provided by flow
@@ -2737,6 +2738,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/FluxMeter'
+        x-deprecated: true
         x-go-tag-validate: deprecated,dive
   Rule:
     description: |-
@@ -2799,6 +2801,7 @@ definitions:
           Note: The module name must match the package name from the "source".
 
         type: string
+        x-deprecated: true
         x-go-tag-validate: deprecated,required
       source:
         description: |+
@@ -2807,6 +2810,7 @@ definitions:
           Note: Must include a "package" declaration.
 
         type: string
+        x-deprecated: true
         x-go-tag-validate: deprecated,required
   Scheduler:
     description: |-

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -749,11 +749,13 @@ definitions:
             rules:
                 additionalProperties:
                     $ref: '#/definitions/Rule'
-                description: |-
+                description: |+
                     A map of {key, value} pairs mapping from
                     [flow label](/concepts/integrations/flow-control/flow-label.md) keys to rules that define
                     how to extract and propagate flow labels with that key.
+
                 type: object
+                x-go-tag-validate: dive,keys,required,endkeys,required
         title: Set of classification rules sharing a common selector
         type: object
     ClassifierInfo:
@@ -3253,7 +3255,7 @@ definitions:
                     $ref: '#/definitions/Classifier'
                     type: object
                 type: array
-                x-go-tag-validate: dive
+                x-go-tag-validate: deprecated,dive
             flow_control:
                 $ref: '#/definitions/FlowControlResources'
                 description: FlowControlResources are resources that are provided by flow control integration.
@@ -3268,7 +3270,7 @@ definitions:
                     Deprecated: v1.5.0. Use `flow_control.flux_meters` instead.
 
                 type: object
-                x-go-tag-validate: dive
+                x-go-tag-validate: deprecated,dive
         title: Resources that need to be setup for the policy to function
         type: object
     Response:
@@ -3339,7 +3341,7 @@ definitions:
                     Note: The module name must match the package name from the "source".
 
                 type: string
-                x-go-tag-validate: required
+                x-go-tag-validate: deprecated,required
             source:
                 description: |+
                     Source code of the rego module.
@@ -3347,7 +3349,7 @@ definitions:
                     Note: Must include a "package" declaration.
 
                 type: string
-                x-go-tag-validate: required
+                x-go-tag-validate: deprecated,required
         required:
             - query
             - source

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -3255,6 +3255,7 @@ definitions:
                     $ref: '#/definitions/Classifier'
                     type: object
                 type: array
+                x-deprecated: true
                 x-go-tag-validate: deprecated,dive
             flow_control:
                 $ref: '#/definitions/FlowControlResources'
@@ -3270,6 +3271,7 @@ definitions:
                     Deprecated: v1.5.0. Use `flow_control.flux_meters` instead.
 
                 type: object
+                x-deprecated: true
                 x-go-tag-validate: deprecated,dive
         title: Resources that need to be setup for the policy to function
         type: object
@@ -3341,6 +3343,7 @@ definitions:
                     Note: The module name must match the package name from the "source".
 
                 type: string
+                x-deprecated: true
                 x-go-tag-validate: deprecated,required
             source:
                 description: |+
@@ -3349,6 +3352,7 @@ definitions:
                     Note: Must include a "package" declaration.
 
                 type: string
+                x-deprecated: true
                 x-go-tag-validate: deprecated,required
         required:
             - query

--- a/docs/content/reference/policies/spec.md
+++ b/docs/content/reference/policies/spec.md
@@ -3575,7 +3575,7 @@ Resources are typically Flux Meters, Classifiers, etc. that can be used to creat
 <dt>classifiers</dt>
 <dd>
 
-([[]Classifier](#classifier)) Classifiers are installed in the data-plane and are used to label the requests based on payload content.
+([[]Classifier](#classifier), **DEPRECATED**) Classifiers are installed in the data-plane and are used to label the requests based on payload content.
 
 The flow labels created by Classifiers can be matched by Flux Meters to create metrics for control purposes.
 
@@ -3591,7 +3591,7 @@ Deprecated: v1.5.0. Use `flow_control.classifiers` instead.
 <dt>flux_meters</dt>
 <dd>
 
-(map of [FluxMeter](#flux-meter)) Flux Meters are installed in the data-plane and form the observability leg of the feedback loop.
+(map of [FluxMeter](#flux-meter), **DEPRECATED**) Flux Meters are installed in the data-plane and form the observability leg of the feedback loop.
 
 Flux Meter created metrics can be consumed as input to the circuit via the PromQL component.
 
@@ -3667,7 +3667,7 @@ Deprecated: 1.5.0
 <dt>query</dt>
 <dd>
 
-(string, **required**) Query string to extract a value (eg. `data.<mymodulename>.<variablename>`).
+(string, **DEPRECATED**, **required**) Query string to extract a value (eg. `data.<mymodulename>.<variablename>`).
 
 Note: The module name must match the package name from the "source".
 
@@ -3675,7 +3675,7 @@ Note: The module name must match the package name from the "source".
 <dt>source</dt>
 <dd>
 
-(string, **required**) Source code of the rego module.
+(string, **DEPRECATED**, **required**) Source code of the rego module.
 
 Note: Must include a "package" declaration.
 

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -710,13 +710,15 @@ definitions:
         x-order: 1
         $ref: '#/definitions/Rego'
       rules:
-        description: |-
+        description: |+
           A map of {key, value} pairs mapping from
           [flow label](/concepts/integrations/flow-control/flow-label.md) keys to rules that define
           how to extract and propagate flow labels with that key.
+
         type: object
         additionalProperties:
           $ref: '#/definitions/Rule'
+        x-go-tag-validate: dive,keys,required,endkeys,required
         x-order: 2
   Component:
     description: |-
@@ -2912,7 +2914,7 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/Classifier'
-        x-go-tag-validate: dive
+        x-go-tag-validate: deprecated,dive
         x-order: 0
       flow_control:
         description: FlowControlResources are resources that are provided by flow
@@ -2930,7 +2932,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/FluxMeter'
-        x-go-tag-validate: dive
+        x-go-tag-validate: deprecated,dive
         x-order: 2
   Rule:
     description: |-
@@ -2996,7 +2998,7 @@ definitions:
           Note: The module name must match the package name from the "source".
 
         type: string
-        x-go-tag-validate: required
+        x-go-tag-validate: deprecated,required
         x-order: 0
       source:
         description: |+
@@ -3005,7 +3007,7 @@ definitions:
           Note: Must include a "package" declaration.
 
         type: string
-        x-go-tag-validate: required
+        x-go-tag-validate: deprecated,required
         x-order: 1
   Scheduler:
     description: |-

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -2914,6 +2914,7 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/Classifier'
+        x-deprecated: true
         x-go-tag-validate: deprecated,dive
         x-order: 0
       flow_control:
@@ -2932,6 +2933,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/FluxMeter'
+        x-deprecated: true
         x-go-tag-validate: deprecated,dive
         x-order: 2
   Rule:
@@ -2998,6 +3000,7 @@ definitions:
           Note: The module name must match the package name from the "source".
 
         type: string
+        x-deprecated: true
         x-go-tag-validate: deprecated,required
         x-order: 0
       source:
@@ -3007,6 +3010,7 @@ definitions:
           Note: Must include a "package" declaration.
 
         type: string
+        x-deprecated: true
         x-go-tag-validate: deprecated,required
         x-order: 1
   Scheduler:

--- a/docs/tools/swagger/process-go-tags.go
+++ b/docs/tools/swagger/process-go-tags.go
@@ -191,7 +191,7 @@ func processValidateRules(m map[string]interface{}, rules []string) (required bo
 	for _, rule := range rules {
 		switch rule {
 		case "deprecated":
-			continue
+			m["x-deprecated"] = true
 		case "required":
 			required = true
 		case "dive":

--- a/docs/tools/swagger/process-go-tags.go
+++ b/docs/tools/swagger/process-go-tags.go
@@ -190,6 +190,8 @@ func processValidateRules(m map[string]interface{}, rules []string) (required bo
 	// convert go validator rules to swagger rules
 	for _, rule := range rules {
 		switch rule {
+		case "deprecated":
+			continue
 		case "required":
 			required = true
 		case "dive":

--- a/docs/tools/swagger/swagger-templates/config.gotmpl
+++ b/docs/tools/swagger/swagger-templates/config.gotmpl
@@ -32,6 +32,9 @@
 
 {{- define "fnConstraints" }}
   {{- with .Extensions -}}
+    {{- with (index . "x-deprecated") -}}
+    **DEPRECATED**
+    {{- end -}}
     {{- with (index . "x-pattern-rules") -}}
  Format: `{{ . }}`
     {{- end -}}
@@ -53,6 +56,9 @@
 {{/* Like fnConstraints, but appropriate to rendering within body of text */ -}}
 {{- define "fnConstraintsInline" }}
   {{- with .Extensions -}}
+    {{- with (index . "x-deprecated") -}}
+    , **DEPRECATED**
+    {{- end -}}
     {{- with (index . "x-pattern-rules") -}}
     , format: `{{ . }}`
     {{- end -}}

--- a/pkg/policies/controlplane/validator.go
+++ b/pkg/policies/controlplane/validator.go
@@ -62,7 +62,7 @@ func ValidateAndCompile(ctx context.Context, name string, yamlSrc []byte) (*circ
 
 	err := config.UnmarshalYAML(yamlSrc, policy)
 	if err != nil {
-		return nil, false, err.Error(), nil
+		return nil, false, err.Error(), err
 	}
 
 	alerter := alerts.NewSimpleAlerter(100)

--- a/pkg/policies/controlplane/validator.go
+++ b/pkg/policies/controlplane/validator.go
@@ -49,27 +49,31 @@ func (v *PolicySpecValidator) ValidateSpec(
 	name string,
 	yamlSrc []byte,
 ) (bool, string, error) {
-	_, valid, msg, err := ValidateAndCompile(ctx, name, yamlSrc)
-	return valid, msg, err
+	_, err := ValidateAndCompile(ctx, name, yamlSrc)
+	if err != nil {
+		// there is no need to handle validator errors. just return validation result.
+		return false, err.Error(), nil
+	}
+	return true, "", nil
 }
 
 // ValidateAndCompile checks the validity of a single Policy and compiles it.
-func ValidateAndCompile(ctx context.Context, name string, yamlSrc []byte) (*circuitfactory.Circuit, bool, string, error) {
+func ValidateAndCompile(ctx context.Context, name string, yamlSrc []byte) (*circuitfactory.Circuit, error) {
 	if len(yamlSrc) == 0 {
-		return nil, false, "Empty yaml", nil
+		return nil, errors.New("empty policy")
 	}
 	policy := &policiesv1.Policy{}
 
 	err := config.UnmarshalYAML(yamlSrc, policy)
 	if err != nil {
-		return nil, false, err.Error(), err
+		return nil, err
 	}
 
 	alerter := alerts.NewSimpleAlerter(100)
 	registry := status.NewRegistry(log.GetGlobalLogger(), alerter)
 	circuit, err := CompilePolicy(policy, registry)
 	if err != nil {
-		return nil, false, err.Error(), err
+		return nil, err
 	}
 
 	if policy.GetResources() != nil {
@@ -88,14 +92,9 @@ func ValidateAndCompile(ctx context.Context, name string, yamlSrc []byte) (*circ
 				},
 			})
 			if err != nil {
-				if errors.Is(err, compiler.BadExtractor) || errors.Is(err, compiler.BadSelector) ||
-					errors.Is(err, compiler.BadRego) || errors.Is(err, compiler.BadLabelName) {
-					return nil, false, err.Error(), nil
-				} else {
-					return nil, false, err.Error(), err
-				}
+				return nil, err
 			}
 		}
 	}
-	return circuit, true, "", nil
+	return circuit, nil
 }

--- a/pkg/policies/controlplane/validator_test.go
+++ b/pkg/policies/controlplane/validator_test.go
@@ -35,9 +35,8 @@ var _ = Describe("Validator", Ordered, func() {
 			Object:    runtime.RawExtension{Raw: []byte(jsonPolicy)},
 		}
 
-		ok, msg, err := policyValidator.ValidateObject(context.TODO(), request)
+		ok, _, err := policyValidator.ValidateObject(context.TODO(), request)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(msg).To(BeEmpty())
 		Expect(ok).To(BeTrue())
 	}
 

--- a/pkg/webhooks/policyvalidator/validator.go
+++ b/pkg/webhooks/policyvalidator/validator.go
@@ -82,11 +82,11 @@ func (v *PolicyValidator) ValidateObject(
 	for _, validator := range v.policyValidators {
 		ok, msg, err := validator.ValidateSpec(ctx, policy.GetName(), policy.Spec.Raw)
 		if err != nil {
-			return false, "Spec is not valid", err
+			return false, "Validator error", err
 		}
 
 		if !ok {
-			return ok, fmt.Sprintf("%s: %s", policy.GetName(), msg), err
+			return ok, fmt.Sprintf("%s: %s", policy.GetName(), msg), nil
 		}
 	}
 

--- a/pkg/webhooks/policyvalidator/validator.go
+++ b/pkg/webhooks/policyvalidator/validator.go
@@ -86,9 +86,9 @@ func (v *PolicyValidator) ValidateObject(
 		}
 
 		if !ok {
-			return ok, fmt.Sprintf("%s: %s", policy.GetName(), msg), nil
+			return false, fmt.Sprintf("%s: %s", policy.GetName(), msg), nil
 		}
 	}
 
-	return true, "", nil
+	return true, fmt.Sprintf("%s: Valid Policy", policy.GetName()), nil
 }


### PR DESCRIPTION
##### Checklist

- [X] Tested in playground or other setup
- [X] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [X] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

![Screenshot 2023-03-31 at 12 20 13 PM](https://user-images.githubusercontent.com/18579817/229210603-538f1653-9f25-4b6c-a28d-3e8020a8afc9.png)




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Deprecates outdated fields and functions
- Adds validation tags to improve code quality
- Updates error messages for better clarity
- Adds new flags to the CLI tool
- Improves Swagger validation with deprecation warnings

> "Deprecated fields are now gone,  
> Validation tags have been put on.  
> Error messages are clear and bright,  
> CLI tool has new flags in sight.  
> With Swagger, warnings now appear,  
> This PR brings good changes near."
<!-- end of auto-generated comment: release notes by openai -->