### PR TITLE
Add agent group label to metrics

### DIFF
--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -145,6 +145,8 @@ const (
 	FlowControlCheckErrorReasonLabel = "error_reason"
 	// FlowControlCheckRejectReasonLabel - label for reject reason on FCS Check request.
 	FlowControlCheckRejectReasonLabel = "reject_reason"
+	// AgentGroupLabel - label for agent group.
+	AgentGroupLabel = "agent_group"
 
 	// DEFAULTS.
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Add `AgentGroupLabel` for better agent group identification in metrics
- Update `podCounter` metric, `newAutoScaleControlPoints`, and `newPodNotifier` functions to support `agentGroup` parameter
- Modify `provideAutoScaleControlPoints` function to include `AgentInfo` argument and create `PodNotifier` with `AgentGroup` value

> 🎉 A new label takes the stage, 🏷️
> Agent groups now engage. 🤖
> Metrics refined, code aligned, 📊
> Our autoscaling knowledge, we gauge! 🚀
<!-- end of auto-generated comment: release notes by openai -->