### PR TITLE
Use gradlew instead of gradle in aperture-java CI checks

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -812,8 +812,8 @@ jobs:
                 name: Dependencies (no examples)
                 command: |
                   cd <<parameters.path>>
-                  gradle --configure-on-demand :lib:dependencies
-                  gradle --configure-on-demand :javaagent:dependencies
+                  ./gradlew --configure-on-demand :lib:dependencies
+                  ./gradlew --configure-on-demand :javaagent:dependencies
             - save_cache:
                 paths:
                   - ~/.gradle
@@ -824,8 +824,8 @@ jobs:
                 name: Build
                 command: |
                   cd <<parameters.path>>
-                  gradle --configure-on-demand :lib:build --no-daemon
-                  gradle --configure-on-demand :javaagent:build --no-daemon
+                  ./gradlew --configure-on-demand :lib:build --no-daemon
+                  ./gradlew --configure-on-demand :javaagent:build --no-daemon
             # run tests if any are added
       - when:
           condition:
@@ -835,7 +835,7 @@ jobs:
                 name: Dependencies
                 command: |
                   cd <<parameters.path>>
-                  gradle dependencies
+                  ./gradlew dependencies
             - save_cache:
                 paths:
                   - ~/.gradle
@@ -846,13 +846,13 @@ jobs:
                 name: Build
                 command: |
                   cd <<parameters.path>>
-                  gradle build --no-daemon
+                  ./gradlew build --no-daemon
             # run tests!
             - run:
                 name: Test
                 command: |
                   cd <<parameters.path>>
-                  gradle test
+                  ./gradlew test
 
   update-environment:
     parameters:

--- a/.circleci/post-release.yaml
+++ b/.circleci/post-release.yaml
@@ -62,7 +62,7 @@ jobs:
           name: Publish to Sonatype
           command: |
             cd <<parameters.path>>
-            GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) gradle assemble publishToSonatype
+            GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) ./gradlew assemble publishToSonatype
       - save_cache:
           paths:
             - ~/.gradle

--- a/sdks/aperture-java/.circleci/config.yml
+++ b/sdks/aperture-java/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             - gradle-v1-{{ checksum "build.gradle.kts" }}
             - gradle-v1-
       # See https://discuss.circleci.com/t/gpg-keys-as-environment-variables/28641
-      - run: GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) gradle assemble publishToSonatype
+      - run: GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) ./gradlew assemble publishToSonatype
       - save_cache:
           paths:
             - ~/.gradle

--- a/sdks/aperture-java/.circleci/continue-workflows.yml
+++ b/sdks/aperture-java/.circleci/continue-workflows.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Publish to Sonatype
           command: |
-            GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) gradle assemble publishToSonatype
+            GPG_PRIVATE_KEY=$(echo -e ${GPG_PRIVATE_KEY}) ./gradlew assemble publishToSonatype
       - save_cache:
           paths:
             - ~/.gradle

--- a/sdks/aperture-java/dockerfiles/aperture-java-all/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/aperture-java-all/Dockerfile
@@ -6,14 +6,14 @@ WORKDIR /
 
 COPY --link . .
 
-RUN gradle javaagent:agent:shadowJar
-RUN gradle javaagent:test-services:armeria-test-service:shadowJar
-RUN gradle javaagent:test-services:netty-test-service:shadowJar
+RUN ./gradlew javaagent:agent:shadowJar
+RUN ./gradlew javaagent:test-services:armeria-test-service:shadowJar
+RUN ./gradlew javaagent:test-services:netty-test-service:shadowJar
 
-RUN gradle examples:armeria-example:shadowJar
-RUN gradle examples:netty-example:shadowJar
-RUN gradle examples:standalone-example:shadowJar
-RUN gradle examples:spring-example:assemble
+RUN ./gradlew examples:armeria-example:shadowJar
+RUN ./gradlew examples:netty-example:shadowJar
+RUN ./gradlew examples:standalone-example:shadowJar
+RUN ./gradlew examples:spring-example:assemble
 # TODO: also add tomcat here
 
 FROM --platform=linux/amd64 openjdk:18-jdk-alpine

--- a/sdks/aperture-java/dockerfiles/example/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/example/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /
 
 COPY --link . .
 
-RUN gradle examples:armeria-example:shadowJar
+RUN ./gradlew examples:armeria-example:shadowJar
 
 FROM --platform=linux/amd64 openjdk:18-jdk-alpine
 

--- a/sdks/aperture-java/javaagent/README.md
+++ b/sdks/aperture-java/javaagent/README.md
@@ -32,7 +32,7 @@ Supported technologies:
 Jar of the java agent can be built from aperture-java root directory, using the
 following command:
 
-`gradle javaagent:agent:shadowJar`
+`./gradlew javaagent:agent:shadowJar`
 
 The resulting jar can be found in the `aperture-java/javaagent/agent/build/libs`
 directory.

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "1.3.0";
+    public static final String LIBRARY_VERSION = "1.4.0";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "1.3.0"
+  var ver = "1.4.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Updated build command to use `./gradlew` in CircleCI configuration files, Dockerfiles, and README.md
- Bumped version number from `1.3.0` to `1.4.0`

> 🎉 A gradle wrapper we now embrace, 🛠️<br>
> In CircleCI, Docker, and README's space. 📖<br>
> With version numbers on the rise, 🚀<br>
> Our code's journey reaches new highs! 🌟
<!-- end of auto-generated comment: release notes by openai -->