### PR TITLE
Fix SMA behaviour

### DIFF
--- a/pkg/policies/controlplane/components/sma.go
+++ b/pkg/policies/controlplane/components/sma.go
@@ -80,13 +80,14 @@ func (sma *SMA) Execute(inPortReadings runtime.PortToReading, tickInfo runtime.T
 			output = runtime.InvalidReading()
 		}
 	} else {
-		output = sma.lastGoodOutput
 		sma.invalidCounter++
 		if sma.invalidCounter >= sma.window {
 			sma.buffer = []float64{}
 			sma.sum = 0
 			sma.invalidCounter = 0
 			output = runtime.InvalidReading()
+		} else {
+			output = sma.lastGoodOutput
 		}
 	}
 

--- a/pkg/policies/controlplane/components/sma.go
+++ b/pkg/policies/controlplane/components/sma.go
@@ -80,13 +80,14 @@ func (sma *SMA) Execute(inPortReadings runtime.PortToReading, tickInfo runtime.T
 			output = runtime.InvalidReading()
 		}
 	} else {
+		output = sma.lastGoodOutput
 		sma.invalidCounter++
 		if sma.invalidCounter >= sma.window {
 			sma.buffer = []float64{}
 			sma.sum = 0
 			sma.invalidCounter = 0
+			output = runtime.InvalidReading()
 		}
-		output = sma.lastGoodOutput
 	}
 
 	// Set the last good output

--- a/pkg/policies/controlplane/components/sma_test.go
+++ b/pkg/policies/controlplane/components/sma_test.go
@@ -165,7 +165,7 @@ var _ = Describe("SMA component", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(circuit.RunDrainInputs()).To(Equal(
 			sim.Outputs{
-				"SMA": sim.NewReadings([]float64{nan, 0.0, 0.5, 1, 1.5, 2.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 1, 3.0, 4.0}),
+				"SMA": sim.NewReadings([]float64{nan, 0.0, 0.5, 1, 1.5, 2.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0, nan, 1, 3.0, 4.0}),
 			},
 		))
 	})


### PR DESCRIPTION
### Description of change
Make output as invalid when invalidCount >= window.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [x] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Improved handling of invalid readings in the Simple Moving Average (SMA) filter
- Updated test case to simulate invalid reading scenario

> 🎉 Oh, rejoice and celebrate! 🥳
> For we've fixed a bug, no time to wait. 🐛
> The SMA filter now stands tall, 💪
> Handling invalid readings, one and all. 📈
<!-- end of auto-generated comment: release notes by openai -->