### PR TITLE
Don't pass metric deletion error in circuit

### DIFF
--- a/pkg/policies/controlplane/runtime/circuit.go
+++ b/pkg/policies/controlplane/runtime/circuit.go
@@ -12,6 +12,7 @@ import (
 
 	policymonitoringv1 "github.com/fluxninja/aperture/api/gen/proto/go/aperture/policy/monitoring/v1"
 	"github.com/fluxninja/aperture/pkg/config"
+	"github.com/fluxninja/aperture/pkg/log"
 	"github.com/fluxninja/aperture/pkg/metrics"
 	"github.com/fluxninja/aperture/pkg/notifiers"
 	"github.com/fluxninja/aperture/pkg/policies/controlplane/iface"
@@ -186,7 +187,10 @@ func (circuit *Circuit) setup(lifecycle fx.Lifecycle) {
 					merr = multierr.Append(merr, err)
 				}
 			}
-			return merr
+			if merr != nil {
+				log.Info().Msgf("stopping circuit: %v", merr)
+			}
+			return nil
 		},
 	})
 }


### PR DESCRIPTION
We delete some metrics for invalid readings. So they get deleted twice.
Deleting a deleted metric is not bad, so we can just handle this and log
in setup.

### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Bug fix
- Improved error handling in circuit setup function by logging errors during metrics deletion and returning nil instead of multi-error when no errors are present.

> 🎉 Oh, rejoice, for we have caught the bug! 🐛
> In circuit setup, it hid snug. 🌿
> With better logs, we now unveil 📜
> The errors that once made us fail. 💪
<!-- end of auto-generated comment: release notes by openai -->