### PR TITLE
Fixed an issue with operator failing to set controller cert correctly in agent

### DIFF
--- a/operator/api/common/common_types.go
+++ b/operator/api/common/common_types.go
@@ -406,9 +406,9 @@ type ServiceDiscoverySpec struct {
 
 // ControllerClientCertConfig defines configuration for client certificate for Controller.
 type ControllerClientCertConfig struct {
-	// ConfigMapName is the name of the ConfigMap containing the client certificate.
+	// ConfigMapName is the name of the ConfigMap containing the client certificate which will be mounted at '/etc/aperture/aperture-agent/certs' path with given key name.
 	ConfigMapName string `json:"configMapName"`
 
 	// ClientCertKeyName is the key name of the client certificate in the ConfigMap.
-	ClientCertKeyName string `json:"clientCertKeyName"`
+	ClientCertKeyName string `json:"clientCertKeyName" default:"controller-ca.pem"`
 }

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -2013,7 +2013,8 @@ spec:
                     type: string
                   configMapName:
                     description: ConfigMapName is the name of the ConfigMap containing
-                      the client certificate.
+                      the client certificate which will be mounted at '/etc/aperture/aperture-agent/certs'
+                      path with given key name.
                     type: string
                 required:
                 - clientCertKeyName

--- a/operator/controllers/agent/configmaps.go
+++ b/operator/controllers/agent/configmaps.go
@@ -99,7 +99,7 @@ func configMapForAgentControllerClientCert(
 			Annotations: instance.Spec.Annotations,
 		},
 		Data: map[string]string{
-			controllers.ControllerClientCertKey: string(localControllerCert),
+			instance.Spec.ControllerClientCertConfig.ClientCertKeyName: string(localControllerCert),
 		},
 	}
 

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -256,7 +256,8 @@ func AgentVolumeMounts(agentSpec agentv1alpha1.AgentSpec) []corev1.VolumeMount {
 		},
 	}
 
-	if agentSpec.ControllerClientCertConfig.ConfigMapName != "" {
+	if len(agentSpec.ConfigSpec.AgentFunctions.Endpoints) > 0 &&
+		agentSpec.ControllerClientCertConfig.ConfigMapName != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      agentSpec.ControllerClientCertConfig.ConfigMapName,
 			MountPath: AgentControllerClientCertPath,


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Improved handling of Controller client certificate in Agent's configuration
- Ensured correct certificate setting even when sidecar is disabled
- Updated key name for Controller client certificate in ConfigMap data

> 🎉 A bug we did smite, 🐛
> With certificates set right, 🔐
> Sidecar or not, 🚗
> The Agent's got what it sought! 🤖
<!-- end of auto-generated comment: release notes by openai -->