### PR TITLE
Fix metrics

### DIFF
--- a/pkg/policies/controlplane/runtime/circuit.go
+++ b/pkg/policies/controlplane/runtime/circuit.go
@@ -160,11 +160,6 @@ func (circuit *Circuit) setup(lifecycle fx.Lifecycle) {
 						metrics.SubCircuitIDLabel: signal.SubCircuitID,
 						metrics.PolicyNameLabel:   circuit.GetPolicyName(),
 					},
-					prometheus.Labels{
-						metrics.SignalNameLabel:   signal.SignalName,
-						metrics.SubCircuitIDLabel: signal.SubCircuitID,
-						metrics.PolicyNameLabel:   circuit.GetPolicyName(),
-					},
 				)
 			}
 		}


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Optimized `Circuit` setup function by removing a duplicate call to `prometheus.Labels` constructor in `pkg/policies/controlplane/runtime/circuit.go`.

> 🎉 A duplicate call we did find, 🕵️‍♂️
> In the Circuit setup, it was left behind. 🚧
> With swift action, we made it right, 🛠️
> Now our code is clean and light! 💡
<!-- end of auto-generated comment: release notes by openai -->