### PR TITLE
docs: fix minor typo in integration section for metrics

### DIFF
--- a/docs/content/get-started/integrations/metrics/active-directory-ds.md
+++ b/docs/content/get-started/integrations/metrics/active-directory-ds.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [activedirectorydsreceiver docs][receiver] in
 opentelemetry-collect-contrib repository.
 
 :::
 
-::: note
+:::note
 
 The `activedirectorydsreceiver` extension is available in the default agent
 image. If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/aerospike.md
+++ b/docs/content/get-started/integrations/metrics/aerospike.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [aerospikereceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `aerospikereceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/apache-web-server.md
+++ b/docs/content/get-started/integrations/metrics/apache-web-server.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [apachereceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `apachereceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/aws-container-insight.md
+++ b/docs/content/get-started/integrations/metrics/aws-container-insight.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [awscontainerinsightreceiver docs][receiver] in
 opentelemetry-collect-contrib repository.
 
 :::
 
-::: note
+:::note
 
 The `awscontainerinsightreceiver` extension is available in the default agent
 image. If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/aws-ecs-container-metrics.md
+++ b/docs/content/get-started/integrations/metrics/aws-ecs-container-metrics.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [awsecscontainermetricsreceiver docs][receiver] in
 opentelemetry-collect-contrib repository.
 
 :::
 
-::: note
+:::note
 
 The `awsecscontainermetricsreceiver` extension is available in the default agent
 image. If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/aws-kinesis-data-firehose.md
+++ b/docs/content/get-started/integrations/metrics/aws-kinesis-data-firehose.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [awsfirehosereceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `awsfirehosereceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/azure-event-hub.md
+++ b/docs/content/get-started/integrations/metrics/azure-event-hub.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [azureeventhubreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `azureeventhubreceiver` extension is available in the default agent image.
 If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/chrony.md
+++ b/docs/content/get-started/integrations/metrics/chrony.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [chronyreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `chronyreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/cloud-foundry.md
+++ b/docs/content/get-started/integrations/metrics/cloud-foundry.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [cloudfoundryreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `cloudfoundryreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/collectd.md
+++ b/docs/content/get-started/integrations/metrics/collectd.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [collectdreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `collectdreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/couchdb.md
+++ b/docs/content/get-started/integrations/metrics/couchdb.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [couchdbreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `couchdbreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/docker.md
+++ b/docs/content/get-started/integrations/metrics/docker.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [dockerstatsreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `dockerstatsreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/elasticsearch.md
+++ b/docs/content/get-started/integrations/metrics/elasticsearch.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [elasticsearchreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `elasticsearchreceiver` extension is available in the default agent image.
 If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/expvar.md
+++ b/docs/content/get-started/integrations/metrics/expvar.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [expvarreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `expvarreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/f5-bigip.md
+++ b/docs/content/get-started/integrations/metrics/f5-bigip.md
@@ -10,14 +10,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [bigipreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `bigipreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/bigipreceiver`

--- a/docs/content/get-started/integrations/metrics/flinkmetrics.md
+++ b/docs/content/get-started/integrations/metrics/flinkmetrics.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [flinkmetricsreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `flinkmetricsreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/google-cloud-spanner.md
+++ b/docs/content/get-started/integrations/metrics/google-cloud-spanner.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [googlecloudspannerreceiver docs][receiver] in
 opentelemetry-collect-contrib repository.
 
 :::
 
-::: note
+:::note
 
 The `googlecloudspannerreceiver` extension is available in the default agent
 image. If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/google-pubsub.md
+++ b/docs/content/get-started/integrations/metrics/google-pubsub.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [googlecloudpubsubreceiver docs][receiver] in
 opentelemetry-collect-contrib repository.
 
 :::
 
-::: note
+:::note
 
 The `googlecloudpubsubreceiver` extension is available in the default agent
 image. If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/haproxy.md
+++ b/docs/content/get-started/integrations/metrics/haproxy.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [haproxyreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `haproxyreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/httpcheck.md
+++ b/docs/content/get-started/integrations/metrics/httpcheck.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [httpcheckreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `httpcheckreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/influxdb.md
+++ b/docs/content/get-started/integrations/metrics/influxdb.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [influxdbreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `influxdbreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/jmx.md
+++ b/docs/content/get-started/integrations/metrics/jmx.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [jmxreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `jmxreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/jmxreceiver`

--- a/docs/content/get-started/integrations/metrics/kafka.md
+++ b/docs/content/get-started/integrations/metrics/kafka.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [kafkametricsreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `kafkametricsreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/kubelet-stats.md
+++ b/docs/content/get-started/integrations/metrics/kubelet-stats.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [kubeletstatsreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `kubeletstatsreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/kubernetes-cluster.md
+++ b/docs/content/get-started/integrations/metrics/kubernetes-cluster.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [k8sclusterreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `k8sclusterreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/memcached.md
+++ b/docs/content/get-started/integrations/metrics/memcached.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [memcachedreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `memcachedreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/microsoft-sql-server.md
+++ b/docs/content/get-started/integrations/metrics/microsoft-sql-server.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [sqlserverreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `sqlserverreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/mongodb-atlas.md
+++ b/docs/content/get-started/integrations/metrics/mongodb-atlas.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [mongodbatlasreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `mongodbatlasreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/mongodb.md
+++ b/docs/content/get-started/integrations/metrics/mongodb.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [mongodbreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `mongodbreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/mysql.md
+++ b/docs/content/get-started/integrations/metrics/mysql.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [mysqlreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `mysqlreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/mysqlreceiver`

--- a/docs/content/get-started/integrations/metrics/nginx.md
+++ b/docs/content/get-started/integrations/metrics/nginx.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [nginxreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `nginxreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/nginxreceiver`

--- a/docs/content/get-started/integrations/metrics/nsxt.md
+++ b/docs/content/get-started/integrations/metrics/nsxt.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [nsxtreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `nsxtreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/nsxtreceiver`

--- a/docs/content/get-started/integrations/metrics/opencensus.md
+++ b/docs/content/get-started/integrations/metrics/opencensus.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [opencensusreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `opencensusreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/oracledb.md
+++ b/docs/content/get-started/integrations/metrics/oracledb.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [oracledbreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `oracledbreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/otlp-json-file.md
+++ b/docs/content/get-started/integrations/metrics/otlp-json-file.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [otlpjsonfilereceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `otlpjsonfilereceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/podman.md
+++ b/docs/content/get-started/integrations/metrics/podman.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [podmanreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `podmanreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/postgresql.md
+++ b/docs/content/get-started/integrations/metrics/postgresql.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [postgresqlreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `postgresqlreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/prometheus-simple.md
+++ b/docs/content/get-started/integrations/metrics/prometheus-simple.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [simpleprometheusreceiver docs][receiver] in
 opentelemetry-collect-contrib repository.
 
 :::
 
-::: note
+:::note
 
 The `simpleprometheusreceiver` extension is available in the default agent
 image. If you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/prometheus.md
+++ b/docs/content/get-started/integrations/metrics/prometheus.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [prometheusreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `prometheusreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/pulsar.md
+++ b/docs/content/get-started/integrations/metrics/pulsar.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [pulsarreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `pulsarreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/pure-storage-flasharray.md
+++ b/docs/content/get-started/integrations/metrics/pure-storage-flasharray.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [purefareceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `purefareceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/pure-storage-flashblade.md
+++ b/docs/content/get-started/integrations/metrics/pure-storage-flashblade.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [purefbreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `purefbreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/rabbitmq.md
+++ b/docs/content/get-started/integrations/metrics/rabbitmq.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [rabbitmqreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `rabbitmqreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/redis.md
+++ b/docs/content/get-started/integrations/metrics/redis.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [redisreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `redisreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/redisreceiver`

--- a/docs/content/get-started/integrations/metrics/riak.md
+++ b/docs/content/get-started/integrations/metrics/riak.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [riakreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `riakreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/riakreceiver`

--- a/docs/content/get-started/integrations/metrics/sap-hana.md
+++ b/docs/content/get-started/integrations/metrics/sap-hana.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [saphanareceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `saphanareceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/signalfx.md
+++ b/docs/content/get-started/integrations/metrics/signalfx.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [signalfxreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `signalfxreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/snmp.md
+++ b/docs/content/get-started/integrations/metrics/snmp.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [snmpreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `snmpreceiver` extension is available in the default agent image. If you're
 [building][build] your own Aperture Agent, add `integrations/otel/snmpreceiver`

--- a/docs/content/get-started/integrations/metrics/snowflake.md
+++ b/docs/content/get-started/integrations/metrics/snowflake.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [snowflakereceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `snowflakereceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/splunk-hec.md
+++ b/docs/content/get-started/integrations/metrics/splunk-hec.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [splunkhecreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `splunkhecreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/sql-query.md
+++ b/docs/content/get-started/integrations/metrics/sql-query.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [sqlqueryreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `sqlqueryreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/sshcheck.md
+++ b/docs/content/get-started/integrations/metrics/sshcheck.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [sshcheckreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `sshcheckreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/statsd.md
+++ b/docs/content/get-started/integrations/metrics/statsd.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [statsdreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `statsdreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/vcenter.md
+++ b/docs/content/get-started/integrations/metrics/vcenter.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [vcenterreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `vcenterreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/wavefront.md
+++ b/docs/content/get-started/integrations/metrics/wavefront.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [wavefrontreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `wavefrontreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add

--- a/docs/content/get-started/integrations/metrics/zookeeper.md
+++ b/docs/content/get-started/integrations/metrics/zookeeper.md
@@ -9,14 +9,14 @@ keywords:
   - metrics
 ---
 
-::: info
+:::info
 
 See also [zookeeperreceiver docs][receiver] in opentelemetry-collect-contrib
 repository.
 
 :::
 
-::: note
+:::note
 
 The `zookeeperreceiver` extension is available in the default agent image. If
 you're [building][build] your own Aperture Agent, add


### PR DESCRIPTION
### Description of change
Due to extra space for `info` and `note` it was not properly viewed on the docs 
##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes
