### PR TITLE
Fix

### DIFF
--- a/pkg/otelcollector/alertsreceiver/receiver.go
+++ b/pkg/otelcollector/alertsreceiver/receiver.go
@@ -35,7 +35,9 @@ func (p *alertsReceiver) Start(_ context.Context, _ component.Host) error {
 
 // Shutdown calls shutdown function which kills run() goroutine.
 func (p *alertsReceiver) Shutdown(_ context.Context) error {
-	p.shutdown()
+	if p.shutdown != nil {
+		p.shutdown()
+	}
 	return nil
 }
 

--- a/playground/scenarios/graphql_query_static_rate_limiting/load_generator/test.js
+++ b/playground/scenarios/graphql_query_static_rate_limiting/load_generator/test.js
@@ -25,11 +25,7 @@ function sign(data, hashAlg, secret) {
 
   // Some manual base64 rawurl encoding as `Hasher.digest(encodingType)`
   // doesn't support that encoding type yet.
-  return hasher
-    .digest("base64")
-    .replace(/\//g, "_")
-    .replace(/\\+/g, "-")
-    .replace(/=/g, "");
+  return hasher.digest("base64").replace(/\\//g, "_").replace(/\\+/g, "-").replace(/=/g, "");
 }
 
 function encode(payload, secret) {


### PR DESCRIPTION
### Description of change
- nil pointer dereference error in altersreceiver's shutdown
- escape in graphql load generator script

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Fixed a nil pointer dereference error in the `otelcollector` package's `Shutdown` function.
- Resolved an escape issue in the `graphql_query_static_rate_limiting` load generator script.

> 🎉 Hooray for fixes, making our code strong! 🛠️
> No more errors, where they don't belong. 🚫
> With each improvement, we march ahead, 🚀
> Crafting software that users can trust and spread. 💻🌐
<!-- end of auto-generated comment: release notes by openai -->