### PR TITLE
Improvemts and fixes in the upgrade process

### DIFF
--- a/docs/content/get-started/installation/agent/agent.md
+++ b/docs/content/get-started/installation/agent/agent.md
@@ -30,6 +30,13 @@ All the configuration parameters for Aperture Agent are listed
 
 The Aperture Agent can be installed in the following modes:
 
+:::caution warning
+
+Upgrading from one of the installation modes below to the other is discouraged
+and can result in unpredictable behavior.
+
+:::
+
 1. **Kubernetes**
 
    1. [**Install with Operator**](kubernetes/operator/operator.md)

--- a/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
@@ -173,7 +173,7 @@ Aperture Agent into your cluster.
    {`helm template agent aperture/aperture-agent -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">
@@ -196,7 +196,7 @@ Aperture Agent into your cluster.
    {`helm template agent aperture/aperture-agent -f values.yaml --namespace aperture-agent | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">

--- a/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
@@ -172,6 +172,13 @@ Aperture Agent into your cluster.
    <CodeBlock language="bash">
    {`helm template agent aperture/aperture-agent -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade agent aperture/aperture-agent -f values.yaml`}
+   </CodeBlock>
    </TabItem>
    </Tabs>
 
@@ -187,6 +194,13 @@ Aperture Agent into your cluster.
    <TabItem value="Helm" label="Helm">
    <CodeBlock language="bash">
    {`helm template agent aperture/aperture-agent -f values.yaml --namespace aperture-agent | kubectl apply -f -`}
+   </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade agent aperture/aperture-agent -f values.yaml --namespace aperture-agent`}
    </CodeBlock>
    </TabItem>
    </Tabs>
@@ -246,5 +260,5 @@ Use the same `values.yaml` file created as part of
    you want to delete them, run the below commands:
 
    ```bash
-   kubectl delete configmap aperture-agent-client-cert
+   kubectl delete configmap -l app.kubernetes.io/instance=agent-aperture-agent
    ```

--- a/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
@@ -248,6 +248,13 @@ Aperture Agent into your cluster.
    <CodeBlock language="bash">
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade agent aperture/aperture-agent -f values.yaml`}
+   </CodeBlock>
    </TabItem>
    </Tabs>
 
@@ -263,6 +270,13 @@ Aperture Agent into your cluster.
    <TabItem value="Helm" label="Helm">
    <CodeBlock language="bash">
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml --namespace aperture-agent | kubectl apply -f -`}
+   </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade agent aperture/aperture-agent -f values.yaml --namespace aperture-agent`}
    </CodeBlock>
    </TabItem>
    </Tabs>
@@ -347,7 +361,7 @@ following these steps:
    to delete it, run the below commands:
 
    ```bash
-   kubectl delete secret -l app.kubernetes.io/component=aperture
+   kubectl delete secret -l app.kubernetes.io/instance=agent-aperture-agent-manager
    ```
 
 5. **Optional**: Delete the CRD installed by the Helm chart:

--- a/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
@@ -249,7 +249,7 @@ Aperture Agent into your cluster.
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">
@@ -272,7 +272,7 @@ Aperture Agent into your cluster.
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml --namespace aperture-agent | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">

--- a/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
@@ -306,6 +306,13 @@ Aperture Agent into your cluster.
    <CodeBlock language="bash">
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade agent aperture/aperture-agent -f values.yaml`}
+   </CodeBlock>
    </TabItem>
    </Tabs>
 
@@ -321,6 +328,13 @@ Aperture Agent into your cluster.
    <TabItem value="Helm" label="Helm">
    <CodeBlock language="bash">
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml --namespace aperture-agent | kubectl apply -f -`}
+   </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade agent aperture/aperture-agent -f values.yaml --namespace aperture-agent`}
    </CodeBlock>
    </TabItem>
    </Tabs>
@@ -487,7 +501,7 @@ following these steps:
    to delete it, run the below commands:
 
    ```bash
-   kubectl delete secret -l app.kubernetes.io/component=aperture
+   kubectl delete secret -l app.kubernetes.io/instance=agent-aperture-agent-manager
    ```
 
 9. **Optional**: Delete the CRD installed by the Helm chart:

--- a/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
@@ -307,7 +307,7 @@ Aperture Agent into your cluster.
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">
@@ -330,7 +330,7 @@ Aperture Agent into your cluster.
    {`helm template --include-crds --no-hooks agent aperture/aperture-agent -f values.yaml --namespace aperture-agent | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">

--- a/docs/content/get-started/installation/controller/controller.md
+++ b/docs/content/get-started/installation/controller/controller.md
@@ -56,6 +56,13 @@ Install the tool of your choice using the following links:
 
 The Aperture Controller can be installed using the below options:
 
+:::caution warning
+
+Upgrading from one of the installation modes below to the other is discouraged
+and can result in unpredictable behavior.
+
+:::
+
 1. [**Install with Operator**](operator/operator.md)
 
    The Aperture Controller can be installed using the Kubernetes Operator

--- a/docs/content/get-started/installation/controller/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/controller/namespace-scoped/namespace-scoped.md
@@ -197,6 +197,13 @@ Aperture Controller into your cluster.
    <CodeBlock language="bash">
    {`helm template controller aperture/aperture-controller -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade controller aperture/aperture-controller -f values.yaml`}
+   </CodeBlock>
    </TabItem>
    </Tabs>
 
@@ -212,6 +219,13 @@ Aperture Controller into your cluster.
    <TabItem value="Helm" label="Helm">
    <CodeBlock language="bash">
    {`helm template controller aperture/aperture-controller -f values.yaml --namespace aperture-controller | kubectl apply -f -`}
+   </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade controller aperture/aperture-controller -f values.yaml --namespace aperture-controller`}
    </CodeBlock>
    </TabItem>
    </Tabs>
@@ -271,6 +285,6 @@ Use the same `values.yaml` file created as part of
    you want to delete them, run the below commands:
 
    ```bash
-   kubectl delete secret controller-aperture-controller-cert
-   kubectl delete configmap controller-aperture-controller-client-cert
+   kubectl delete secret -l app.kubernetes.io/instance=controller-aperture-controller
+   kubectl delete configmap -l app.kubernetes.io/instance=controller-aperture-controller
    ```

--- a/docs/content/get-started/installation/controller/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/controller/namespace-scoped/namespace-scoped.md
@@ -191,7 +191,7 @@ Aperture Controller into your cluster.
    {`helm template controller aperture/aperture-controller -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">
@@ -214,7 +214,7 @@ Aperture Controller into your cluster.
    {`helm template controller aperture/aperture-controller -f values.yaml --namespace aperture-controller | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">

--- a/docs/content/get-started/installation/controller/operator/operator.md
+++ b/docs/content/get-started/installation/controller/operator/operator.md
@@ -221,7 +221,7 @@ Aperture Controller into your cluster.
    {`helm template --include-crds --no-hooks controller aperture/aperture-controller -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">
@@ -244,7 +244,7 @@ Aperture Controller into your cluster.
    {`helm template --include-crds --no-hooks controller aperture/aperture-controller -f values.yaml --namespace aperture-controller | kubectl apply -f -`}
    </CodeBlock>
 
-   Once all the pods are in running state after upgrade, run the below command
+   Once all the pods are in a running state after upgrade, run the below command
    to keep the Helm release updated:
 
    <CodeBlock language="bash">

--- a/docs/content/get-started/installation/controller/operator/operator.md
+++ b/docs/content/get-started/installation/controller/operator/operator.md
@@ -220,6 +220,13 @@ Aperture Controller into your cluster.
    <CodeBlock language="bash">
    {`helm template --include-crds --no-hooks controller aperture/aperture-controller -f values.yaml | kubectl apply -f -`}
    </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade controller aperture/aperture-controller -f values.yaml`}
+   </CodeBlock>
    </TabItem>
    </Tabs>
 
@@ -235,6 +242,13 @@ Aperture Controller into your cluster.
    <TabItem value="Helm" label="Helm">
    <CodeBlock language="bash">
    {`helm template --include-crds --no-hooks controller aperture/aperture-controller -f values.yaml --namespace aperture-controller | kubectl apply -f -`}
+   </CodeBlock>
+
+   Once all the pods are in running state after upgrade, run the below command
+   to keep the Helm release updated:
+
+   <CodeBlock language="bash">
+   {`helm upgrade controller aperture/aperture-controller -f values.yaml --namespace aperture-controller`}
    </CodeBlock>
    </TabItem>
    </Tabs>
@@ -327,8 +341,9 @@ following the below steps:
    with above steps. If you want to delete them, run the below commands:
 
    ```bash
-   kubectl delete secret -l app.kubernetes.io/component=aperture
-   kubectl delete configmap -l app.kubernetes.io/component=aperture
+   kubectl delete secret -l app.kubernetes.io/instance=controller-aperture-controller-manager
+   kubectl delete secret -l app.kubernetes.io/instance=controller
+   kubectl delete configmap -l app.kubernetes.io/instance=controller
    ```
 
 6. **Optional**: Delete the CRD installed by the Helm chart:

--- a/manifests/charts/aperture-controller/Chart.lock
+++ b/manifests/charts/aperture-controller/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.17.1
 - name: etcd
   repository: https://charts.bitnami.com/bitnami
-  version: 8.8.1
+  version: 8.9.0
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.18.0
-digest: sha256:9c064f9fa1edf55eefbb58dc29ed1606e00285c27e64289a6053cfdc5786aa20
-generated: "2023-04-06T21:08:59.18044504+05:30"
+digest: sha256:c16e0f10234a15181cdde670a1c422e17ae90020598a4e2f0b254ea391898ab3
+generated: "2023-04-21T11:34:56.926829081+05:30"

--- a/manifests/charts/aperture-controller/Chart.yaml
+++ b/manifests/charts/aperture-controller/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: "=1.17.1"
   - name: etcd
-    version: "=8.8.1"
+    version: "=8.9.0"
     repository: https://charts.bitnami.com/bitnami
     condition: etcd.enabled
   - name: prometheus

--- a/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
@@ -20,6 +20,8 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 10
+  backoffLimit: 0
   template:
     metadata:
       annotations:

--- a/manifests/charts/aperture-controller/templates/operator-rbac.yaml
+++ b/manifests/charts/aperture-controller/templates/operator-rbac.yaml
@@ -30,6 +30,7 @@ rules:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
   - create
   - delete
@@ -74,6 +75,7 @@ rules:
   - secrets
   - serviceaccounts
   - services
+  - pods
   verbs:
   - create
   - delete
@@ -117,6 +119,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - delete
+  - get
+  - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/aperture-controller/templates/post-install-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/post-install-hook.yaml
@@ -1,0 +1,48 @@
+{{- if not .Values.controller.namespaceScoped }}
+# We have updated the default parameters for built-in Etcd and Prometheus,
+# which may leave some resources behind. This job will clean up the old
+# resources. If you have customized the Etcd or Prometheus parameters, you
+# should manually clean up the old resources.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "common.names.fullname" . }}-post-install-hook
+  namespace: {{ template "common.names.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: aperture-controller-manager
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  ttlSecondsAfterFinished: 10
+  backoffLimit: 0
+  template:
+    metadata:
+      annotations:
+        sidecar.fluxninja.com/injection: "false"
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: aperture-controller-manager
+    spec:
+      serviceAccountName: {{ include "controller-operator.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+      - name: post-install-job
+        image: "bitnami/kubectl"
+        command:
+          - "/bin/bash"
+          - "-xc"
+          - |
+            kubectl delete service,deployment --selector=app.kubernetes.io/name=kube-state-metrics,app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/managed-by=Helm -n {{ template "common.names.namespace" . }}
+            kubectl delete clusterrole,clusterrolebinding,serviceaccount --selector=app.kubernetes.io/name=kube-state-metrics,app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/managed-by=Helm
+            kubectl wait statefulset {{ .Release.Name }}-prometheus-server -n {{ template "common.names.namespace" . }} --for=jsonpath='{.status.readyReplicas}'={{ .Values.prometheus.server.replicaCount | default 1}} --timeout=600s
+            kubectl label --overwrite=true --selector=app=prometheus,release={{ .Release.Name }},heritage=Helm pod,service,statefulset -n {{ template "common.names.namespace" . }} app.kubernetes.io/managed-by=Helm
+            kubectl annotate --overwrite=true --selector=app=prometheus,release={{ .Release.Name }},heritage=Helm pod,service,statefulset -n {{ template "common.names.namespace" . }} meta.helm.sh/release-name={{ .Release.Name }}
+            kubectl annotate --overwrite=true --selector=app=prometheus,release={{ .Release.Name }},heritage=Helm pod,service,statefulset -n {{ template "common.names.namespace" . }} meta.helm.sh/release-namespace={{ .Release.Namespace }}
+            kubectl delete deployment --selector=app=prometheus,release={{ .Release.Name }},heritage=Helm -n {{ template "common.names.namespace" . }}
+            kubectl delete clusterrole,clusterrolebinding --selector=app=prometheus,release={{ .Release.Name }},heritage=Helm
+            kubectl delete pdb --selector=app.kubernetes.io/name=etcd,app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/managed-by=Helm -n {{ template "common.names.namespace" . }}
+{{- end }}

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -606,6 +606,8 @@ prometheus:
       tag: 3.1.0
       pullPolicy: IfNotPresent
   server:
+    statefulSet:
+      enabled: true
     image:
       tag: v2.33.5
     extraFlags:

--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -186,7 +186,7 @@ DEP_TREE = {
                         ("^controller-prometheus", None),
                     ],
                     "ignored_objects": [
-                        ("^controller-prometheus", "Service|Deployment"),
+                        ("^controller-prometheus", "Service|StatefulSet"),
                         "controller-prometheus:grafanadatasource"
                     ]
                 },


### PR DESCRIPTION
### Description of change

- Updated default prometheus to use StatefulSet to fix the upgrade issue
- Update Etcd chart to v8.9.0
- Added post-install job to delete resource from previous release
- Updated docs

##### Checklist

- [x] Tested in playground or other setup
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Improved installation instructions for Aperture Agent and Controller in Kubernetes
- Added warning messages to discourage upgrading between installation modes

**Bug fix:**
- Fixed Prometheus upgrade issue by using StatefulSet
- Updated Etcd chart to v8.9.0 and added post-install job

> 🎉 A smoother install, we've paved the way,
> For Agent and Controller, come what may.
> With warnings in place, and upgrades refined,
> Our users rejoice, peace of mind they find. 🚀
<!-- end of auto-generated comment: release notes by openai -->