### PR TITLE
Use the `community/mitchellh-go-json` remote plugin

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -17,7 +17,8 @@ buf-generate:
 	@rm -rfd gen/proto gen/openapiv2
 	@buf format -w
 	@buf lint
-	@buf generate --path aperture --template buf.gen.aperture.yaml
+	@buf generate --path aperture --template buf.gen.aperture-langs.yaml
+	@buf generate --path aperture --template buf.gen.aperture-grpc-ecosystem.yaml
 	@buf generate --path envoy --template buf.gen.envoy.yaml --include-imports
 	@#inject go annotations
 	@find . -name \*.pb.go -exec protoc-go-inject-tag -input={} \;

--- a/api/buf.gen.aperture-grpc-ecosystem.yaml
+++ b/api/buf.gen.aperture-grpc-ecosystem.yaml
@@ -1,0 +1,25 @@
+version: v1
+managed:
+  enabled: true
+  java_package_prefix:
+    default: com.fluxninja.generated
+  go_package_prefix:
+    default: github.com/fluxninja/aperture/api/gen/proto/go
+    except:
+      - buf.build/googleapis/googleapis
+      - buf.build/grpc-ecosystem/grpc-gateway
+      - buf.build/envoyproxy/protoc-gen-validate
+plugins:
+  - plugin: buf.build/grpc-ecosystem/gateway
+    out: gen/proto/go
+    opt:
+      - paths=source_relative
+  - plugin: buf.build/grpc-ecosystem/openapiv2
+    out: gen/openapiv2
+    opt:
+      - json_names_for_fields=false
+      - merge_file_name=aperture
+      - allow_merge=true
+      - output_format=yaml
+      - generate_unbound_methods=false
+      - openapi_naming_strategy=fqn

--- a/api/buf.gen.aperture-langs.yaml
+++ b/api/buf.gen.aperture-langs.yaml
@@ -29,7 +29,7 @@ plugins:
     opt:
       - paths=source_relative
       - require_unimplemented_servers=false
-  - remote: buf.build/mitchellh/plugins/protoc-gen-go-json:v1.1.0
+  - plugin: buf.build/community/mitchellh-go-json
     out: gen/proto/go
     opt:
       - paths=source_relative
@@ -40,19 +40,6 @@ plugins:
     out: gen/proto/go
     opt:
       - paths=source_relative
-  - plugin: buf.build/grpc-ecosystem/gateway
-    out: gen/proto/go
-    opt:
-      - paths=source_relative
-  - plugin: buf.build/grpc-ecosystem/openapiv2
-    out: gen/openapiv2
-    opt:
-      - json_names_for_fields=false
-      - merge_file_name=aperture
-      - allow_merge=true
-      - output_format=yaml
-      - generate_unbound_methods=false
-      - openapi_naming_strategy=fqn
   - plugin: buf.build/bufbuild/validate-go
     out: gen/proto/go
     opt:


### PR DESCRIPTION
### Description of change

- Remove the deprecated remote plugin, move to newly added official community plugin
  - Ref: https://github.com/bufbuild/plugins/issues/489
- Break up apreture buf gen file because `buf generate` now complains if there are more than 10 remote plugins
  - langs for languages remote plugins
  - grpc-ecosystem for grpc-ecosystem related remote plugins

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes
