### PR TITLE
Remove default timeout in aperture-go

### DIFF
--- a/sdks/aperture-go/sdk/client.go
+++ b/sdks/aperture-go/sdk/client.go
@@ -81,13 +81,6 @@ func NewClient(ctx context.Context, opts Options) (Client, error) {
 
 	fcClient := flowcontrol.NewFlowControlServiceClient(opts.ApertureAgentGRPCClientConn)
 
-	var timeout time.Duration
-	if opts.CheckTimeout == 0 {
-		timeout = defaultRPCTimeout
-	} else {
-		timeout = opts.CheckTimeout
-	}
-
 	var logger logr.Logger
 	if opts.Logger != nil {
 		logger = *opts.Logger
@@ -98,7 +91,7 @@ func NewClient(ctx context.Context, opts Options) (Client, error) {
 	c := &apertureClient{
 		flowControlClient: fcClient,
 		tracer:            tracer,
-		timeout:           timeout,
+		timeout:           opts.CheckTimeout,
 		exporter:          exporter,
 		log:               logger,
 	}

--- a/sdks/aperture-go/sdk/const.go
+++ b/sdks/aperture-go/sdk/const.go
@@ -1,17 +1,9 @@
 package aperture
 
-import (
-	"time"
-)
-
 const (
 	// Library name and version can be used by the user to create a resource that connects to telemetry exporter.
 	libraryName    = "aperture-go"
 	libraryVersion = "v0.1.0"
-
-	// Config defaults.
-	defaultRPCTimeout           = 200 * time.Millisecond
-	defaultGRPCReconnectionTime = 10 * time.Second
 
 	// Label keys.
 	// Label to hold source of flow.


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Removed default timeout value and unused constants in aperture-go SDK
- Timeout value now taken from `Options` struct

> 🎉 A timeout once set in stone, 🪨
> Now flexible, it has grown. 🌱
> Constants gone, no longer bound, 🗑️
> In `Options`, the value is found. 🔍
<!-- end of auto-generated comment: release notes by openai -->