### PR TITLE
Handle multiple definitions of FluxMeter with same name

### DIFF
--- a/pkg/policies/controlplane/validator.go
+++ b/pkg/policies/controlplane/validator.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	policiesv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/language/v1"
 	policysyncv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/sync/v1"
@@ -27,12 +28,16 @@ type FxOut struct {
 // Note: This validator must be registered to be accessible.
 func providePolicyValidator() FxOut {
 	return FxOut{
-		Validator: &PolicySpecValidator{},
+		Validator: &PolicySpecValidator{
+			fluxmeterNames: make(map[string]bool),
+		},
 	}
 }
 
 // PolicySpecValidator Policy implementation of PolicySpecValidator interface.
-type PolicySpecValidator struct{}
+type PolicySpecValidator struct {
+	fluxmeterNames map[string]bool
+}
 
 // ValidateSpec checks the validity of a Policy spec
 //
@@ -49,11 +54,29 @@ func (v *PolicySpecValidator) ValidateSpec(
 	name string,
 	yamlSrc []byte,
 ) (bool, string, error) {
-	_, _, err := ValidateAndCompile(ctx, name, yamlSrc)
+	_, policy, err := ValidateAndCompile(ctx, name, yamlSrc)
 	if err != nil {
 		// there is no need to handle validator errors. just return validation result.
 		return false, err.Error(), nil
 	}
+
+	fluxmeters := policy.GetResources().GetFlowControl().GetFluxMeters()
+	// Deprecated: v1.5.0
+	if fluxmeters == nil {
+		fluxmeters = policy.GetResources().GetFluxMeters()
+	}
+
+	newNames := make(map[string]bool)
+	for fluxMeterName := range fluxmeters {
+		newNames[fluxMeterName] = true
+		if v.fluxmeterNames[fluxMeterName] {
+			return false, fmt.Sprintf("fluxmeter name \"%s\" already used in other policy", fluxMeterName), nil
+		}
+	}
+	for key, val := range newNames {
+		v.fluxmeterNames[key] = val
+	}
+
 	return true, "", nil
 }
 

--- a/pkg/policies/controlplane/validator.go
+++ b/pkg/policies/controlplane/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	policiesv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/language/v1"
 	policysyncv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/sync/v1"
@@ -36,6 +37,7 @@ func providePolicyValidator() FxOut {
 
 // PolicySpecValidator Policy implementation of PolicySpecValidator interface.
 type PolicySpecValidator struct {
+	mu             sync.Mutex
 	fluxmeterNames map[string]bool
 }
 
@@ -65,6 +67,9 @@ func (v *PolicySpecValidator) ValidateSpec(
 	if fluxmeters == nil {
 		fluxmeters = policy.GetResources().GetFluxMeters()
 	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
 
 	newNames := make(map[string]bool)
 	for fluxMeterName := range fluxmeters {


### PR DESCRIPTION
### Description of change
Closes: GH-1690

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added mutex-protected map for FluxMeter names to prevent duplicates in the validation process

> 🎉 A map now stands, guarding our land,
> 🛡️ Mutex-protected, duplicates detected,
> 🌟 FluxMeter names, no more the same,
> 🚀 Our code's refined, a brighter future designed. 🎉
<!-- end of auto-generated comment: release notes by openai -->