### PR TITLE
reviewer: remove redundant option

### DIFF
--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -30,4 +30,3 @@ jobs:
           debug: false
           review_comment_lgtm: false
           openai_heavy_model: gpt-4
-          max_files_to_summarize: 40


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes
- Chore: Removed `max_files_to_summarize` option from OpenAI Reviewer workflow

> 🎉 A change so small, yet it stands tall,
> Removing limits, we now can call.
> The workflow's free, to summarize all,
> Embrace the update, let's have a ball! 🥳
<!-- end of auto-generated comment: release notes by openai -->