### PR TITLE
Add control point name configurability to servlet filters and netty

### DIFF
--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "1.2.0";
+    public static final String LIBRARY_VERSION = "1.3.0";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -17,14 +17,22 @@ import java.util.Map;
 public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
     private final ApertureSDK apertureSDK;
+    private final String controlPointName;
 
     public ApertureServerHandler(ApertureSDK sdk) {
         this.apertureSDK = sdk;
+        this.controlPointName = "ingress";
+    }
+
+    public ApertureServerHandler(ApertureSDK sdk, String controlPointName) {
+        this.apertureSDK = sdk;
+        this.controlPointName = controlPointName;
     }
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, HttpRequest req) {
-        CheckHTTPRequest checkRequest = NettyUtils.checkRequestFromRequest(ctx, req);
+        CheckHTTPRequest checkRequest =
+                NettyUtils.checkRequestFromRequest(ctx, req, controlPointName);
         String path = new QueryStringDecoder(req.uri()).path();
 
         TrafficFlow flow = this.apertureSDK.startTrafficFlow(path, checkRequest);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -18,11 +18,12 @@ import java.util.Map;
 public class ApertureFilter implements Filter {
 
     private ApertureSDK apertureSDK;
+    private String controlPointName;
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
             throws ServletException, IOException {
-        CheckHTTPRequest checkRequest = ServletUtils.checkRequestFromRequest(req);
+        CheckHTTPRequest checkRequest = ServletUtils.checkRequestFromRequest(req, controlPointName);
 
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
@@ -66,6 +67,7 @@ public class ApertureFilter implements Filter {
     public void init(FilterConfig filterConfig) throws ServletException {
         String agentHost;
         String agentPort;
+        String initControlPointName;
         String timeoutMs;
         boolean insecureGrpc;
         String rootCertificateFile;
@@ -74,6 +76,7 @@ public class ApertureFilter implements Filter {
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
+            initControlPointName = filterConfig.getInitParameter("control_point_name");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
             rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
@@ -83,6 +86,12 @@ public class ApertureFilter implements Filter {
                             filterConfig.getInitParameter("ignored_paths_match_regex"));
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
+        }
+
+        if (initControlPointName != null) {
+            controlPointName = initControlPointName;
+        } else {
+            controlPointName = "ingress";
         }
 
         try {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
@@ -29,7 +29,8 @@ public class ServletUtils {
         return 403;
     }
 
-    protected static CheckHTTPRequest checkRequestFromRequest(ServletRequest req) {
+    protected static CheckHTTPRequest checkRequestFromRequest(
+            ServletRequest req, String controlPointName) {
         Map<String, String> baggageLabels = new HashMap<>();
 
         for (Map.Entry<String, BaggageEntry> entry : Baggage.current().asMap().entrySet()) {
@@ -46,7 +47,9 @@ public class ServletUtils {
             baggageLabels.put(entry.getKey(), value);
         }
 
-        return addHttpAttributes(baggageLabels, req).build();
+        CheckHTTPRequest.Builder builder = addHttpAttributes(baggageLabels, req);
+        builder.setControlPoint(controlPointName);
+        return builder.build();
     }
 
     protected static ServletRequest updateHeaders(
@@ -96,16 +99,15 @@ public class ServletUtils {
 
         CheckHTTPRequest.Builder builder = CheckHTTPRequest.newBuilder();
 
-        builder.setControlPoint("ingress")
-                .setRequest(
-                        CheckHTTPRequest.HttpRequest.newBuilder()
-                                .setMethod(request.getMethod())
-                                .setPath(request.getServletPath())
-                                .setHost(req.getRemoteHost())
-                                .setScheme(req.getScheme())
-                                .setSize(req.getContentLength())
-                                .setProtocol(req.getProtocol())
-                                .putAllHeaders(headers));
+        builder.setRequest(
+                CheckHTTPRequest.HttpRequest.newBuilder()
+                        .setMethod(request.getMethod())
+                        .setPath(request.getServletPath())
+                        .setHost(req.getRemoteHost())
+                        .setScheme(req.getScheme())
+                        .setSize(req.getContentLength())
+                        .setProtocol(req.getProtocol())
+                        .putAllHeaders(headers));
 
         if (sourceIp != null) {
             builder.setSource(Utils.createSocketAddress(sourceIp, sourcePort, "TCP"));

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -18,11 +18,12 @@ import javax.servlet.http.HttpServletResponse;
 public class ApertureFilter implements Filter {
 
     private ApertureSDK apertureSDK;
+    private String controlPointName;
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
             throws ServletException, IOException {
-        CheckHTTPRequest checkRequest = ServletUtils.checkRequestFromRequest(req);
+        CheckHTTPRequest checkRequest = ServletUtils.checkRequestFromRequest(req, controlPointName);
 
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
@@ -66,6 +67,7 @@ public class ApertureFilter implements Filter {
     public void init(FilterConfig filterConfig) throws ServletException {
         String agentHost;
         String agentPort;
+        String initControlPointName;
         String timeoutMs;
         boolean insecureGrpc;
         String rootCertificateFile;
@@ -74,6 +76,7 @@ public class ApertureFilter implements Filter {
         try {
             agentHost = filterConfig.getInitParameter("agent_host");
             agentPort = filterConfig.getInitParameter("agent_port");
+            initControlPointName = filterConfig.getInitParameter("control_point_name");
             timeoutMs = filterConfig.getInitParameter("timeout_ms");
             insecureGrpc = Boolean.parseBoolean(filterConfig.getInitParameter("insecure_grpc"));
             rootCertificateFile = filterConfig.getInitParameter("root_certificate_file");
@@ -85,6 +88,11 @@ public class ApertureFilter implements Filter {
             throw new ServletException("Could not read config parameters", e);
         }
 
+        if (initControlPointName != null) {
+            controlPointName = initControlPointName;
+        } else {
+            controlPointName = "ingress";
+        }
         try {
             ApertureSDKBuilder builder = ApertureSDK.builder();
             builder.setHost(agentHost);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
@@ -29,7 +29,8 @@ public class ServletUtils {
         return 403;
     }
 
-    protected static CheckHTTPRequest checkRequestFromRequest(ServletRequest req) {
+    protected static CheckHTTPRequest checkRequestFromRequest(
+            ServletRequest req, String controlPointName) {
         Map<String, String> baggageLabels = new HashMap<>();
 
         for (Map.Entry<String, BaggageEntry> entry : Baggage.current().asMap().entrySet()) {
@@ -46,7 +47,9 @@ public class ServletUtils {
             baggageLabels.put(entry.getKey(), value);
         }
 
-        return addHttpAttributes(baggageLabels, req).build();
+        CheckHTTPRequest.Builder builder = addHttpAttributes(baggageLabels, req);
+        builder.setControlPoint(controlPointName);
+        return builder.build();
     }
 
     protected static ServletRequest updateHeaders(
@@ -96,16 +99,15 @@ public class ServletUtils {
 
         CheckHTTPRequest.Builder builder = CheckHTTPRequest.newBuilder();
 
-        builder.setControlPoint("ingress")
-                .setRequest(
-                        CheckHTTPRequest.HttpRequest.newBuilder()
-                                .setMethod(request.getMethod())
-                                .setPath(request.getServletPath())
-                                .setHost(req.getRemoteHost())
-                                .setScheme(req.getScheme())
-                                .setSize(req.getContentLength())
-                                .setProtocol(req.getProtocol())
-                                .putAllHeaders(headers));
+        builder.setRequest(
+                CheckHTTPRequest.HttpRequest.newBuilder()
+                        .setMethod(request.getMethod())
+                        .setPath(request.getServletPath())
+                        .setHost(req.getRemoteHost())
+                        .setScheme(req.getScheme())
+                        .setSize(req.getContentLength())
+                        .setProtocol(req.getProtocol())
+                        .putAllHeaders(headers));
 
         if (sourceIp != null) {
             builder.setSource(Utils.createSocketAddress(sourceIp, sourcePort, "TCP"));

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "1.2.0"
+  var ver = "1.3.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added support for custom control point names in `CheckHTTPRequest` across various classes and methods.

> 🎉 A new feature we bring, with joy and cheer,
> Custom control points now appear,
> In requests they'll shine, so bright and clear,
> Enhancing our library, a milestone to revere! 🌟
<!-- end of auto-generated comment: release notes by openai -->