### PR TITLE
blueprints: deprecation tooling

### DIFF
--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -79,6 +79,17 @@ aperturectl blueprints generate --name=policies/static-rate-limiting --values-fi
 		if err != nil {
 			return err
 		}
+		// check whether the blueprint is deprecated
+		blueprintDir := filepath.Join(blueprintsDir, blueprintName)
+		ok, deprecated := utils.IsBlueprintDeprecated(blueprintDir)
+		if ok {
+			if utils.AllowDeprecated {
+				log.Warn().Msgf("Blueprint %s is deprecated: %s", blueprintName, deprecated)
+			} else {
+				return fmt.Errorf("blueprint %s is deprecated: %s", blueprintName, deprecated)
+			}
+		}
+
 		if !noValidate {
 			var valuesBytes []byte
 			valuesBytes, err = os.ReadFile(valuesFile)
@@ -254,13 +265,13 @@ func saveJSONFile(_, path, filename string, content map[string]interface{}) erro
 }
 
 func blueprintExists(name string) error {
-	blueprintsList, err := getBlueprints(blueprintsURIRoot)
+	blueprintsList, err := getBlueprints(blueprintsURIRoot, true)
 	if err != nil {
 		return err
 	}
 
 	if !slices.Contains(blueprintsList, name) {
-		return fmt.Errorf("invalid blueprints name '%s'", name)
+		return fmt.Errorf("invalid blueprint name '%s'", name)
 	}
 	return nil
 }

--- a/cmd/aperturectl/cmd/root.go
+++ b/cmd/aperturectl/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/discovery"
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/flowcontrol"
 	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/installation"
+	"github.com/fluxninja/aperture/cmd/aperturectl/cmd/utils"
 	"github.com/fluxninja/aperture/pkg/config"
 	"github.com/fluxninja/aperture/pkg/info"
 	"github.com/fluxninja/aperture/pkg/log"
@@ -20,9 +21,8 @@ import (
 
 // Version shows the version of ApertureCtl.
 var (
-	Version         = info.Version
-	allowDeprecated bool
-	verbose         bool
+	Version = info.Version
+	verbose bool
 )
 
 func init() {
@@ -52,15 +52,15 @@ aperturectl is a CLI tool which can be used to interact with Aperture seamlessly
 	Version: Version,
 }
 
-// Execute is the entrypoint for the CLI. It is called from the main package.
+// Execute is the entry point for the CLI. It is called from the main package.
 func Execute() {
 	// Process the verbose and allowDeprecated flags before executing the command.
 	// Fun fact: PersistentPreRunE doesn't allow chaining.
 
 	// set flags manually using pflag and parse them
 	pflag.BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
-	pflag.BoolVar(&allowDeprecated, "allow-deprecated", false, "Allow deprecated fields in the configuration")
-	// Set help flag to false by default to print help for aperturectl command instead of pflags
+	pflag.BoolVar(&utils.AllowDeprecated, "allow-deprecated", false, "Allow deprecated fields in the configuration")
+	// Set help flag to false by default to print help for aperturectl command instead of pflag
 	pflag.BoolP("help", "h", false, "Display help for aperturectl command")
 	// configure pflag to ignore unknown flags
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
@@ -75,7 +75,7 @@ func Execute() {
 	logger := log.NewLogger(log.GetPrettyConsoleWriter(), level)
 	log.SetGlobalLogger(logger)
 
-	err := config.RegisterDeprecatedValidator(allowDeprecated)
+	err := config.RegisterDeprecatedValidator(utils.AllowDeprecated)
 	if err != nil {
 		log.Error().Err(err).Msg("Error registering deprecated validator")
 		os.Exit(1)

--- a/cmd/aperturectl/cmd/utils/globals.go
+++ b/cmd/aperturectl/cmd/utils/globals.go
@@ -3,3 +3,5 @@ package utils
 const (
 	apertureRepo = "https://github.com/fluxninja/aperture"
 )
+
+var AllowDeprecated = false

--- a/cmd/aperturectl/cmd/utils/utils.go
+++ b/cmd/aperturectl/cmd/utils/utils.go
@@ -297,3 +297,26 @@ func ValidateWithJSONSchema(rootSchema string, schemas []string, documentFile st
 	}
 	return nil
 }
+
+// IsBlueprintDeprecated whether the policyDir is deprecated
+// it reads metadata.yaml and checks for deprecated key
+// the value of that key is the deprecation message.
+func IsBlueprintDeprecated(policyDir string) (bool, string) {
+	metadataPath := filepath.Join(policyDir, "metadata.yaml")
+	metadataFile, err := os.ReadFile(metadataPath)
+	if err != nil {
+		log.Warn().Err(err).Msgf("failed to read metadata.yaml file in %s", policyDir)
+		return false, ""
+	}
+	var metadata map[string]interface{}
+	err = yaml.Unmarshal(metadataFile, &metadata)
+	if err != nil {
+		log.Warn().Err(err).Msgf("failed to unmarshal metadata.yaml file in %s", policyDir)
+		return false, ""
+	}
+	deprecated, ok := metadata["deprecated"]
+	if !ok {
+		return false, ""
+	}
+	return true, deprecated.(string)
+}

--- a/pkg/policies/controlplane/components/ema.go
+++ b/pkg/policies/controlplane/components/ema.go
@@ -95,70 +95,106 @@ func (ema *EMA) resetStages() {
 }
 
 // Execute implements runtime.Component.Execute.
+// Execute calculates the Exponential Moving Average (EMA) of a series of readings.
+// It takes inPortReadings, a map of input readings, and tickInfo, a struct containing
+// information about the current tick, as input parameters.
+// It returns a map of output readings and an error.
 func (ema *EMA) Execute(inPortReadings runtime.PortToReading, tickInfo runtime.TickInfo) (runtime.PortToReading, error) {
-	logger := ema.policyReadAPI.GetStatusRegistry().GetLogger()
-	retErr := func(err error) (runtime.PortToReading, error) {
-		return runtime.PortToReading{
-			"output": []runtime.Reading{runtime.InvalidReading()},
-		}, err
+	input, maxEnvelope, minEnvelope, err := ema.readInputs(inPortReadings)
+	if err != nil {
+		return ema.retErr(err)
 	}
 
-	input := inPortReadings.ReadSingleReadingPort("input")
-	maxEnvelope := inPortReadings.ReadSingleReadingPort("max_envelope")
-	minEnvelope := inPortReadings.ReadSingleReadingPort("min_envelope")
-	output := runtime.InvalidReading()
+	output, err := ema.calculateOutput(input, maxEnvelope, minEnvelope)
+	if err != nil {
+		return ema.retErr(err)
+	}
+
+	return runtime.PortToReading{
+		"output": []runtime.Reading{output},
+	}, nil
+}
+
+func (ema *EMA) readInputs(inPortReadings runtime.PortToReading) (input, maxEnvelope, minEnvelope runtime.Reading, err error) {
+	input = inPortReadings.ReadSingleReadingPort("input")
+	maxEnvelope = inPortReadings.ReadSingleReadingPort("max_envelope")
+	minEnvelope = inPortReadings.ReadSingleReadingPort("min_envelope")
+	return
+}
+
+func (ema *EMA) retErr(err error) (runtime.PortToReading, error) {
+	return runtime.PortToReading{
+		"output": []runtime.Reading{runtime.InvalidReading()},
+	}, err
+}
+
+func (ema *EMA) calculateOutput(input, maxEnvelope, minEnvelope runtime.Reading) (output runtime.Reading, err error) {
+	logger := ema.policyReadAPI.GetStatusRegistry().GetLogger()
 
 	switch ema.currentStage {
 	case warmUpStage:
-		ema.warmupCount++
-		if input.Valid() {
-			ema.sum += input.Value()
-			ema.count++
-			// Decide to switch to EMA stage
-			if ema.warmupCount >= ema.warmupWindow {
-				ema.currentStage = emaStage
-			}
-		} else {
-			// Immediately reset on any missing values during warm-up.
-			ema.resetStages()
-		}
-		// Emit valid output during emaStage or during warm-up if configured to do so.
-		if ema.currentStage == emaStage || ema.validDuringWarmup {
-			// Emit the avg value of input signal during the warm-up window.
-			avg, err := ema.computeAverage()
-			if err != nil {
-				return retErr(err)
-			}
-			output = avg
-		} else {
-			output = runtime.InvalidReading()
-		}
+		output, err = ema.handleWarmUpStage(input)
 	case emaStage:
-		if input.Valid() {
-			if !ema.lastGoodOutput.Valid() {
-				err := errors.New("ema: last good output is invalid")
-				logger.Error().Err(err).Msg("This is unexpected!")
-				return retErr(err)
-			}
-			// Compute the new outputValue.
-			outputValue := (ema.alpha * input.Value()) + ((1 - ema.alpha) * ema.lastGoodOutput.Value())
-			output = runtime.NewReading(outputValue)
-		} else {
-			ema.invalidCount++
-			// If invalid count is greater than the ema window, reset the stages.
-			if ema.invalidCount >= ema.emaWindow {
-				ema.resetStages()
-			}
-			// emit last good EMA value
-			output = ema.lastGoodOutput
-		}
+		output, err = ema.handleEMAStage(input)
 	default:
 		logger.Panic().Msg("unexpected ema stage")
 	}
 
-	// Set the last good output
+	if err != nil {
+		return runtime.InvalidReading(), err
+	}
+
+	output = ema.applyCorrection(output, maxEnvelope, minEnvelope)
+	ema.lastGoodOutput = output
+
+	return output, nil
+}
+
+func (ema *EMA) handleWarmUpStage(input runtime.Reading) (output runtime.Reading, err error) {
+	ema.warmupCount++
+	if input.Valid() {
+		ema.sum += input.Value()
+		ema.count++
+		if ema.warmupCount >= ema.warmupWindow {
+			ema.currentStage = emaStage
+		}
+	} else {
+		ema.resetStages()
+	}
+
+	if ema.currentStage == emaStage || ema.validDuringWarmup {
+		output, err = ema.computeAverage()
+	} else {
+		output = runtime.InvalidReading()
+	}
+
+	return
+}
+
+func (ema *EMA) handleEMAStage(input runtime.Reading) (output runtime.Reading, err error) {
+	logger := ema.policyReadAPI.GetStatusRegistry().GetLogger()
+
+	if input.Valid() {
+		if !ema.lastGoodOutput.Valid() {
+			err = errors.New("ema: last good output is invalid")
+			logger.Error().Err(err).Msg("This is unexpected!")
+			return runtime.InvalidReading(), err
+		}
+		outputValue := (ema.alpha * input.Value()) + ((1 - ema.alpha) * ema.lastGoodOutput.Value())
+		output = runtime.NewReading(outputValue)
+	} else {
+		ema.invalidCount++
+		if ema.invalidCount >= ema.emaWindow {
+			ema.resetStages()
+		}
+		output = ema.lastGoodOutput
+	}
+
+	return
+}
+
+func (ema *EMA) applyCorrection(output, maxEnvelope, minEnvelope runtime.Reading) runtime.Reading {
 	if output.Valid() {
-		// apply correction
 		value := output.Value()
 		if maxEnvelope.Valid() && value > maxEnvelope.Value() {
 			value *= ema.correctionFactorOnMaxViolation
@@ -167,12 +203,8 @@ func (ema *EMA) Execute(inPortReadings runtime.PortToReading, tickInfo runtime.T
 			value *= ema.correctionFactorOnMinViolation
 		}
 		output = runtime.NewReading(value)
-		ema.lastGoodOutput = output
 	}
-	// Returns Exponential Moving Average of a series of readings.
-	return runtime.PortToReading{
-		"output": []runtime.Reading{output},
-	}, nil
+	return output
 }
 
 func (ema *EMA) computeAverage() (runtime.Reading, error) {

--- a/pkg/policies/controlplane/components/ema.go
+++ b/pkg/policies/controlplane/components/ema.go
@@ -94,16 +94,14 @@ func (ema *EMA) resetStages() {
 	ema.lastGoodOutput = runtime.InvalidReading()
 }
 
-// Execute implements runtime.Component.Execute.
 // Execute calculates the Exponential Moving Average (EMA) of a series of readings.
 // It takes inPortReadings, a map of input readings, and tickInfo, a struct containing
 // information about the current tick, as input parameters.
 // It returns a map of output readings and an error.
 func (ema *EMA) Execute(inPortReadings runtime.PortToReading, tickInfo runtime.TickInfo) (runtime.PortToReading, error) {
-	input, maxEnvelope, minEnvelope, err := ema.readInputs(inPortReadings)
-	if err != nil {
-		return ema.retErr(err)
-	}
+	input := inPortReadings.ReadSingleReadingPort("input")
+	maxEnvelope := inPortReadings.ReadSingleReadingPort("max_envelope")
+	minEnvelope := inPortReadings.ReadSingleReadingPort("min_envelope")
 
 	output, err := ema.calculateOutput(input, maxEnvelope, minEnvelope)
 	if err != nil {
@@ -113,13 +111,6 @@ func (ema *EMA) Execute(inPortReadings runtime.PortToReading, tickInfo runtime.T
 	return runtime.PortToReading{
 		"output": []runtime.Reading{output},
 	}, nil
-}
-
-func (ema *EMA) readInputs(inPortReadings runtime.PortToReading) (input, maxEnvelope, minEnvelope runtime.Reading, err error) {
-	input = inPortReadings.ReadSingleReadingPort("input")
-	maxEnvelope = inPortReadings.ReadSingleReadingPort("max_envelope")
-	minEnvelope = inPortReadings.ReadSingleReadingPort("min_envelope")
-	return
 }
 
 func (ema *EMA) retErr(err error) (runtime.PortToReading, error) {

--- a/scripts/jsonnet-lib-gen.py
+++ b/scripts/jsonnet-lib-gen.py
@@ -5,7 +5,6 @@ import json
 import os
 import subprocess
 import tempfile
-import textwrap
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, Optional, Tuple
 
@@ -201,11 +200,6 @@ def withNameMixinFilter(name: str) -> str:
 
 
 def defaultPorts(definition: JsonnetDefinition) -> str:
-    TPL = textwrap.dedent(
-        """\
-
-    """
-    )
     if definition.type_ != JsonnetType.OBJECT:
         return ""
     in_ports = definition.properties.get("in_ports")


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Support for handling deprecated blueprints with a `deprecation_message` property
- Options to allow or disallow deprecated blueprints in various commands
- Improved error messages for invalid blueprint names

**Refactor:**
- Introduced a new `utils` package and removed unused variable

**Style:**
- Removed unused import and multiline string in `scripts/jsonnet-lib-gen.py`

> 🎉 Deprecated blueprints, we now embrace, 📚
> With options and warnings, keeping pace. 🚀
> Error messages improved, code refined, 🛠️
> A utils package added, intertwined. 🌟
<!-- end of auto-generated comment: release notes by openai -->