### PR TITLE
Refactor context handling in `StartFlow`

### DIFF
--- a/sdks/aperture-go/example/main.go
+++ b/sdks/aperture-go/example/main.go
@@ -88,7 +88,7 @@ func main() {
 	// Adding the http middleware to be executed before the actual business logic execution.
 	superRouter := mux.PathPrefix("/super").Subrouter()
 	superRouter.HandleFunc("", a.SuperHandler)
-	superRouter.Use(a.apertureClient.HTTPMiddleware("awesomeFeature", labels, 30*time.Second))
+	superRouter.Use(a.apertureClient.HTTPMiddleware("awesomeFeature", labels))
 
 	mux.HandleFunc("/connected", a.ConnectedHandler)
 	mux.HandleFunc("/health", a.HealthHandler)

--- a/sdks/aperture-go/sdk/client.go
+++ b/sdks/aperture-go/sdk/client.go
@@ -34,8 +34,8 @@ import (
 type Client interface {
 	StartFlow(ctx context.Context, controlPoint string, labels map[string]string) (Flow, error)
 	Shutdown(ctx context.Context) error
-	HTTPMiddleware(controlPoint string, labels map[string]string, timeout time.Duration) mux.MiddlewareFunc
-	GRPCUnaryInterceptor(controlPoint string, labels map[string]string, timeout time.Duration) func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error)
+	HTTPMiddleware(controlPoint string, labels map[string]string) mux.MiddlewareFunc
+	GRPCUnaryInterceptor(controlPoint string, labels map[string]string) grpc.UnaryServerInterceptor
 }
 
 type apertureClient struct {
@@ -110,13 +110,19 @@ func NewClient(ctx context.Context, opts Options) (Client, error) {
 // The call returns immediately in case connection with Aperture Agent is not established.
 // The default semantics are fail-to-wire. If StartFlow fails, calling Flow.Accepted() on returned Flow returns as true.
 func (c *apertureClient) StartFlow(ctx context.Context, controlPoint string, explicitLabels map[string]string) (Flow, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	var newCtx context.Context
+	var cancel context.CancelFunc
+	if c.timeout == 0 {
+		newCtx = ctx
+	} else {
+		newCtx, cancel = context.WithTimeout(ctx, c.timeout)
+	}
 	defer cancel()
 
 	labels := make(map[string]string)
 
 	// Inherit labels from baggage
-	baggageCtx := baggage.FromContext(ctx)
+	baggageCtx := baggage.FromContext(newCtx)
 	for _, member := range baggageCtx.Members() {
 		value, err := url.QueryUnescape(member.Value())
 		if err != nil {
@@ -135,7 +141,7 @@ func (c *apertureClient) StartFlow(ctx context.Context, controlPoint string, exp
 		Labels:       labels,
 	}
 
-	_, span := c.tracer.Start(ctx, "Aperture Check", trace.WithAttributes(
+	_, span := c.tracer.Start(newCtx, "Aperture Check", trace.WithAttributes(
 		attribute.Int64(flowStartTimestampLabel, time.Now().UnixNano()),
 		attribute.String(sourceLabel, "sdk"),
 	))
@@ -144,7 +150,7 @@ func (c *apertureClient) StartFlow(ctx context.Context, controlPoint string, exp
 		span: span,
 	}
 
-	res, err := c.flowControlClient.Check(ctx, req)
+	res, err := c.flowControlClient.Check(newCtx, req)
 	if err != nil {
 		f.checkResponse = nil
 	} else {
@@ -159,7 +165,7 @@ func (c *apertureClient) StartFlow(ctx context.Context, controlPoint string, exp
 }
 
 // HTTPMiddleware takes a control point name, labels and timeout and creates a Middleware which can be used with HTTP server.
-func (c *apertureClient) HTTPMiddleware(controlPoint string, labels map[string]string, timeout time.Duration) mux.MiddlewareFunc {
+func (c *apertureClient) HTTPMiddleware(controlPoint string, labels map[string]string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			newLabels := make(map[string]string, len(labels))
@@ -169,7 +175,10 @@ func (c *apertureClient) HTTPMiddleware(controlPoint string, labels map[string]s
 				newLabels[key] = strings.Join(value, ",")
 			}
 
-			flow := c.executeFlow(r.Context(), controlPoint, newLabels, timeout)
+			flow, err := c.StartFlow(r.Context(), controlPoint, labels)
+			if err != nil {
+				c.log.Info("Aperture flow control got error. Returned flow defaults to Allowed.", "flow.Accepted()", flow.Accepted())
+			}
 
 			if flow.Accepted() {
 				// Simulate work being done
@@ -198,7 +207,7 @@ func (c *apertureClient) HTTPMiddleware(controlPoint string, labels map[string]s
 }
 
 // GRPCUnaryInterceptor takes a control point name, labels and timeout and creates a UnaryInterceptor which can be used with gRPC server.
-func (c *apertureClient) GRPCUnaryInterceptor(controlPoint string, labels map[string]string, timeout time.Duration) func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func (c *apertureClient) GRPCUnaryInterceptor(controlPoint string, labels map[string]string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		newLabels := make(map[string]string, len(labels))
 		maps.Copy(newLabels, labels)
@@ -210,7 +219,10 @@ func (c *apertureClient) GRPCUnaryInterceptor(controlPoint string, labels map[st
 			}
 		}
 
-		flow := c.executeFlow(ctx, controlPoint, newLabels, timeout)
+		flow, err := c.StartFlow(ctx, controlPoint, labels)
+		if err != nil {
+			c.log.Info("Aperture flow control got error. Returned flow defaults to Allowed.", "flow.Accepted()", flow.Accepted())
+		}
 
 		if flow.Accepted() {
 			// Simulate work being done
@@ -235,25 +247,6 @@ func (c *apertureClient) GRPCUnaryInterceptor(controlPoint string, labels map[st
 			)
 		}
 	}
-}
-
-func (c *apertureClient) executeFlow(ctx context.Context, controlPoint string, labels map[string]string, timeout time.Duration) Flow {
-	var newCtx context.Context
-	var cancel context.CancelFunc
-	if timeout == 0 {
-		newCtx = ctx
-	} else {
-		newCtx, cancel = context.WithTimeout(ctx, timeout)
-	}
-	defer cancel()
-
-	// StartFlow performs a flowcontrolv1.Check call to Aperture Agent. It returns a Flow and an error if any.
-	flow, err := c.StartFlow(newCtx, controlPoint, labels)
-	if err != nil {
-		c.log.Info("Aperture flow control got error. Returned flow defaults to Allowed.", "flow.Accepted()", flow.Accepted())
-	}
-
-	return flow
 }
 
 // Shutdown shuts down the aperture client.


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Updated context handling in `StartFlow` method of `apertureClient` struct
- Removed duration parameter from `HTTPMiddleware` function call
- Adjusted related methods to use the new `StartFlow`

> 🎉 A refactor's here, a change so grand,
> Contexts handled with a skillful hand.
> Duration gone, but middleware thrives,
> Our code evolves, like bees in their hives. 🐝
<!-- end of auto-generated comment: release notes by openai -->