### PR TITLE
fix: upgrade circleci cli and add check for know errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: shellcheck
         exclude: ^(sdks/aperture-java/gradlew)$
   - repo: https://github.com/fluxninja/pre-commit-hooks.git
-    rev: v0.0.3
+    rev: v0.0.4
     hooks:
       - id: circleci-validate
   - repo: https://github.com/fluxninja/pre-commit-golang

--- a/.tool-versions
+++ b/.tool-versions
@@ -18,5 +18,5 @@ jb 0.5.1
 tanka 0.24.0
 tilt 0.31.2
 jsonnet 0.19.1
-circleci 0.1.23667
+circleci 0.1.25638
 java corretto-19.0.2.7.1


### PR DESCRIPTION
### Description of change
with the latest version for circleci cli the validate command fails if there in no workflow to run in yaml file.
Updated the pre-commit hooks to handle the know error. https://github.com/fluxninja/pre-commit-hooks/pull/28

##### Checklist
Tested it on local


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Bug fix: Upgraded CircleCI CLI version to `0.1.25638` and added a check for known errors to handle validation errors when there is no workflow to run in the YAML file.

> "CircleCI validation, oh what a pain,
> But fear not, this PR has come to our gain.
> With an upgrade and a check, 
> We can now validate without a wreck."
<!-- end of auto-generated comment: release notes by openai -->