### PR TITLE
GRPC -> gRPC

### DIFF
--- a/.github/styles/Vocab/FluxNinja/accept.txt
+++ b/.github/styles/Vocab/FluxNinja/accept.txt
@@ -51,3 +51,5 @@ Pub/Sub
 [Aa]uto-scalers?\b
 [Rr]ollouts?\b
 AIMD
+gRPC
+DaemonSet

--- a/docs/content/concepts/flow-control/flow-label.md
+++ b/docs/content/concepts/flow-control/flow-label.md
@@ -31,7 +31,7 @@ baggage, flow classifiers, and explicit labels from the Aperture SDK call.
 
 ### Request labels
 
-For each HTTP [_Control Point_][control-point] (where flows are HTTP or GRPC
+For each HTTP [_Control Point_][control-point] (where flows are HTTP or gRPC
 requests), some basic metadata is available as _request labels_. These are
 `http.method`, `http.target`, `http.host`, `http.scheme`,
 `http.request_content_length` and `http.flavor`. Additionally, all (non-pseudo)

--- a/docs/content/concepts/flow-control/flow-selector.md
+++ b/docs/content/concepts/flow-control/flow-selector.md
@@ -81,12 +81,12 @@ graph LR
 
 </Zoom>
 
-In the above diagram, each service has _Traffic_ (HTTP or GRPC) control points.
-Every incoming API request to a service is a flow at its `ingress` control
-point. Likewise, every outgoing request from a service is a flow at its `egress`
+In the above diagram, each service has HTTP or gRPC control points. Every
+incoming API request to a service is a flow at its `ingress` control point.
+Likewise, every outgoing request from a service is a flow at its `egress`
 control point.
 
-In addition, the `Frontend` service has _Feature_ control points identifying
+In addition, the `Frontend` service has feature control points identifying
 _recommendations_ and _live-update_ features inside the `Frontend` service's
 code.
 

--- a/docs/content/get-started/integrations/flow-control/sdk/sdk.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/sdk.md
@@ -21,9 +21,9 @@ Points][flow-control] must be set within the service.
 
 This can be achieved in the following ways:
 
-- [Istio/Envoy integration][istio] for controlling HTTP or GRPC requests flowing
+- [Istio/Envoy integration][istio] for controlling HTTP or gRPC requests flowing
   through the service.
-- Aperture SDKs can be used to set feature or traffic (HTTP and GRPC) control
+- Aperture SDKs can be used to set feature or traffic (HTTP and gRPC) control
   points within the service code. This approach allows for fine-grained flow
   control.
 

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -77,6 +77,8 @@ Generated File Starts
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -84,6 +86,8 @@ Generated File Starts
 Environment variable prefix: `APERTURE_AGENT_AGENT_INFO_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -97,6 +101,8 @@ Environment variable prefix: `APERTURE_AGENT_AGENT_INFO_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>kubernetes</dt>
 <dd>
 
@@ -104,6 +110,8 @@ Environment variable prefix: `APERTURE_AGENT_AGENT_INFO_`
 Environment variable prefix: `APERTURE_AGENT_AUTO_SCALE_KUBERNETES_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -117,6 +125,8 @@ Environment variable prefix: `APERTURE_AGENT_AUTO_SCALE_KUBERNETES_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>proxy</dt>
 <dd>
 
@@ -124,6 +134,8 @@ Environment variable prefix: `APERTURE_AGENT_AUTO_SCALE_KUBERNETES_`
 Environment variable prefix: `APERTURE_AGENT_CLIENT_PROXY_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -137,6 +149,8 @@ Environment variable prefix: `APERTURE_AGENT_CLIENT_PROXY_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -144,6 +158,8 @@ Environment variable prefix: `APERTURE_AGENT_CLIENT_PROXY_`
 Environment variable prefix: `APERTURE_AGENT_DIST_CACHE_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -157,6 +173,8 @@ Environment variable prefix: `APERTURE_AGENT_DIST_CACHE_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -164,6 +182,8 @@ Environment variable prefix: `APERTURE_AGENT_DIST_CACHE_`
 Environment variable prefix: `APERTURE_AGENT_ETCD_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -177,6 +197,8 @@ Environment variable prefix: `APERTURE_AGENT_ETCD_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>preview_service</dt>
 <dd>
 
@@ -184,6 +206,8 @@ Environment variable prefix: `APERTURE_AGENT_ETCD_`
 Environment variable prefix: `APERTURE_AGENT_FLOW_CONTROL_PREVIEW_SERVICE_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -197,6 +221,8 @@ Environment variable prefix: `APERTURE_AGENT_FLOW_CONTROL_PREVIEW_SERVICE_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -204,6 +230,8 @@ Environment variable prefix: `APERTURE_AGENT_FLOW_CONTROL_PREVIEW_SERVICE_`
 Environment variable prefix: `APERTURE_AGENT_FLUXNINJA_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -217,6 +245,8 @@ Environment variable prefix: `APERTURE_AGENT_FLUXNINJA_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>http_client</dt>
 <dd>
 
@@ -224,6 +254,8 @@ Environment variable prefix: `APERTURE_AGENT_FLUXNINJA_`
 Environment variable prefix: `APERTURE_AGENT_KUBERNETES_CLIENT_HTTP_CLIENT_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -237,6 +269,8 @@ Environment variable prefix: `APERTURE_AGENT_KUBERNETES_CLIENT_HTTP_CLIENT_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>scheduler</dt>
 <dd>
 
@@ -245,6 +279,10 @@ Environment variable prefix: `APERTURE_AGENT_LIVENESS_SCHEDULER_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>service</dt>
 <dd>
 
@@ -252,6 +290,8 @@ Environment variable prefix: `APERTURE_AGENT_LIVENESS_SCHEDULER_`
 Environment variable prefix: `APERTURE_AGENT_LIVENESS_SERVICE_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -265,6 +305,8 @@ Environment variable prefix: `APERTURE_AGENT_LIVENESS_SERVICE_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -272,6 +314,8 @@ Environment variable prefix: `APERTURE_AGENT_LIVENESS_SERVICE_`
 Environment variable prefix: `APERTURE_AGENT_LOG_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -285,6 +329,8 @@ Environment variable prefix: `APERTURE_AGENT_LOG_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -292,6 +338,8 @@ Environment variable prefix: `APERTURE_AGENT_LOG_`
 Environment variable prefix: `APERTURE_AGENT_METRICS_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -305,6 +353,8 @@ Environment variable prefix: `APERTURE_AGENT_METRICS_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -312,6 +362,8 @@ Environment variable prefix: `APERTURE_AGENT_METRICS_`
 Environment variable prefix: `APERTURE_AGENT_OTEL_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -325,6 +377,8 @@ Environment variable prefix: `APERTURE_AGENT_OTEL_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -332,6 +386,8 @@ Environment variable prefix: `APERTURE_AGENT_OTEL_`
 Environment variable prefix: `APERTURE_AGENT_PEER_DISCOVERY_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -345,6 +401,8 @@ Environment variable prefix: `APERTURE_AGENT_PEER_DISCOVERY_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -352,6 +410,8 @@ Environment variable prefix: `APERTURE_AGENT_PEER_DISCOVERY_`
 Environment variable prefix: `APERTURE_AGENT_PROFILERS_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -365,6 +425,8 @@ Environment variable prefix: `APERTURE_AGENT_PROFILERS_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -373,6 +435,10 @@ Environment variable prefix: `APERTURE_AGENT_PROMETHEUS_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>http_client</dt>
 <dd>
 
@@ -380,6 +446,8 @@ Environment variable prefix: `APERTURE_AGENT_PROMETHEUS_`
 Environment variable prefix: `APERTURE_AGENT_PROMETHEUS_HTTP_CLIENT_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -393,6 +461,8 @@ Environment variable prefix: `APERTURE_AGENT_PROMETHEUS_HTTP_CLIENT_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>scheduler</dt>
 <dd>
 
@@ -401,6 +471,10 @@ Environment variable prefix: `APERTURE_AGENT_READINESS_SCHEDULER_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>service</dt>
 <dd>
 
@@ -408,6 +482,8 @@ Environment variable prefix: `APERTURE_AGENT_READINESS_SCHEDULER_`
 Environment variable prefix: `APERTURE_AGENT_READINESS_SERVICE_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -421,6 +497,8 @@ Environment variable prefix: `APERTURE_AGENT_READINESS_SERVICE_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -428,6 +506,8 @@ Environment variable prefix: `APERTURE_AGENT_READINESS_SERVICE_`
 Environment variable prefix: `APERTURE_AGENT_SENTRY_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -441,6 +521,8 @@ Environment variable prefix: `APERTURE_AGENT_SENTRY_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>grpc</dt>
 <dd>
 
@@ -448,6 +530,10 @@ Environment variable prefix: `APERTURE_AGENT_SENTRY_`
 Environment variable prefix: `APERTURE_AGENT_SERVER_GRPC_`
 
 </dd>
+
+<!-- vale off -->
+
+<!-- vale off -->
 
 <dt>grpc_gateway</dt>
 <dd>
@@ -457,6 +543,10 @@ Environment variable prefix: `APERTURE_AGENT_SERVER_GRPC_GATEWAY_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>http</dt>
 <dd>
 
@@ -464,6 +554,10 @@ Environment variable prefix: `APERTURE_AGENT_SERVER_GRPC_GATEWAY_`
 Environment variable prefix: `APERTURE_AGENT_SERVER_HTTP_`
 
 </dd>
+
+<!-- vale off -->
+
+<!-- vale off -->
 
 <dt>listener</dt>
 <dd>
@@ -473,6 +567,10 @@ Environment variable prefix: `APERTURE_AGENT_SERVER_LISTENER_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>tls</dt>
 <dd>
 
@@ -480,6 +578,8 @@ Environment variable prefix: `APERTURE_AGENT_SERVER_LISTENER_`
 Environment variable prefix: `APERTURE_AGENT_SERVER_TLS_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -493,6 +593,8 @@ Environment variable prefix: `APERTURE_AGENT_SERVER_TLS_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>kubernetes</dt>
 <dd>
 
@@ -501,6 +603,10 @@ Environment variable prefix: `APERTURE_AGENT_SERVICE_DISCOVERY_KUBERNETES_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>static</dt>
 <dd>
 
@@ -508,6 +614,8 @@ Environment variable prefix: `APERTURE_AGENT_SERVICE_DISCOVERY_KUBERNETES_`
 Environment variable prefix: `APERTURE_AGENT_SERVICE_DISCOVERY_STATIC_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -521,6 +629,8 @@ Environment variable prefix: `APERTURE_AGENT_SERVICE_DISCOVERY_STATIC_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>memory</dt>
 <dd>
 
@@ -528,6 +638,8 @@ Environment variable prefix: `APERTURE_AGENT_SERVICE_DISCOVERY_STATIC_`
 Environment variable prefix: `APERTURE_AGENT_WATCHDOG_MEMORY_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -734,7 +846,7 @@ Enables the Kubernetes auto-scale capability.
 
 <!-- vale on -->
 
-BackoffConfig holds configuration for GRPC client backoff.
+BackoffConfig holds configuration for gRPC client backoff.
 
 <dl>
 <dt>base_delay</dt>
@@ -1415,7 +1527,7 @@ API Key for this agent. If this key is not set, the extension won't be enabled.
 
 <!-- vale on -->
 
-Address to GRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
+Address to gRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
 
 </dd>
 <dt>heartbeat_interval</dt>
@@ -1462,7 +1574,7 @@ Installation mode describes on which underlying platform the Agent or the Contro
 
 <!-- vale on -->
 
-GRPCClientConfig holds configuration for GRPC Client.
+GRPCClientConfig holds configuration for gRPC Client.
 
 <dl>
 <dt>insecure</dt>
@@ -1531,7 +1643,7 @@ Use HTTP CONNECT Proxy
 
 <!-- vale on -->
 
-GRPCGatewayConfig holds configuration for grpc-http gateway
+GRPCGatewayConfig holds configuration for gRPC to HTTP gateway
 
 <dl>
 <dt>grpc_server_address</dt>
@@ -1543,7 +1655,7 @@ GRPCGatewayConfig holds configuration for grpc-http gateway
 
 <!-- vale on -->
 
-GRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs GRPC and HTTP servers on the same port
+gRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs gRPC and HTTP servers on the same port
 
 </dd>
 </dl>
@@ -1556,7 +1668,7 @@ GRPC server address to connect to - By default it points to HTTP server port bec
 
 <!-- vale on -->
 
-GRPCServerConfig holds configuration for GRPC Server.
+GRPCServerConfig holds configuration for gRPC Server.
 
 <dl>
 <dt>connection_timeout</dt>

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -71,6 +71,8 @@ Generated File Starts
 
 <dl>
 
+<!-- vale off -->
+
 <dt>proxy</dt>
 <dd>
 
@@ -78,6 +80,8 @@ Generated File Starts
 Environment variable prefix: `APERTURE_CONTROLLER_CLIENT_PROXY_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -91,6 +95,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_CLIENT_PROXY_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -98,6 +104,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_CLIENT_PROXY_`
 Environment variable prefix: `APERTURE_CONTROLLER_ETCD_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -111,6 +119,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_ETCD_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -118,6 +128,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_ETCD_`
 Environment variable prefix: `APERTURE_CONTROLLER_FLUXNINJA_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -131,6 +143,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_FLUXNINJA_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>scheduler</dt>
 <dd>
 
@@ -139,6 +153,10 @@ Environment variable prefix: `APERTURE_CONTROLLER_LIVENESS_SCHEDULER_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>service</dt>
 <dd>
 
@@ -146,6 +164,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_LIVENESS_SCHEDULER_`
 Environment variable prefix: `APERTURE_CONTROLLER_LIVENESS_SERVICE_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -159,6 +179,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_LIVENESS_SERVICE_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -166,6 +188,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_LIVENESS_SERVICE_`
 Environment variable prefix: `APERTURE_CONTROLLER_LOG_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -179,6 +203,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_LOG_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -186,6 +212,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_LOG_`
 Environment variable prefix: `APERTURE_CONTROLLER_METRICS_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -199,6 +227,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_METRICS_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -206,6 +236,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_METRICS_`
 Environment variable prefix: `APERTURE_CONTROLLER_OTEL_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -219,6 +251,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_OTEL_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>promql_jobs_scheduler</dt>
 <dd>
 
@@ -226,6 +260,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_OTEL_`
 Environment variable prefix: `APERTURE_CONTROLLER_POLICIES_PROMQL_JOBS_SCHEDULER_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -239,6 +275,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_POLICIES_PROMQL_JOBS_SCHEDULER
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -246,6 +284,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_POLICIES_PROMQL_JOBS_SCHEDULER
 Environment variable prefix: `APERTURE_CONTROLLER_PROFILERS_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -259,6 +299,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_PROFILERS_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -267,6 +309,10 @@ Environment variable prefix: `APERTURE_CONTROLLER_PROMETHEUS_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>http_client</dt>
 <dd>
 
@@ -274,6 +320,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_PROMETHEUS_`
 Environment variable prefix: `APERTURE_CONTROLLER_PROMETHEUS_HTTP_CLIENT_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -287,6 +335,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_PROMETHEUS_HTTP_CLIENT_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>scheduler</dt>
 <dd>
 
@@ -295,6 +345,10 @@ Environment variable prefix: `APERTURE_CONTROLLER_READINESS_SCHEDULER_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>service</dt>
 <dd>
 
@@ -302,6 +356,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_READINESS_SCHEDULER_`
 Environment variable prefix: `APERTURE_CONTROLLER_READINESS_SERVICE_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -315,6 +371,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_READINESS_SERVICE_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt></dt>
 <dd>
 
@@ -322,6 +380,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_READINESS_SERVICE_`
 Environment variable prefix: `APERTURE_CONTROLLER_SENTRY_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -335,6 +395,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_SENTRY_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>grpc</dt>
 <dd>
 
@@ -342,6 +404,10 @@ Environment variable prefix: `APERTURE_CONTROLLER_SENTRY_`
 Environment variable prefix: `APERTURE_CONTROLLER_SERVER_GRPC_`
 
 </dd>
+
+<!-- vale off -->
+
+<!-- vale off -->
 
 <dt>grpc_gateway</dt>
 <dd>
@@ -351,6 +417,10 @@ Environment variable prefix: `APERTURE_CONTROLLER_SERVER_GRPC_GATEWAY_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>http</dt>
 <dd>
 
@@ -358,6 +428,10 @@ Environment variable prefix: `APERTURE_CONTROLLER_SERVER_GRPC_GATEWAY_`
 Environment variable prefix: `APERTURE_CONTROLLER_SERVER_HTTP_`
 
 </dd>
+
+<!-- vale off -->
+
+<!-- vale off -->
 
 <dt>listener</dt>
 <dd>
@@ -367,6 +441,10 @@ Environment variable prefix: `APERTURE_CONTROLLER_SERVER_LISTENER_`
 
 </dd>
 
+<!-- vale off -->
+
+<!-- vale off -->
+
 <dt>tls</dt>
 <dd>
 
@@ -374,6 +452,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_SERVER_LISTENER_`
 Environment variable prefix: `APERTURE_CONTROLLER_SERVER_TLS_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -387,6 +467,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_SERVER_TLS_`
 
 <dl>
 
+<!-- vale off -->
+
 <dt>memory</dt>
 <dd>
 
@@ -394,6 +476,8 @@ Environment variable prefix: `APERTURE_CONTROLLER_SERVER_TLS_`
 Environment variable prefix: `APERTURE_CONTROLLER_WATCHDOG_MEMORY_`
 
 </dd>
+
+<!-- vale off -->
 
 </dl>
 
@@ -446,7 +530,7 @@ Factor sets user-configured limit of available memory
 
 <!-- vale on -->
 
-BackoffConfig holds configuration for GRPC client backoff.
+BackoffConfig holds configuration for gRPC client backoff.
 
 <dl>
 <dt>base_delay</dt>
@@ -779,7 +863,7 @@ API Key for this agent. If this key is not set, the extension won't be enabled.
 
 <!-- vale on -->
 
-Address to GRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
+Address to gRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
 
 </dd>
 <dt>heartbeat_interval</dt>
@@ -826,7 +910,7 @@ Installation mode describes on which underlying platform the Agent or the Contro
 
 <!-- vale on -->
 
-GRPCClientConfig holds configuration for GRPC Client.
+GRPCClientConfig holds configuration for gRPC Client.
 
 <dl>
 <dt>insecure</dt>
@@ -895,7 +979,7 @@ Use HTTP CONNECT Proxy
 
 <!-- vale on -->
 
-GRPCGatewayConfig holds configuration for grpc-http gateway
+GRPCGatewayConfig holds configuration for gRPC to HTTP gateway
 
 <dl>
 <dt>grpc_server_address</dt>
@@ -907,7 +991,7 @@ GRPCGatewayConfig holds configuration for grpc-http gateway
 
 <!-- vale on -->
 
-GRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs GRPC and HTTP servers on the same port
+gRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs gRPC and HTTP servers on the same port
 
 </dd>
 </dl>
@@ -920,7 +1004,7 @@ GRPC server address to connect to - By default it points to HTTP server port bec
 
 <!-- vale on -->
 
-GRPCServerConfig holds configuration for GRPC Server.
+GRPCServerConfig holds configuration for gRPC Server.
 
 <dl>
 <dt>connection_timeout</dt>

--- a/docs/content/reference/observability/prometheus-metrics/common.md
+++ b/docs/content/reference/observability/prometheus-metrics/common.md
@@ -52,8 +52,8 @@ for more information.
 
 <!-- vale on -->
 
-### GRPC Server Metrics
+### gRPC Server Metrics
 
-GRPC server metrics are exposed by default. See
+gRPC server metrics are exposed by default. See
 [grpc-ecosystem/go-grpc-prometheus server_metrics](https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-prometheus#NewServerMetrics)
 for more information.

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -208,7 +208,7 @@ definitions:
                 x-go-tag-default: "1.6"
                 x-go-tag-json: multiplier
                 x-go-tag-validate: gte=0
-        title: BackoffConfig holds configuration for GRPC client backoff.
+        title: BackoffConfig holds configuration for gRPC client backoff.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     BatchAlertsConfig:
@@ -613,15 +613,15 @@ definitions:
                 x-go-name: UseProxy
                 x-go-tag-default: "false"
                 x-go-tag-json: use_proxy
-        title: GRPCClientConfig holds configuration for GRPC Client.
+        title: GRPCClientConfig holds configuration for gRPC Client.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     GRPCGatewayConfig:
-        description: GRPCGatewayConfig holds configuration for grpc-http gateway
+        description: GRPCGatewayConfig holds configuration for gRPC to HTTP gateway
         properties:
             grpc_server_address:
                 default: 0.0.0.0:1
-                description: GRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs GRPC and HTTP servers on the same port
+                description: gRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs gRPC and HTTP servers on the same port
                 pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$
                 type: string
                 x-go-name: GRPCAddr
@@ -666,7 +666,7 @@ definitions:
                 x-go-tag-default: '[10.0,25.0,100.0,250.0,1000.0]'
                 x-go-tag-json: latency_buckets_ms
                 x-go-tag-validate: gte=0
-        title: GRPCServerConfig holds configuration for GRPC Server.
+        title: GRPCServerConfig holds configuration for gRPC Server.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     HTTPClientConfig:

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -119,7 +119,7 @@ definitions:
                 x-go-tag-default: "1.6"
                 x-go-tag-json: multiplier
                 x-go-tag-validate: gte=0
-        title: BackoffConfig holds configuration for GRPC client backoff.
+        title: BackoffConfig holds configuration for gRPC client backoff.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     BatchAlertsConfig:
@@ -279,15 +279,15 @@ definitions:
                 x-go-name: UseProxy
                 x-go-tag-default: "false"
                 x-go-tag-json: use_proxy
-        title: GRPCClientConfig holds configuration for GRPC Client.
+        title: GRPCClientConfig holds configuration for gRPC Client.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     GRPCGatewayConfig:
-        description: GRPCGatewayConfig holds configuration for grpc-http gateway
+        description: GRPCGatewayConfig holds configuration for gRPC to HTTP gateway
         properties:
             grpc_server_address:
                 default: 0.0.0.0:1
-                description: GRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs GRPC and HTTP servers on the same port
+                description: gRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs gRPC and HTTP servers on the same port
                 pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$
                 type: string
                 x-go-name: GRPCAddr
@@ -332,7 +332,7 @@ definitions:
                 x-go-tag-default: '[10.0,25.0,100.0,250.0,1000.0]'
                 x-go-tag-json: latency_buckets_ms
                 x-go-tag-validate: gte=0
-        title: GRPCServerConfig holds configuration for GRPC Server.
+        title: GRPCServerConfig holds configuration for gRPC Server.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     HTTPClientConfig:

--- a/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
+++ b/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
@@ -41,7 +41,7 @@ definitions:
                 x-go-tag-default: "1.6"
                 x-go-tag-json: multiplier
                 x-go-tag-validate: gte=0
-        title: BackoffConfig holds configuration for GRPC client backoff.
+        title: BackoffConfig holds configuration for gRPC client backoff.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     ClientConfig:
@@ -96,7 +96,7 @@ definitions:
                 $ref: '#/definitions/ClientConfig'
                 x-go-tag-json: client
             endpoint:
-                description: Address to GRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
+                description: Address to gRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
                 pattern: (((^$)|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$))|(^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,\'/\\\+&amp;%\$#\=~])*$))|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$)
                 type: string
                 x-go-name: Endpoint
@@ -160,7 +160,7 @@ definitions:
                 x-go-name: UseProxy
                 x-go-tag-default: "false"
                 x-go-tag-json: use_proxy
-        title: GRPCClientConfig holds configuration for GRPC Client.
+        title: GRPCClientConfig holds configuration for gRPC Client.
         type: object
         x-go-package: github.com/fluxninja/aperture/pkg/net/grpc
     HTTPClientConfig:

--- a/docs/tools/swagger/swagger-templates/config.gotmpl
+++ b/docs/tools/swagger/swagger-templates/config.gotmpl
@@ -234,7 +234,7 @@ Generated File Starts
 
 (
     {{- template "fnProperty" . -}}
-    {{ if $env  }}, env-var: `{{ upper (snakize (slice $base 1)) }}_{{ if $path }}{{ (upper (snakize (slice $path 1))) }}_{{ end }}{{ if and .Name (ne .Name ".") }}{{ upper (snakize .Name) }}{{ end }}`{{ end -}}
+    {{ if $env  }}, Environment variable prefix: `{{ upper (snakize (slice $base 1)) }}_{{ if $path }}{{ (upper (snakize (slice $path 1))) }}_{{ end }}{{ if and .Name (ne .Name ".") }}{{ upper (snakize .Name) }}{{ end }}`{{ end -}}
 ){{ with .Description }} {{ . }}{{ end }}
 
 <!-- vale on -->
@@ -247,6 +247,8 @@ Generated File Starts
 {{- range .Params }}
 {{- if .IsBodyParam }}
 
+<!-- vale off -->
+
 <dt>{{ .Name }}</dt>
 <dd>{{/* blank lines inside dd are important for correct markdown rendering, don't remove */}}
 
@@ -254,6 +256,9 @@ Generated File Starts
 {{ if $env  }} Environment variable prefix: `{{ upper (snakize (slice $base 1)) }}_{{ if $path }}{{ (upper (snakize (slice $path 1))) }}_{{ end }}{{ if and .Name (ne .Name ".") }}{{ upper (snakize .Name) }}_{{ end }}`{{ end }}
 
 </dd>
+
+<!-- vale off -->
+
 {{ end }}
 {{- end }}
 {{- end }}{{/* end .HasBodyParams */}}

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -20,7 +20,7 @@ const (
 type FluxNinjaExtensionConfig struct {
 	// Interval between each heartbeat.
 	HeartbeatInterval config.Duration `json:"heartbeat_interval" validate:"gte=0s" default:"5s"`
-	// Address to GRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
+	// Address to gRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
 	Endpoint string `json:"endpoint" validate:"omitempty,hostname_port|url|fqdn"`
 	// API Key for this agent. If this key is not set, the extension won't be enabled.
 	APIKey string `json:"api_key"`

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1285,7 +1285,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Address to GRPC or HTTP(s) server listening in
+                        description: Address to gRPC or HTTP(s) server listening in
                           agent service. To use HTTP protocol, the address must start
                           with `http(s)://`.
                         type: string
@@ -1723,9 +1723,9 @@ spec:
                         description: GRPC Gateway configuration.
                         properties:
                           grpc_server_address:
-                            description: GRPC server address to connect to - By default
+                            description: gRPC server address to connect to - By default
                               it points to HTTP server port because FluxNinja stack
-                              runs GRPC and HTTP servers on the same port
+                              runs gRPC and HTTP servers on the same port
                             type: string
                         type: object
                       http:

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1173,7 +1173,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Address to GRPC or HTTP(s) server listening in
+                        description: Address to gRPC or HTTP(s) server listening in
                           agent service. To use HTTP protocol, the address must start
                           with `http(s)://`.
                         type: string
@@ -1453,9 +1453,9 @@ spec:
                         description: GRPC Gateway configuration.
                         properties:
                           grpc_server_address:
-                            description: GRPC server address to connect to - By default
+                            description: gRPC server address to connect to - By default
                               it points to HTTP server port because FluxNinja stack
-                              runs GRPC and HTTP servers on the same port
+                              runs gRPC and HTTP servers on the same port
                             type: string
                         type: object
                       http:

--- a/pkg/net/grpc/client.go
+++ b/pkg/net/grpc/client.go
@@ -27,7 +27,7 @@ type ClientConstructor struct {
 	DefaultConfig GRPCClientConfig
 }
 
-// GRPCClientConfig holds configuration for GRPC Client.
+// GRPCClientConfig holds configuration for gRPC Client.
 // swagger:model
 // +kubebuilder:object:generate=true
 type GRPCClientConfig struct {
@@ -43,7 +43,7 @@ type GRPCClientConfig struct {
 	UseProxy bool `json:"use_proxy" default:"false"`
 }
 
-// BackoffConfig holds configuration for GRPC client backoff.
+// BackoffConfig holds configuration for gRPC client backoff.
 // swagger:model
 // +kubebuilder:object:generate=true
 type BackoffConfig struct {

--- a/pkg/net/grpc/server.go
+++ b/pkg/net/grpc/server.go
@@ -40,7 +40,7 @@ func GMuxServerModule() fx.Option {
 	)
 }
 
-// GRPCServerConfig holds configuration for GRPC Server.
+// GRPCServerConfig holds configuration for gRPC Server.
 // swagger:model
 // +kubebuilder:object:generate=true
 type GRPCServerConfig struct {

--- a/pkg/net/grpcgateway/grpcgateway.go
+++ b/pkg/net/grpcgateway/grpcgateway.go
@@ -44,10 +44,10 @@ type Constructor struct {
 	DefaultConfig GRPCGatewayConfig
 }
 
-// GRPCGatewayConfig holds configuration for grpc-http gateway
+// GRPCGatewayConfig holds configuration for gRPC to HTTP gateway
 // swagger:model
 type GRPCGatewayConfig struct {
-	// GRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs GRPC and HTTP servers on the same port
+	// gRPC server address to connect to - By default it points to HTTP server port because FluxNinja stack runs gRPC and HTTP servers on the same port
 	GRPCAddr string `json:"grpc_server_address" validate:"hostname_port" default:"0.0.0.0:1"`
 }
 


### PR DESCRIPTION
### Description of change

Fix the terminology of gRPC.

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Updated terminology from "GRPC" to "gRPC" across documentation files, comments, and struct names.

> 🎉 gRPC now spelled right, we see,
> Consistency throughout the spree,
> Docs and code aligned with glee,
> Celebrate this change with me! 🥳
<!-- end of auto-generated comment: release notes by openai -->