### PR TITLE
actions: target branch to main for some actions

### DIFF
--- a/.github/workflows/languagetool.yaml
+++ b/.github/workflows/languagetool.yaml
@@ -6,6 +6,8 @@ permissions:
 
 on:
   pull_request:
+    branches:
+      - "main"
 
 jobs:
   languagetool:

--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -6,11 +6,14 @@ permissions:
 
 on:
   pull_request:
+    branches:
+      - "main"
   pull_request_review_comment:
     types: [created]
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref ||
+  group:
+    ${{ github.repository }}-${{ github.event.number || github.head_ref ||
     github.sha }}-${{ github.workflow }}-${{ github.event_name ==
     'pull_request_review_comment' && 'pr_comment' || 'pr' }}
   cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,5 +1,8 @@
 name: vale
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   vale:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Restrict GitHub Actions workflows to `main` branch pull requests

> 🎉 Oh, the joy of a focused run, 🏃‍♂️<br>
> On `main` branch, our tasks are done. 🌟<br>
> With filters set, resources saved, 💾<br>
> Our workflows now well-behaved! 🥳
<!-- end of auto-generated comment: release notes by openai -->