### PR TITLE
Playground delete prometheus pvc on tilt down

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -135,7 +135,7 @@ DEP_TREE = {
                 "controller-prometheus-server": "9090:9090",
                 "controller-etcd": "2379:2379",
             },
-            "pvc_selectors": ["app.kubernetes.io/name=etcd"],
+            "pvc_selectors": ["app.kubernetes.io/name=etcd","app=prometheus"],
             "kinds": [
                 dict(kind="Controller", image_object={'json_path': '{.spec.image}', 'repo_field': 'repository', 'tag_field': 'tag'}, pod_readiness='wait'),
             ],


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added Prometheus selector to PVC selectors for Kubernetes controller

> 🎉 A new dawn rises, with metrics in sight,
> Prometheus joins the fray, a powerful knight.
> Our Kubernetes controller now gains more might,
> With PVC selectors updated, we take flight! 🚀
<!-- end of auto-generated comment: release notes by openai -->