### PR TITLE
Fixed controller client cert issue in agent sidecar mode

### DIFF
--- a/operator/api/common/common_types.go
+++ b/operator/api/common/common_types.go
@@ -407,8 +407,10 @@ type ServiceDiscoverySpec struct {
 // ControllerClientCertConfig defines configuration for client certificate for Controller.
 type ControllerClientCertConfig struct {
 	// ConfigMapName is the name of the ConfigMap containing the client certificate which will be mounted at '/etc/aperture/aperture-agent/certs' path with given key name.
+	//+kubebuilder:validation:Optional
 	ConfigMapName string `json:"configMapName"`
 
 	// ClientCertKeyName is the key name of the client certificate in the ConfigMap.
+	//+kubebuilder:validation:Optional
 	ClientCertKeyName string `json:"clientCertKeyName" default:"controller-ca.pem"`
 }

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -2016,9 +2016,6 @@ spec:
                       the client certificate which will be mounted at '/etc/aperture/aperture-agent/certs'
                       path with given key name.
                     type: string
-                required:
-                - clientCertKeyName
-                - configMapName
                 type: object
               customLivenessProbe:
                 description: Custom livenessProbe that overrides the default one


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Fixed controller client cert issue in agent sidecar mode
- Improved validation for optional fields in `ControllerClientCertConfig`
- Enhanced reconciliation process for config map, handling endpoints and deletion of resources installed for DaemonSet mode of Agent

> 🎉 A bug we've slain, sidecar mode's gain, 🚀
> Validation improved, our code further soothed. 🛠️
> Reconciliation refined, endpoints aligned, 🌐
> Farewell to resources, DaemonSet forces. 🗑️
<!-- end of auto-generated comment: release notes by openai -->