### PR TITLE
Update gcp-gcr CircleCI org for Python 3.11 compatibility

### DIFF
--- a/.circleci/post-release.yaml
+++ b/.circleci/post-release.yaml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.13.0
+  gcp-gcr: circleci/gcp-gcr@0.15.1
 
 executors:
   base-cimg-executor:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes
- Chore: Updated `gcp-gcr` orb version in CircleCI configuration for Python 3.11 compatibility.

> 🎉 A small change, yet so wise,
> For Python 3.11, we now optimize.
> With orbs updated, we celebrate,
> Our CircleCI config, up-to-date! 🚀
<!-- end of auto-generated comment: release notes by openai -->