### PR TITLE
Minor changes in installation docs

### DIFF
--- a/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
@@ -229,7 +229,7 @@ Use the same `values.yaml` file created as part of
    <Tabs groupId="setup" queryString>
    <TabItem value="aperturectl" label="aperturectl">
    <CodeBlock language="bash">
-   {`aperturectl uninstall agent --values-file values.yaml`}
+   {`aperturectl uninstall agent --values-file values.yaml --version ${apertureVersion}`}
    </CodeBlock>
    </TabItem>
    <TabItem value="Helm" label="Helm">
@@ -245,7 +245,7 @@ Use the same `values.yaml` file created as part of
    <Tabs groupId="setup" queryString>
    <TabItem value="aperturectl" label="aperturectl">
    <CodeBlock language="bash">
-   {`aperturectl uninstall agent --namespace aperture-agent --values-file values.yaml`}
+   {`aperturectl uninstall agent --namespace aperture-agent --values-file values.yaml --version ${apertureVersion}`}
    </CodeBlock>
    </TabItem>
    <TabItem value="Helm" label="Helm">

--- a/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
@@ -305,7 +305,7 @@ following these steps:
    <Tabs groupId="setup" queryString>
    <TabItem value="aperturectl" label="aperturectl">
    <CodeBlock language="bash">
-   {`aperturectl uninstall agent`}
+   {`aperturectl uninstall agent --version ${apertureVersion}`}
    </CodeBlock>
    </TabItem>
    <TabItem value="Helm" label="Helm">
@@ -329,7 +329,7 @@ following these steps:
       <Tabs groupId="setup" queryString>
       <TabItem value="aperturectl" label="aperturectl">
       <CodeBlock language="bash">
-      {`aperturectl uninstall agent`}
+      {`aperturectl uninstall agent --version ${apertureVersion}`}
       </CodeBlock>
       </TabItem>
       <TabItem value="Helm" label="Helm">

--- a/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
@@ -430,9 +430,18 @@ following these steps:
 
 1. Delete the Aperture Agent chart:
 
-   ```bash
-   helm uninstall agent
-   ```
+   <Tabs groupId="setup" queryString>
+   <TabItem value="aperturectl" label="aperturectl">
+   <CodeBlock language="bash">
+   {`aperturectl uninstall agent --version ${apertureVersion}`}
+   </CodeBlock>
+   </TabItem>
+   <TabItem value="Helm" label="Helm">
+   <CodeBlock language="bash">
+   {`helm uninstall agent`}
+   </CodeBlock>
+   </TabItem>
+   </Tabs>
 
 2. If you have installed the Aperture Agent Custom Resource, follow the steps
    below:
@@ -448,7 +457,7 @@ following these steps:
       <Tabs groupId="setup" queryString>
       <TabItem value="aperturectl" label="aperturectl">
       <CodeBlock language="bash">
-      {`aperturectl uninstall agent`}
+      {`aperturectl uninstall agent --version ${apertureVersion}`}
       </CodeBlock>
       </TabItem>
       <TabItem value="Helm" label="Helm">
@@ -464,7 +473,7 @@ following these steps:
    <Tabs groupId="setup" queryString>
    <TabItem value="aperturectl" label="aperturectl">
    <CodeBlock language="bash">
-   {`aperturectl uninstall agent --namespace aperture-agent`}
+   {`aperturectl uninstall agent --namespace aperture-agent --version ${apertureVersion}`}
    </CodeBlock>
    </TabItem>
    <TabItem value="Helm" label="Helm">

--- a/docs/content/get-started/installation/controller/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/controller/namespace-scoped/namespace-scoped.md
@@ -247,7 +247,7 @@ Use the same `values.yaml` file created as part of
    <Tabs groupId="setup" queryString>
    <TabItem value="aperturectl" label="aperturectl">
    <CodeBlock language="bash">
-   {`aperturectl uninstall controller --values-file values.yaml`}
+   {`aperturectl uninstall controller --values-file values.yaml --version ${apertureVersion}`}
    </CodeBlock>
    </TabItem>
    <TabItem value="Helm" label="Helm">
@@ -263,7 +263,7 @@ Use the same `values.yaml` file created as part of
    <Tabs groupId="setup" queryString>
    <TabItem value="aperturectl" label="aperturectl">
    <CodeBlock language="bash">
-   {`aperturectl uninstall controller --namespace aperture-controller --values-file values.yaml`}
+   {`aperturectl uninstall controller --namespace aperture-controller --values-file values.yaml --version ${apertureVersion}`}
    </CodeBlock>
    </TabItem>
    <TabItem value="Helm" label="Helm">

--- a/docs/content/get-started/installation/controller/operator/operator.md
+++ b/docs/content/get-started/installation/controller/operator/operator.md
@@ -277,7 +277,7 @@ following the below steps:
    <Tabs groupId="setup" queryString>
    <TabItem value="aperturectl" label="aperturectl">
    <CodeBlock language="bash">
-   {`aperturectl uninstall controller`}
+   {`aperturectl uninstall controller --version ${apertureVersion}`}
    </CodeBlock>
    </TabItem>
    <TabItem value="Helm" label="Helm">

--- a/manifests/charts/aperture-agent/templates/agent-cm.yaml
+++ b/manifests/charts/aperture-agent/templates/agent-cm.yaml
@@ -25,7 +25,7 @@ data:
       {{- end }}
       disable_kubernetes_scraper: true
       custom_metrics:
-        {{- if (omit .Values.agent.config.otel.custom_metrics "kubeletstats")}}
+        {{- if and .Values.agent.config.otel .Values.agent.config.otel.custom_metrics (omit .Values.agent.config.otel.custom_metrics "kubeletstats")}}
         {{- omit .Values.agent.config.otel.custom_metrics "kubeletstats" | toYaml | nindent 8 }}
         {{- end }}
         kubeletstats: {}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Added `--version` flag to `aperturectl uninstall` commands for Aperture Agent and Aperture Controller installation documentation.

> 🎉 A flag was born today, so bright and clear, 🌟
> To help uninstall with version, bringing cheer! 😄
> Aperture's docs now shine with added grace, ✨
> For users to follow, in their software chase. 🏃‍♂️💨
<!-- end of auto-generated comment: release notes by openai -->