### PR TITLE
Add docs for receivers that support metrics type

### DIFF
--- a/docs/content/get-started/integrations/metrics/aerospike.md
+++ b/docs/content/get-started/integrations/metrics/aerospike.md
@@ -1,0 +1,41 @@
+---
+title: Aerospike
+description: Integrating Aerospike Metrics
+keywords:
+  - aerospike
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`aerospikereceiver` extension enabled, so that [aerospikereceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Aerospike using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    aerospike:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - aerospike
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        aerospike: [aerospikereceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/aerospikereceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/apache-web-server.md
+++ b/docs/content/get-started/integrations/metrics/apache-web-server.md
@@ -1,0 +1,41 @@
+---
+title: Apache Web Server
+description: Integrating Apache Web Server Metrics
+keywords:
+  - apache
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`apachereceiver` extension enabled, so that [apachereceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Apache Web Server using
+the following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    apache:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - apache
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        apache: [apachereceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachereceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/chrony.md
+++ b/docs/content/get-started/integrations/metrics/chrony.md
@@ -1,0 +1,41 @@
+---
+title: Chrony
+description: Integrating Chrony Metrics
+keywords:
+  - chrony
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`chronyreceiver` extension enabled, so that [chronyreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Chrony using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    chrony:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - chrony
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        chrony: [chronyreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/couchdb.md
+++ b/docs/content/get-started/integrations/metrics/couchdb.md
@@ -1,0 +1,41 @@
+---
+title: CouchDB
+description: Integrating CouchDB Metrics
+keywords:
+  - couchdb
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`couchdbreceiver` extension enabled, so that [couchdbreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for CouchDB using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    couchdb:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - couchdb
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        couchdb: [couchdbreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/couchdbreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/expvar.md
+++ b/docs/content/get-started/integrations/metrics/expvar.md
@@ -1,0 +1,41 @@
+---
+title: Expvar
+description: Integrating Expvar Metrics
+keywords:
+  - expvar
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`expvarreceiver` extension enabled, so that [expvarreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Expvar using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    expvar:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - expvar
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        expvar: [expvarreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/expvarreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/f5-bigip.md
+++ b/docs/content/get-started/integrations/metrics/f5-bigip.md
@@ -1,0 +1,42 @@
+---
+title: F5 Big-IP
+description: Integrating F5 Big-IP Metrics
+keywords:
+  - f5
+  - big-ip
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`bigipreceiver` extension enabled, so that [bigipreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for F5 Big-IP using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    bigip:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - bigip
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        bigip: [bigipreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/bigipreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/haproxy.md
+++ b/docs/content/get-started/integrations/metrics/haproxy.md
@@ -1,0 +1,41 @@
+---
+title: HAProxy
+description: Integrating HAProxy Metrics
+keywords:
+  - haproxy
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`haproxyreceiver` extension enabled, so that [haproxyreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for HAProxy using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    haproxy:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - haproxy
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        haproxy: [haproxyreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/httpcheck.md
+++ b/docs/content/get-started/integrations/metrics/httpcheck.md
@@ -1,0 +1,41 @@
+---
+title: HTTP Check
+description: Integrating HTTP Check Metrics
+keywords:
+  - httpcheck
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`httpcheckreceiver` extension enabled, so that [httpcheckreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for HTTP Check using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    httpcheck:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - httpcheck
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        httpcheck: [httpcheckreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/memcached.md
+++ b/docs/content/get-started/integrations/metrics/memcached.md
@@ -1,0 +1,41 @@
+---
+title: Memcached
+description: Integrating Memcached Metrics
+keywords:
+  - memcached
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`memcachedreceiver` extension enabled, so that [memcachedreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Memcached using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    memcached:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - memcached
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        memcached: [memcachedreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/memcachedreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/microsoft-sql-server.md
+++ b/docs/content/get-started/integrations/metrics/microsoft-sql-server.md
@@ -1,0 +1,42 @@
+---
+title: Microsoft SQL Server
+description: Integrating Microsoft SQL Server Metrics
+keywords:
+  - sqlserver
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`sqlserverreceiver` extension enabled, so that [sqlserverreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Microsoft SQL Server
+using the following configuration in the [Aperture Agent's
+config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    sqlserver:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - sqlserver
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        sqlserver: [sqlserverreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/mongodb.md
+++ b/docs/content/get-started/integrations/metrics/mongodb.md
@@ -1,0 +1,41 @@
+---
+title: MongoDB
+description: Integrating MongoDB Metrics
+keywords:
+  - mongodb
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`mongodbreceiver` extension enabled, so that [mongodbreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for MongoDB using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    mongodb:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - mongodb
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        mongodb: [mongodbreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/mysql.md
+++ b/docs/content/get-started/integrations/metrics/mysql.md
@@ -1,0 +1,41 @@
+---
+title: MySQL
+description: Integrating MySQL Metrics
+keywords:
+  - mysql
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`mysqlreceiver` extension enabled, so that [mysqlreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for MySQL using the following
+configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    mysql:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - mysql
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        mysql: [mysqlreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mysqlreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/nginx.md
+++ b/docs/content/get-started/integrations/metrics/nginx.md
@@ -1,0 +1,41 @@
+---
+title: Nginx
+description: Integrating Nginx Metrics
+keywords:
+  - nginx
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`nginxreceiver` extension enabled, so that [nginxreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Nginx using the following
+configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    nginx:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - nginx
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        nginx: [nginxreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/nginxreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/nsxt.md
+++ b/docs/content/get-started/integrations/metrics/nsxt.md
@@ -1,0 +1,40 @@
+---
+title: NSX-T
+description: Integrating NSX-T Metrics
+keywords:
+  - nsx-t
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`nsxtreceiver` extension enabled, so that [nsxtreceiver][receiver] is available.
+
+You can configure [Custom metrics][custom-metrics] for NSX-T using the following
+configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    nsxt:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - nsxt
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        nsxt: [nsxtreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/nsxtreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/oracledb.md
+++ b/docs/content/get-started/integrations/metrics/oracledb.md
@@ -1,0 +1,41 @@
+---
+title: Oracle DB
+description: Integrating Oracle DB Metrics
+keywords:
+  - oracledb
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`oracledbreceiver` extension enabled, so that [oracledbreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Oracle DB using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    oracledb:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - oracledb
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        oracledb: [oracledbreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/oracledbreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/postgresql.md
+++ b/docs/content/get-started/integrations/metrics/postgresql.md
@@ -1,0 +1,41 @@
+---
+title: PostgreSQL
+description: Integrating PostgreSQL Metrics
+keywords:
+  - postgresql
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`postgresqlreceiver` extension enabled, so that [postgresqlreceiver][receiver]
+is available.
+
+You can configure [Custom metrics][custom-metrics] for PostgreSQL using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    postgresql:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - postgresql
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        postgresql: [postgresqlreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/rabbitmq.md
+++ b/docs/content/get-started/integrations/metrics/rabbitmq.md
@@ -7,12 +7,11 @@ keywords:
   - opentelemetry
   - collector
   - metrics
-sidebar_position: 1
 ---
 
-Before proceeding, ensure that you have [built][build] the Aperture Agent with
-the `rabbitmqreceiver` extension enabled, so that [rabbitmqreceiver][receiver]
-is available.
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`rabbitmqreceiver` extension enabled, so that [rabbitmqreceiver][receiver] is
+available.
 
 You can configure [Custom metrics][custom-metrics] for RabbitMQ using the
 following configuration in the [Aperture Agent's config][agent-config]:
@@ -127,4 +126,4 @@ agent:
 [receiver]:
   https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver
 [custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
-[agent-config]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/redis.md
+++ b/docs/content/get-started/integrations/metrics/redis.md
@@ -1,0 +1,41 @@
+---
+title: Redis
+description: Integrating Redis Metrics
+keywords:
+  - redis
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`redisreceiver` extension enabled, so that [redisreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Redis using the following
+configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    redis:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - redis
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        redis: [redisreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/riak.md
+++ b/docs/content/get-started/integrations/metrics/riak.md
@@ -1,0 +1,40 @@
+---
+title: Riak
+description: Integrating Riak Metrics
+keywords:
+  - riak
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`riakreceiver` extension enabled, so that [riakreceiver][receiver] is available.
+
+You can configure [Custom metrics][custom-metrics] for Riak using the following
+configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    riak:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - riak
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        riak: [riakreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/riakreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/sap-hana.md
+++ b/docs/content/get-started/integrations/metrics/sap-hana.md
@@ -1,0 +1,41 @@
+---
+title: SAP HANA
+description: Integrating SAP HANA Metrics
+keywords:
+  - saphana
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`saphanareceiver` extension enabled, so that [saphanareceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for SAP HANA using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    saphana:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - saphana
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        saphana: [saphanareceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/saphanareceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/snowflake.md
+++ b/docs/content/get-started/integrations/metrics/snowflake.md
@@ -1,0 +1,41 @@
+---
+title: Snowflake
+description: Integrating Snowflake Metrics
+keywords:
+  - snowflake
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`snowflakereceiver` extension enabled, so that [snowflakereceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Snowflake using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    snowflake:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - snowflake
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        snowflake: [snowflakereceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snowflakereceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/sshcheck.md
+++ b/docs/content/get-started/integrations/metrics/sshcheck.md
@@ -1,0 +1,41 @@
+---
+title: SSH Check
+description: Integrating SSH Check Metrics
+keywords:
+  - sshcheck
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`sshcheckreceiver` extension enabled, so that [sshcheckreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for SSH Check using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    sshcheck:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - sshcheck
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        sshcheck: [sshcheckreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sshcheckreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/vcenter.md
+++ b/docs/content/get-started/integrations/metrics/vcenter.md
@@ -1,0 +1,41 @@
+---
+title: vCenter
+description: Integrating vCenter Metrics
+keywords:
+  - vcenter
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`vcenterreceiver` extension enabled, so that [vcenterreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for vCenter using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    vcenter:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - vcenter
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        vcenter: [vcenterreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/vcenterreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/get-started/integrations/metrics/zookeeper.md
+++ b/docs/content/get-started/integrations/metrics/zookeeper.md
@@ -1,0 +1,41 @@
+---
+title: Zookeeper
+description: Integrating Zookeeper Metrics
+keywords:
+  - zookeeper
+  - otel
+  - opentelemetry
+  - collector
+  - metrics
+---
+
+Before proceeding, ensure that you have [built][build] Aperture Agent with the
+`zookeeperreceiver` extension enabled, so that [zookeeperreceiver][receiver] is
+available.
+
+You can configure [Custom metrics][custom-metrics] for Zookeeper using the
+following configuration in the [Aperture Agent's config][agent-config]:
+
+```yaml
+otel:
+  custom_metrics:
+    zookeeper:
+      per_agent_group: true
+      pipeline:
+        processors:
+          - batch
+        receivers:
+          - zookeeper
+      processors:
+        batch:
+          send_batch_size: 10
+          timeout: 10s
+      receivers:
+        zookeeper: [zookeeperreceiver configuration here]
+```
+
+[build]: /reference/aperturectl/build/agent/agent.md
+[receiver]:
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zookeeperreceiver
+[custom-metrics]: /reference/configuration/agent.md#custom-metrics-config
+[agent-config]: /reference/configuration/agent.md#agent-o-t-e-l-config

--- a/docs/content/reference/aperturectl/build/agent/agent.md
+++ b/docs/content/reference/aperturectl/build/agent/agent.md
@@ -37,17 +37,18 @@ build:
   flags:
     - -some-flag
     - -some-other-flag
-bundled_extensions: # remote extensions to be bundled
+bundled_extensions: # built-in extensions to be enabled
+  - integrations/otel/rabbitmqreceiver
+  - fluxninja
+  - sentry
+extensions: # remote extensions to be bundled
   - go_mod_name: github.com/org/name
     version: v1.0.0
     pkg_name: pkg
-extensions: # built-in extensions to be enabled
-  - fluxninja
-  - sentry
 replaces:
   - old: github.com/org/name
     new: github.com/org/name2
-enable_core_extensions: false # default is true
+enable_core_extensions: false # default is true`
 ```
 
 ### Options

--- a/docs/content/reference/aperturectl/build/controller/controller.md
+++ b/docs/content/reference/aperturectl/build/controller/controller.md
@@ -37,17 +37,17 @@ build:
   flags:
     - -some-flag
     - -some-other-flag
-bundled_extensions: # remote extensions to be bundled
+bundled_extensions: # built-in extensions to be enabled
+  - fluxninja
+  - sentry
+extensions: # remote extensions to be bundled
   - go_mod_name: github.com/org/name
     version: v1.0.0
     pkg_name: pkg
-extensions: # built-in extensions to be enabled
-  - fluxninja
-  - sentry
 replaces:
   - old: github.com/org/name
     new: github.com/org/name2
-enable_core_extensions: false # default is true
+enable_core_extensions: false # default is true`
 ```
 
 ### Options


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added documentation for integrating metrics from various sources using Aperture Agent's receiver extensions.

> 🎉 A myriad of metrics we bring, 📊
> From many sources, they now spring. 🌱
> With Aperture Agent by our side, 🤖
> In data-driven insights, we confide. 💡
<!-- end of auto-generated comment: release notes by openai -->