### PR TITLE
Fixed aperturectl help and blueprints uri issue

### DIFF
--- a/cmd/aperturectl/cmd/blueprints/root.go
+++ b/cmd/aperturectl/cmd/blueprints/root.go
@@ -3,6 +3,7 @@ package blueprints
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,9 +76,15 @@ Use this command to pull, list, remove and generate Aperture Policy resources us
 			}
 			blueprintsURI = fmt.Sprintf("%s@%s", defaultBlueprintsRepo, blueprintsVersion)
 		} else {
-			blueprintsURI, err = filepath.Abs(blueprintsURI)
+			var blueprintsURL *url.URL
+			blueprintsURL, err = url.Parse(blueprintsURI)
 			if err != nil {
-				return err
+				blueprintsURI, err = filepath.Abs(blueprintsURI)
+				if err != nil {
+					return err
+				}
+			} else {
+				blueprintsURI = blueprintsURL.String()
 			}
 		}
 

--- a/cmd/aperturectl/cmd/root.go
+++ b/cmd/aperturectl/cmd/root.go
@@ -60,6 +60,8 @@ func Execute() {
 	// set flags manually using pflag and parse them
 	pflag.BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	pflag.BoolVar(&allowDeprecated, "allow-deprecated", false, "Allow deprecated fields in the configuration")
+	// Set help flag to false by default to print help for aperturectl command instead of pflags
+	pflag.BoolP("help", "h", false, "Display help for aperturectl command")
 	// configure pflag to ignore unknown flags
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.Parse()


### PR DESCRIPTION
### Description of change

Disabled the help of pflags to get the correct output with `aperturectl -h`
There was an issue with remote URLs as uri for aperturectl blueprints command which is fixed.

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added support for remote URLs as URIs in `aperturectl blueprints` command
- Disabled pflags help for correct output with `aperturectl -h`

> 🌐 Remote URLs, now we embrace, 🤗<br>
> For blueprints, a wider space. 🚀<br>
> With pflags help, no more collide, 🛠️<br>
> A better experience, we provide! 🎉
<!-- end of auto-generated comment: release notes by openai -->