### PR TITLE
Documented ways to use environment variables in rabbitmq OTEL receiver

### DIFF
--- a/cmd/aperture-agent/config/types.go
+++ b/cmd/aperture-agent/config/types.go
@@ -97,6 +97,7 @@ type BatchPostrollupConfig struct {
 }
 
 // CustomMetricsConfig defines receivers, processors, and single metrics pipeline which will be exported to the controller prometheus.
+// Environment variables can be used in the configuration using format `${ENV_VAR_NAME}`.
 // +kubebuilder:object:generate=true
 //
 // :::info

--- a/docs/content/get-started/integrations/metrics/rabbitmq.md
+++ b/docs/content/get-started/integrations/metrics/rabbitmq.md
@@ -10,11 +10,12 @@ keywords:
 sidebar_position: 1
 ---
 
-First, make sure you've [built][build] agent with `rabbitmqreceiver` extension
-enabled, so that [rabbitmqreceiver][receiver] is available.
+Before proceeding, ensure that you have [built][build] the Aperture Agent with
+the `rabbitmqreceiver` extension enabled, so that [rabbitmqreceiver][receiver]
+is available.
 
-Then, you can use the following [custom metrics][custom-metrics] configuration
-in [agent's config][agent-config]:
+You can configure [Custom metrics][custom-metrics] for RabbitMQ using the
+following configuration in the [Aperture Agent's config][agent-config]:
 
 ```yaml
 otel:
@@ -32,10 +33,94 @@ otel:
           timeout: 10s
       receivers:
         rabbitmq:
+          endpoint: http://<rabbitmq-service-address>:15672
+          username: <username>
+          password: <password>
           collection_interval: 1s
-          endpoint: http://rabbitmq.rabbitmq.svc.cluster.local:15672
-          password: secretpassword
-          username: admin
+```
+
+You can also pass these configurations using environment variables as shown
+below:
+
+```yaml
+otel:
+  custom_metrics:
+    rabbitmq:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - rabbitmq
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        rabbitmq:
+          endpoint: ${RABBITMQ_ENDPOINT}
+          username: ${RABBITMQ_USERNAME}
+          password: ${RABBITMQ_PASSWORD}
+          collection_interval: 1s
+```
+
+If you're installing the Aperture Agent on Kubernetes, you can use a Secret and
+a ConfigMap to pass environment variables to the Aperture Agent, as shown below:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq
+data:
+  RABBITMQ_ENDPOINT: http://rabbitmq.rabbitmq.svc.cluster.local:15672
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-creds
+  namespace: aperture-agent
+data:
+  RABBITMQ_USERNAME: <rabbitmq-username>
+  RABBITMQ_PASSWORD: <rabbitmq-password>
+```
+
+To use these secrets and config maps during the
+[Aperture Agent Installation](/get-started/installation/agent/agent.md#agent-installation-modes),
+refer to them in the values.yaml file, as shown below:
+
+```yaml
+agent:
+  config:
+    etcd:
+      endpoints: ["http://controller-etcd.default.svc.cluster.local:2379"]
+    prometheus:
+      address: "http://controller-prometheus-server.default.svc.cluster.local:80"
+    agent_functions:
+      endpoints: ["aperture-controller.default.svc.cluster.local:8080"]
+    otel:
+      custom_metrics:
+        rabbitmq:
+          per_agent_group: true
+          pipeline:
+            processors:
+              - batch
+            receivers:
+              - rabbitmq
+          processors:
+            batch:
+              send_batch_size: 10
+              timeout: 10s
+          receivers:
+            rabbitmq:
+              endpoint: ${RABBITMQ_ENDPOINT}
+              username: ${RABBITMQ_USERNAME}
+              password: ${RABBITMQ_PASSWORD}
+              collection_interval: 1s
+  extraEnvVarsSecret: "rabbitmq-creds"
+  extraEnvVarsCM: "rabbitmq"
 ```
 
 [build]: /reference/aperturectl/build/agent/agent.md

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -761,6 +761,7 @@ https://github.com/kubernetes-sigs/kubebuilder/issues/528
 ### CustomMetricsConfig {#custom-metrics-config}
 
 CustomMetricsConfig defines receivers, processors, and single metrics pipeline which will be exported to the controller prometheus.
+Environment variables can be used in the configuration using format `${ENV_VAR_NAME}`.
 
 :::info
 See also [Get Started / Setup Integrations / Metrics](/get-started/integrations/metrics/metrics.md).

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -408,7 +408,9 @@ definitions:
             receivers:
                 $ref: '#/definitions/Components'
                 x-go-tag-json: receivers
-        title: CustomMetricsConfig defines receivers, processors, and single metrics pipeline which will be exported to the controller prometheus.
+        title: |-
+            CustomMetricsConfig defines receivers, processors, and single metrics pipeline which will be exported to the controller prometheus.
+            Environment variables can be used in the configuration using format `${ENV_VAR_NAME}`.
         type: object
         x-go-package: github.com/fluxninja/aperture/cmd/aperture-agent/config
     CustomMetricsPipelineConfig:

--- a/extensions/integrations/otel/rabbitmqreceiver/rabbitmqreceiver.go
+++ b/extensions/integrations/otel/rabbitmqreceiver/rabbitmqreceiver.go
@@ -16,7 +16,7 @@ import (
 func Module() fx.Option {
 	log.Info().Msg("Loading rabbitmqreceiver Receiver")
 	if info.Service != utils.ApertureAgent {
-		return nil
+		return fx.Options()
 	}
 	return fx.Options(
 		fx.Provide(

--- a/manifests/charts/aperture-agent/templates/agent.yaml
+++ b/manifests/charts/aperture-agent/templates/agent.yaml
@@ -107,6 +107,12 @@ spec:
   {{- if .Values.agent.extraEnvVars }}
   extraEnvVars: {{ .Values.agent.extraEnvVars | toYaml | nindent 4 }}
   {{- end }}
+  {{- if .Values.agent.extraEnvVarsCM }}
+  extraEnvVarsCM: {{ .Values.agent.extraEnvVarsCM }}
+  {{- end }}
+  {{- if .Values.agent.extraEnvVarsSecret }}
+  extraEnvVarsSecret: {{ .Values.agent.extraEnvVarsSecret }}
+  {{- end }}
   {{- if .Values.agent.extraVolumes }}
   extraVolumes: {{ .Values.agent.extraVolumes | toYaml | nindent 4}}
   {{- end }}

--- a/manifests/charts/aperture-controller/templates/controller.yaml
+++ b/manifests/charts/aperture-controller/templates/controller.yaml
@@ -110,6 +110,12 @@ spec:
   {{- if .Values.controller.extraEnvVars }}
   extraEnvVars: {{ .Values.controller.extraEnvVars | toYaml | nindent 4 }}
   {{- end }}
+  {{- if .Values.controller.extraEnvVarsCM }}
+  extraEnvVarsCM: {{ .Values.controller.extraEnvVarsCM }}
+  {{- end }}
+  {{- if .Values.controller.extraEnvVarsSecret }}
+  extraEnvVarsSecret: {{ .Values.controller.extraEnvVarsSecret }}
+  {{- end }}
   {{- if .Values.controller.extraVolumes }}
   extraVolumes: {{ .Values.controller.extraVolumes | toYaml | nindent 4}}
   {{- end }}

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1529,8 +1529,10 @@ spec:
                         additionalProperties:
                           description: "CustomMetricsConfig defines receivers, processors,
                             and single metrics pipeline which will be exported to
-                            the controller prometheus. \n :::info See also [Get Started
-                            / Setup Integrations / Metrics](/get-started/integrations/metrics/metrics.md).
+                            the controller prometheus. Environment variables can be
+                            used in the configuration using format `${ENV_VAR_NAME}`.
+                            \n :::info See also [Get Started / Setup Integrations
+                            / Metrics](/get-started/integrations/metrics/metrics.md).
                             :::"
                           properties:
                             per_agent_group:


### PR DESCRIPTION
- [x] Tested in playground or other setup
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Support for environment variables in `CustomMetricsConfig` and RabbitMQ configurations 🌍
- Improved RabbitMQ receiver module loading 🐇

> 🎉 Environment variables, now we can use,
> In configs, they bring flexibility to choose.
> RabbitMQ receiver, always ready to load,
> A better experience, this update bestowed. 🚀
<!-- end of auto-generated comment: release notes by openai -->