### PR TITLE
fix: add check for darwin to upload packages

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -982,15 +982,18 @@ jobs:
             - run:
                 name: Upload package to GCP
                 command: |
-                  gcloud config set artifacts/location us-central1
-                  for package in "deb" "rpm"
-                  do
-                    gcloud config set artifacts/repository aperture-${package}-packages
-                    case "${package}" in
-                      deb) gcloud artifacts apt upload aperture-${package}-packages --source="$(ls dist/packages/*.${package})" --project=${GOOGLE_PROJECT_ID};;
-                      rpm) gcloud artifacts yum upload aperture-${package}-packages --source="$(ls dist/packages/*.${package})" --project=${GOOGLE_PROJECT_ID};;
-                    esac
-                  done
+                  if [ "${GOOS}" != "darwin" ]
+                  then
+                    gcloud config set artifacts/location us-central1
+                    for package in "deb" "rpm"
+                    do
+                      gcloud config set artifacts/repository aperture-${package}-packages
+                      case "${package}" in
+                        deb) gcloud artifacts apt upload aperture-${package}-packages --source="$(ls dist/packages/*.${package})" --project=${GOOGLE_PROJECT_ID};;
+                        rpm) gcloud artifacts yum upload aperture-${package}-packages --source="$(ls dist/packages/*.${package})" --project=${GOOGLE_PROJECT_ID};;
+                      esac
+                    done
+                  fi
       - save_cache:
           name: Save go cache
           key: aperture-{{ .Environment.COMPONENT }}-packages-go-cache


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Prevents uploading packages to GCP for darwin OS by adding an OS check in `.circleci/continue-workflows.yml`

> 🎉 No more darwin uploads, we say,
> 🛠️ A bug fix that saves the day!
> 🌐 To GCP, packages now go,
> 🚀 With gcloud commands, smooth as a bow. 🏹
<!-- end of auto-generated comment: release notes by openai -->