### PR TITLE
Added required pre-requisites to install Python in CI

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -941,6 +941,10 @@ jobs:
       COMPONENT: <<parameters.component>>
     steps:
       - checkout
+      - run:
+          name: "Install Python pre-requisites"
+          command: |
+            sudo apt-get update && sudo apt install libedit-dev zlib1g zlib1g-dev libssl-dev libbz2-dev libsqlite3-dev
       - asdf_install: # We need to install python before gcloud
           cache_name: aperture-{{ .Environment.COMPONENT }}-packages
           tools: |-


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Updated CI pipeline to install Python pre-requisites based on the `tools` parameter
- Modified string values in `cmd/aperturectl/main.go` for testing purposes

> 🎉 A pipeline tweak, a test name change,
> 🚀 Our code's journey, an ever-wider range.
> 🛠️ With tools in place, and tests refined,
> 🌟 This PR shines, as progress we find.
<!-- end of auto-generated comment: release notes by openai -->