### PR TITLE
Add information on path ignoring to SDK libraries documentation

### DIFF
--- a/docs/content/get-started/integrations/flow-control/sdk/java/armeria.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/armeria.md
@@ -38,6 +38,31 @@ traffic Control Points for decorated services:
     serverBuilder.service("/somePath", decoratedService);
 ```
 
+You can instruct the decorator to exclude specific paths from being monitored by
+the Aperture SDK. For example, you might want to exclude endpoints used for
+health checks. To do this, you can add the path(s) you want to ignore to the
+ignoredPaths field of the SDK, as shown in the following code:
+
+```java
+ApertureSDK sdk = ApertureSDK.Builder()
+        .setHost(...)
+        .setPort(...)
+        ...
+        .addIgnoredPaths("/healthz")
+        ...
+        .build()
+```
+
+The paths should be specified as a comma-separated list. Note that the paths you
+specify must match exactly. However, you can change this behavior to treat the
+paths as regular expressions by setting the ignoredPathMatchRegex flag to true,
+like so:
+
+```java
+  builder
+        .setIgnoredPathMatchRegex(true)
+```
+
 For more context on how to use Aperture Armeria Decorators to set Control
 Points, you can take a look at the [example app][armeria-example] available in
 our repository.

--- a/docs/content/get-started/integrations/flow-control/sdk/java/armeria.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/armeria.md
@@ -44,11 +44,11 @@ health checks. To do this, you can add the path(s) you want to ignore to the
 ignoredPaths field of the SDK, as shown in the following code:
 
 ```java
-ApertureSDK sdk = ApertureSDK.Builder()
+ApertureSDK sdk = ApertureSDK.builder()
         .setHost(...)
         .setPort(...)
         ...
-        .addIgnoredPaths("/healthz")
+        .addIgnoredPaths("/healthz,/metrics")
         ...
         .build()
 ```

--- a/docs/content/get-started/integrations/flow-control/sdk/java/auto-instrumentation.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/auto-instrumentation.md
@@ -44,8 +44,8 @@ system properties or environment variables:
 | aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                   |
 | aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                       |
 | aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                          |
-| aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                 |
-| aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions |
+| aperture.javaagent.ignored.paths       | APERTURE_JAVAAGENT_IGNORED_PATHS       |               | Comma-separated list of paths that should not start a flow                 |
+| aperture.javaagent.ignored.paths.regex | APERTURE_JAVAAGENT_IGNORED_PATHS_REGEX |               | Whether the configured ignored paths should be read as regular expressions |
 
 The priority order is `system.property` > `ENV_VARIABLE` > `properties file`.
 
@@ -55,7 +55,7 @@ Example invocation with commandline-set properties:
 java -javaagent:path/to/javaagent.jar \
 -Daperture.agent.hostname="some_host" \
 -Daperture.agent.port=12345 \
--Daperture.javaagent.blocked.paths="/health,/connected" \
+-Daperture.javaagent.ignored.paths="/health,/connected" \
 -jar path/to/application.jar
 ```
 
@@ -72,7 +72,7 @@ The `/config.properties` file:
 ```properties
 aperture.agent.hostname=some_host
 aperture.agent.port=12345
-aperture.javaagent.blocked.paths=/health,/connected
+aperture.javaagent.ignored.paths=/health,/connected
 ```
 
 [download_link]:

--- a/docs/content/get-started/integrations/flow-control/sdk/java/netty.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/netty.md
@@ -57,11 +57,11 @@ health checks. To do this, you can add the path(s) you want to ignore to the
 ignoredPaths field of the SDK, as shown in the following code:
 
 ```java
-ApertureSDK sdk = ApertureSDK.Builder()
+ApertureSDK sdk = ApertureSDK.builder()
         .setHost(...)
         .setPort(...)
         ...
-        .addIgnoredPaths("/healthz")
+        .addIgnoredPaths("/healthz,/metrics")
         ...
         .build()
 ```

--- a/docs/content/get-started/integrations/flow-control/sdk/java/netty.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/netty.md
@@ -51,6 +51,31 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
 }
 ```
 
+You can instruct the handler to exclude specific paths from being monitored by
+the Aperture SDK. For example, you might want to exclude endpoints used for
+health checks. To do this, you can add the path(s) you want to ignore to the
+ignoredPaths field of the SDK, as shown in the following code:
+
+```java
+ApertureSDK sdk = ApertureSDK.Builder()
+        .setHost(...)
+        .setPort(...)
+        ...
+        .addIgnoredPaths("/healthz")
+        ...
+        .build()
+```
+
+The paths should be specified as a comma-separated list. Note that the paths you
+specify must match exactly. However, you can change this behavior to treat the
+paths as regular expressions by setting the ignoredPathMatchRegex flag to true,
+like so:
+
+```java
+  builder
+        .setIgnoredPathMatchRegex(true)
+```
+
 For more context on how to use Aperture Netty Handler to set Control Points, you
 can take a look at the [example app][netty-example] available in our repository.
 

--- a/docs/content/get-started/integrations/flow-control/sdk/java/springboot.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/springboot.md
@@ -59,7 +59,7 @@ health checks. To do this, you can add the path(s) you want to ignore to the
 filter configuration, as shown in the following code:
 
 ```java
-registrationBean.addInitParameter("ignored_paths", "/healthz");
+registrationBean.addInitParameter("ignored_paths", "/healthz,/metrics");
 ```
 
 The paths should be specified as a comma-separated list. Note that the paths you

--- a/docs/content/get-started/integrations/flow-control/sdk/java/springboot.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/springboot.md
@@ -53,6 +53,24 @@ public class AppController {
 }
 ```
 
+You can instruct the filter to exclude specific paths from being monitored by
+the Aperture SDK. For example, you might want to exclude endpoints used for
+health checks. To do this, you can add the path(s) you want to ignore to the
+filter configuration, as shown in the following code:
+
+```java
+registrationBean.addInitParameter("ignored_paths", "/healthz");
+```
+
+The paths should be specified as a comma-separated list. Note that the paths you
+specify must match exactly. However, you can change this behavior to treat the
+paths as regular expressions by setting the ignored_paths_match_regex init
+parameter to true, like so:
+
+```java
+registrationBean.addInitParameter("ignored_paths_match_regex", "true");
+```
+
 For example usage, you can view the [example app][spring-example] available in
 our repository.
 

--- a/docs/content/get-started/integrations/flow-control/sdk/java/tomcat.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/tomcat.md
@@ -41,7 +41,7 @@ filter configuration, as shown in the following code:
 ```xml
 <init-param>
   <param-name>ignored_paths</param-name>
-  <param-value>/healthz</param-value>
+  <param-value>/healthz,/metrics</param-value>
 </init-param>
 ```
 

--- a/docs/content/get-started/integrations/flow-control/sdk/java/tomcat.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/tomcat.md
@@ -33,6 +33,30 @@ web.xml file to automatically set traffic Control Points for relevant services:
     </filter>
 ```
 
+You can instruct the filter to exclude specific paths from being monitored by
+the Aperture SDK. For example, you might want to exclude endpoints used for
+health checks. To do this, you can add the path(s) you want to ignore to the
+filter configuration, as shown in the following code:
+
+```xml
+<init-param>
+  <param-name>ignored_paths</param-name>
+  <param-value>/healthz</param-value>
+</init-param>
+```
+
+The paths should be specified as a comma-separated list. Note that the paths you
+specify must match exactly. However, you can change this behavior to treat the
+paths as regular expressions by setting the ignored_paths_match_regex init
+parameter to true, like so:
+
+```xml
+<init-param>
+  <param-name>ignored_paths_match_regex</param-name>
+  <param-value>true</param-value>
+</init-param>
+```
+
 For example usage, you can view the [example app][tomcat-example] available in
 our repository.
 

--- a/sdks/aperture-java/javaagent/README.md
+++ b/sdks/aperture-java/javaagent/README.md
@@ -57,8 +57,8 @@ system properties or environment variables:
 | aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether GRPC connection to Aperture Agent should be over plaintext                                  |
 | aperture.javaagent.root.certificate    | APERTURE_JAVAAGENT_ROOT_CERTIFICATE    |               | Path to a file containing root certificate to be used <br /> (insecure connection must be disabled) |
 | aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                   |
-| aperture.javaagent.blocked.paths       | APERTURE_JAVAAGENT_BLOCKED_PATHS       |               | Comma-separated list of paths that should not start a flow                                          |
-| aperture.javaagent.blocked.paths.regex | APERTURE_JAVAAGENT_BLOCKED_PATHS_REGEX |               | Whether the configured blocked paths should be read as regular expressions                          |
+| aperture.javaagent.ignored.paths       | APERTURE_JAVAAGENT_IGNORED_PATHS       |               | Comma-separated list of paths that should not start a flow                                          |
+| aperture.javaagent.ignored.paths.regex | APERTURE_JAVAAGENT_IGNORED_PATHS_REGEX |               | Whether the configured ignored paths should be read as regular expressions                          |
 
 The priority order is `system.property` > `ENV_VARIABLE` > `properties file`.
 
@@ -68,7 +68,7 @@ Example invocation with commandline-set properties:
 java -javaagent:path/to/javaagent.jar \
 -Daperture.agent.hostname="some_host" \
 -Daperture.agent.port=12345 \
--Daperture.javaagent.blocked.paths="/health,/connected" \
+-Daperture.javaagent.ignored.paths="/healthz,/connected" \
 -jar path/to/application.jar
 ```
 
@@ -85,5 +85,5 @@ The `/config.properties` file:
 ```properties
 aperture.agent.hostname=some_host
 aperture.agent.port=12345
-aperture.javaagent.blocked.paths=/health,/connected
+aperture.javaagent.ignored.paths=/healthz,/connected
 ```

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -100,7 +100,7 @@ public class Config {
                             .addIgnoredPaths(
                                     config.getProperty(
                                             IGNORED_PATHS_PROPERTY, IGNORED_PATHS_DEFAULT_VALUE))
-                            .setIgnoredPathMatchRegex(
+                            .setIgnoredPathsMatchRegex(
                                     Boolean.parseBoolean(
                                             config.getProperty(
                                                     IGNORED_PATHS_REGEX_PROPERTY,

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -17,9 +17,9 @@ public class Config {
     public static final String AGENT_PORT_PROPERTY = "aperture.agent.port";
     public static final String CONNECTION_TIMEOUT_MILLIS_PROPERTY =
             "aperture.connection.timeout.millis";
-    public static final String BLOCKED_PATHS_PROPERTY = "aperture.javaagent.blocked.paths";
-    public static final String BLOCKED_PATHS_REGEX_PROPERTY =
-            "aperture.javaagent.blocked.paths.regex";
+    public static final String IGNORED_PATHS_PROPERTY = "aperture.javaagent.ignored.paths";
+    public static final String IGNORED_PATHS_REGEX_PROPERTY =
+            "aperture.javaagent.ignored.paths.regex";
     public static final String INSECURE_GRPC_PROPERTY = "aperture.javaagent.insecure.grpc";
     public static final String ROOT_CERTIFICATE_FILE_PROPERTY =
             "aperture.javaagent.root.certificate";
@@ -27,8 +27,8 @@ public class Config {
     private static final String AGENT_HOST_DEFAULT_VALUE = "localhost";
     private static final String AGENT_PORT_DEFAULT_VALUE = "8089";
     private static final String CONNECTION_TIMEOUT_MILLIS_DEFAULT_VALUE = "1000";
-    private static final String BLOCKED_PATHS_DEFAULT_VALUE = "";
-    private static final String BLOCKED_PATHS_REGEX_DEFAULT_VALUE = "false";
+    private static final String IGNORED_PATHS_DEFAULT_VALUE = "";
+    private static final String IGNORED_PATHS_REGEX_DEFAULT_VALUE = "false";
     private static final String INSECURE_GRPC_DEFAULT_VALUE = "true";
     private static final String ROOT_CERTIFICATE_FILE_DEFAULT_VALUE = "";
 
@@ -38,8 +38,8 @@ public class Config {
                     add(AGENT_HOST_PROPERTY);
                     add(AGENT_PORT_PROPERTY);
                     add(CONNECTION_TIMEOUT_MILLIS_PROPERTY);
-                    add(BLOCKED_PATHS_PROPERTY);
-                    add(BLOCKED_PATHS_REGEX_PROPERTY);
+                    add(IGNORED_PATHS_PROPERTY);
+                    add(IGNORED_PATHS_REGEX_PROPERTY);
                 }
             };
 
@@ -97,14 +97,14 @@ public class Config {
                                                     config.getProperty(
                                                             CONNECTION_TIMEOUT_MILLIS_PROPERTY,
                                                             CONNECTION_TIMEOUT_MILLIS_DEFAULT_VALUE))))
-                            .addBlockedPaths(
+                            .addIgnoredPaths(
                                     config.getProperty(
-                                            BLOCKED_PATHS_PROPERTY, BLOCKED_PATHS_DEFAULT_VALUE))
-                            .setBlockedPathMatchRegex(
+                                            IGNORED_PATHS_PROPERTY, IGNORED_PATHS_DEFAULT_VALUE))
+                            .setIgnoredPathMatchRegex(
                                     Boolean.parseBoolean(
                                             config.getProperty(
-                                                    BLOCKED_PATHS_REGEX_PROPERTY,
-                                                    BLOCKED_PATHS_REGEX_DEFAULT_VALUE)));
+                                                    IGNORED_PATHS_REGEX_PROPERTY,
+                                                    IGNORED_PATHS_REGEX_DEFAULT_VALUE)));
 
             boolean insecureGrpc =
                     Boolean.parseBoolean(

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
@@ -28,22 +28,22 @@ public final class ApertureSDK {
             httpFlowControlClient;
     private final Tracer tracer;
     private final Duration timeout;
-    private final List<String> blockedPaths;
-    private final boolean blockedPathsMatchRegex;
+    private final List<String> ignoredPaths;
+    private final boolean ignoredPathsMatchRegex;
 
     ApertureSDK(
             FlowControlServiceGrpc.FlowControlServiceBlockingStub flowControlClient,
             FlowControlServiceHTTPGrpc.FlowControlServiceHTTPBlockingStub httpFlowControlClient,
             Tracer tracer,
             Duration timeout,
-            List<String> blockedPaths,
-            boolean blockedPathsMatchRegex) {
+            List<String> ignoredPaths,
+            boolean ignoredPathsMatchRegex) {
         this.flowControlClient = flowControlClient;
         this.tracer = tracer;
         this.timeout = timeout;
         this.httpFlowControlClient = httpFlowControlClient;
-        this.blockedPaths = blockedPaths;
-        this.blockedPathsMatchRegex = blockedPathsMatchRegex;
+        this.ignoredPaths = ignoredPaths;
+        this.ignoredPathsMatchRegex = ignoredPathsMatchRegex;
     }
 
     /**
@@ -103,7 +103,7 @@ public final class ApertureSDK {
     }
 
     public TrafficFlow startTrafficFlow(String path, CheckHTTPRequest req) {
-        if (isBlocked(path)) {
+        if (isIgnored(path)) {
             return TrafficFlow.ignoredFlow();
         }
 
@@ -128,17 +128,17 @@ public final class ApertureSDK {
         return new TrafficFlow(res, span, false);
     }
 
-    private boolean isBlocked(String path) {
+    private boolean isIgnored(String path) {
         if (path == null) {
             return false;
         }
-        for (String blockedPattern : blockedPaths) {
-            if (blockedPathsMatchRegex) {
-                if (Pattern.matches(blockedPattern, path)) {
+        for (String ignoredPattern : ignoredPaths) {
+            if (ignoredPathsMatchRegex) {
+                if (Pattern.matches(ignoredPattern, path)) {
                     return true;
                 }
             } else {
-                if (blockedPattern.equals(path)) {
+                if (ignoredPattern.equals(path)) {
                     return true;
                 }
             }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /** A builder for configuring an {@link ApertureSDK}. */
@@ -33,7 +33,7 @@ public final class ApertureSDKBuilder {
     private boolean ignoredPathsMatchRegex = false;
 
     ApertureSDKBuilder() {
-        ignoredPaths = Collections.emptyList();
+        ignoredPaths = new ArrayList<>();
     }
 
     public ApertureSDKBuilder setHost(String host) {
@@ -133,7 +133,7 @@ public final class ApertureSDKBuilder {
     /**
      * Whether ignored paths should be matched by regex. If false, exact matches will be expected.
      *
-     * @deprecated use setIgnoredPathMatchRegex
+     * @deprecated use setIgnoredPathsMatchRegex
      * @param flag whether paths should be matched by regex.
      * @return the builder object.
      */
@@ -148,7 +148,7 @@ public final class ApertureSDKBuilder {
      * @param flag whether paths should be matched by regex.
      * @return the builder object.
      */
-    public ApertureSDKBuilder setIgnoredPathMatchRegex(boolean flag) {
+    public ApertureSDKBuilder setIgnoredPathsMatchRegex(boolean flag) {
         this.ignoredPathsMatchRegex = flag;
         return this;
     }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /** A builder for configuring an {@link ApertureSDK}. */
@@ -29,11 +29,11 @@ public final class ApertureSDKBuilder {
     private boolean useHttpsInOtlpExporter = false;
     private boolean insecureGrpc = true;
     private String certFile;
-    private final List<String> blockedPaths;
-    private boolean blockedPathsMatchRegex = false;
+    private final List<String> ignoredPaths;
+    private boolean ignoredPathsMatchRegex = false;
 
     ApertureSDKBuilder() {
-        blockedPaths = new ArrayList<>();
+        ignoredPaths = Collections.emptyList();
     }
 
     public ApertureSDKBuilder setHost(String host) {
@@ -83,6 +83,7 @@ public final class ApertureSDKBuilder {
     /**
      * Adds comma-separated paths to ignore in traffic control points.
      *
+     * @deprecated use addIgnoredPaths
      * @param paths comma-separated list of paths to ignore when creating traffic control points.
      * @return the builder object.
      */
@@ -90,7 +91,32 @@ public final class ApertureSDKBuilder {
         if (paths == null || paths.isEmpty()) {
             return this;
         }
-        return this.addBlockedPaths(Arrays.asList(paths.split("\\s*,\\s*")));
+        return this.addIgnoredPaths(Arrays.asList(paths.split("\\s*,\\s*")));
+    }
+
+    /**
+     * Adds comma-separated paths to ignore in traffic control points.
+     *
+     * @param paths comma-separated list of paths to ignore when creating traffic control points.
+     * @return the builder object.
+     */
+    public ApertureSDKBuilder addIgnoredPaths(String paths) {
+        if (paths == null || paths.isEmpty()) {
+            return this;
+        }
+        return this.addIgnoredPaths(Arrays.asList(paths.split("\\s*,\\s*")));
+    }
+
+    /**
+     * Adds paths to ignore in traffic control points.
+     *
+     * @deprecated use addIgnoredPaths
+     * @param paths list of paths to ignore when creating traffic control points.
+     * @return the builder object.
+     */
+    public ApertureSDKBuilder addBlockedPaths(List<String> paths) {
+        this.ignoredPaths.addAll(paths);
+        return this;
     }
 
     /**
@@ -99,19 +125,31 @@ public final class ApertureSDKBuilder {
      * @param paths list of paths to ignore when creating traffic control points.
      * @return the builder object.
      */
-    public ApertureSDKBuilder addBlockedPaths(List<String> paths) {
-        this.blockedPaths.addAll(paths);
+    public ApertureSDKBuilder addIgnoredPaths(List<String> paths) {
+        this.ignoredPaths.addAll(paths);
         return this;
     }
 
     /**
-     * Whether paths should be matched by regex. If false, exact matches will be expected.
+     * Whether ignored paths should be matched by regex. If false, exact matches will be expected.
      *
+     * @deprecated use setIgnoredPathMatchRegex
      * @param flag whether paths should be matched by regex.
      * @return the builder object.
      */
     public ApertureSDKBuilder setBlockedPathMatchRegex(boolean flag) {
-        this.blockedPathsMatchRegex = flag;
+        this.ignoredPathsMatchRegex = flag;
+        return this;
+    }
+
+    /**
+     * Whether ignored paths should be matched by regex. If false, exact matches will be expected.
+     *
+     * @param flag whether paths should be matched by regex.
+     * @return the builder object.
+     */
+    public ApertureSDKBuilder setIgnoredPathMatchRegex(boolean flag) {
+        this.ignoredPathsMatchRegex = flag;
         return this;
     }
 
@@ -187,7 +225,7 @@ public final class ApertureSDKBuilder {
                 httpFlowControlClient,
                 tracer,
                 timeout,
-                blockedPaths,
-                blockedPathsMatchRegex);
+                ignoredPaths,
+                ignoredPathsMatchRegex);
     }
 }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -83,7 +83,7 @@ public final class ApertureSDKBuilder {
     /**
      * Adds comma-separated paths to ignore in traffic control points.
      *
-     * @deprecated use addIgnoredPaths
+     * @deprecated use {@link #addIgnoredPaths(String)}
      * @param paths comma-separated list of paths to ignore when creating traffic control points.
      * @return the builder object.
      */
@@ -110,7 +110,7 @@ public final class ApertureSDKBuilder {
     /**
      * Adds paths to ignore in traffic control points.
      *
-     * @deprecated use addIgnoredPaths
+     * @deprecated use {@link #addIgnoredPaths(List)}
      * @param paths list of paths to ignore when creating traffic control points.
      * @return the builder object.
      */
@@ -133,7 +133,7 @@ public final class ApertureSDKBuilder {
     /**
      * Whether ignored paths should be matched by regex. If false, exact matches will be expected.
      *
-     * @deprecated use setIgnoredPathsMatchRegex
+     * @deprecated use {@link #setIgnoredPathsMatchRegex(boolean)}
      * @param flag whether paths should be matched by regex.
      * @return the builder object.
      */

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -69,12 +69,16 @@ public class ApertureFilter implements Filter {
         String timeoutMs;
         boolean insecureGrpc;
         String rootCertificateFile;
+        String ignoredPaths;
+        boolean ignoredPathsRegex;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
             rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
+            ignoredPaths = filterConfig.getInitParameter("ignored_paths");
+            ignoredPathsRegex = Boolean.parseBoolean(filterConfig.getInitParameter("ignored_paths_match_regex"));
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -90,6 +94,8 @@ public class ApertureFilter implements Filter {
             if (rootCertificateFile != null && !rootCertificateFile.isEmpty()) {
                 builder.setRootCertificateFile(rootCertificateFile);
             }
+            builder.addIgnoredPaths(ignoredPaths);
+            builder.setIgnoredPathMatchRegex(ignoredPathsRegex);
 
             this.apertureSDK = builder.build();
         } catch (ApertureSDKException e) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -78,7 +78,9 @@ public class ApertureFilter implements Filter {
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
             rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
             ignoredPaths = filterConfig.getInitParameter("ignored_paths");
-            ignoredPathsRegex = Boolean.parseBoolean(filterConfig.getInitParameter("ignored_paths_match_regex"));
+            ignoredPathsRegex =
+                    Boolean.parseBoolean(
+                            filterConfig.getInitParameter("ignored_paths_match_regex"));
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -95,7 +97,7 @@ public class ApertureFilter implements Filter {
                 builder.setRootCertificateFile(rootCertificateFile);
             }
             builder.addIgnoredPaths(ignoredPaths);
-            builder.setIgnoredPathMatchRegex(ignoredPathsRegex);
+            builder.setIgnoredPathsMatchRegex(ignoredPathsRegex);
 
             this.apertureSDK = builder.build();
         } catch (ApertureSDKException e) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -69,12 +69,16 @@ public class ApertureFilter implements Filter {
         String timeoutMs;
         boolean insecureGrpc;
         String rootCertificateFile;
+        String ignoredPaths;
+        boolean ignoredPathsRegex;
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
             rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
+            ignoredPaths = filterConfig.getInitParameter("ignored_paths");
+            ignoredPathsRegex = Boolean.parseBoolean(filterConfig.getInitParameter("ignored_paths_match_regex"));
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -90,6 +94,8 @@ public class ApertureFilter implements Filter {
             if (rootCertificateFile != null && !rootCertificateFile.isEmpty()) {
                 builder.setRootCertificateFile(rootCertificateFile);
             }
+            builder.addIgnoredPaths(ignoredPaths);
+            builder.setIgnoredPathMatchRegex(ignoredPathsRegex);
 
             this.apertureSDK = builder.build();
         } catch (ApertureSDKException e) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -78,7 +78,9 @@ public class ApertureFilter implements Filter {
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
             rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
             ignoredPaths = filterConfig.getInitParameter("ignored_paths");
-            ignoredPathsRegex = Boolean.parseBoolean(filterConfig.getInitParameter("ignored_paths_match_regex"));
+            ignoredPathsRegex =
+                    Boolean.parseBoolean(
+                            filterConfig.getInitParameter("ignored_paths_match_regex"));
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }
@@ -95,7 +97,7 @@ public class ApertureFilter implements Filter {
                 builder.setRootCertificateFile(rootCertificateFile);
             }
             builder.addIgnoredPaths(ignoredPaths);
-            builder.setIgnoredPathMatchRegex(ignoredPathsRegex);
+            builder.setIgnoredPathsMatchRegex(ignoredPathsRegex);
 
             this.apertureSDK = builder.build();
         } catch (ApertureSDKException e) {


### PR DESCRIPTION
Also rename 'blockedPaths' to 'ignoredPaths'



<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Renamed `blockedPaths` to `ignoredPaths` across SDK libraries and documentation
- Added support for path ignoring in Armeria, Netty, Spring Boot, and Tomcat integrations
- Provided code snippets demonstrating the new functionality

> 🎉 With paths ignored, we've soared, 🚀
> In Armeria, Netty, and more! 🌟
> From blocked to ignored, we've roared, 🦁
> A better SDK is now in store! 🛠️
<!-- end of auto-generated comment: release notes by openai -->