### PR TITLE
vale style release action

### DIFF
--- a/.github/workflows/style-release.yml
+++ b/.github/workflows/style-release.yml
@@ -1,0 +1,13 @@
+name: Create Vale Style Archive
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Vale Style Release
+      uses: thedoctor0/zip-release@0.7.1
+      with:
+        type: 'zip'
+        filename: 'vale-aperture.zip'
+        directory: '.github/styles/Vocab/FluxNinja'

--- a/.github/workflows/style-release.yml
+++ b/.github/workflows/style-release.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Vale Style Release
       uses: thedoctor0/zip-release@0.7.1
       with:


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes



<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added a GitHub workflow to automatically create Vale style archives on push events using the `zip-release` action.

> 🎉 A new workflow we bring, 🚀
> To zip and release with a zing! 💫
> Vale styles now bundled with ease, 📦
> Making updates a delightful breeze. 🌬️
<!-- end of auto-generated comment: release notes by openai -->