### PR TITLE
Update source, destination services label

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -1103,7 +1103,7 @@ message AdaptiveLoadScheduler {
     InPort signal = 1;
     // Setpoint input to the controller.
     InPort setpoint = 2;
-    // Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
+    // Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.
     InPort overload_confirmation = 3;
   }
 

--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -1103,7 +1103,7 @@ message AdaptiveLoadScheduler {
     InPort signal = 1;
     // Setpoint input to the controller.
     InPort setpoint = 2;
-    // Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.
+    // Overload confirmation port provides additional criteria to determine overload state which results in flow throttling at the service.
     InPort overload_confirmation = 3;
   }
 

--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -1099,11 +1099,11 @@ message LoadActuator {
 message AdaptiveLoadScheduler {
   // Input ports for the _Adaptive Load Scheduler_ component.
   message Ins {
-    // The input signal to the controller.
+    // Input signal to the controller.
     InPort signal = 1;
-    // The setpoint input to the controller.
+    // Setpoint input to the controller.
     InPort setpoint = 2;
-    // The overload_confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
+    // Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
     InPort overload_confirmation = 3;
   }
 

--- a/api/aperture/policy/language/v1/label_matcher.proto
+++ b/api/aperture/policy/language/v1/label_matcher.proto
@@ -53,7 +53,9 @@ message K8sLabelMatcherRequirement {
 // all:
 //   of:
 //     - label_exists: foo
-//     - label_equals: { label = app, value = frobnicator }
+//     - label_equals:
+//          label: app
+//          value: frobnicator
 // ```
 message MatchExpression {
   // List of MatchExpressions that is used for all or any matching
@@ -76,7 +78,7 @@ message MatchExpression {
     List any = 3;
 
     // The expression is true when label with given name exists.
-    string label_exists = 4; // @gotags: validate:"required"
+    string label_exists = 4;
 
     // The expression is true when label value equals given value.
     EqualsMatchExpression label_equals = 5;

--- a/api/aperture/policy/language/v1/label_matcher.proto
+++ b/api/aperture/policy/language/v1/label_matcher.proto
@@ -54,8 +54,8 @@ message K8sLabelMatcherRequirement {
 //   of:
 //     - label_exists: foo
 //     - label_equals:
-//          label: app
-//          value: frobnicator
+//         label: app
+//         value: frobnicator
 // ```
 message MatchExpression {
   // List of MatchExpressions that is used for all or any matching

--- a/api/buf.lock
+++ b/api/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: 0ebaabe696e045e2b43c45e9a206c8a8
-    digest: shake256:270c97e41515cc6c072259ade1d989248527c583309de49e5a1b9661d7addb932adeaf1e5463044934e77bf9e64992eb089ed97752ca1a9810d51055cea5b196
+    commit: f5049f07f04843848fcaa4be1c8d1847
+    digest: shake256:0bd201e2c932bbfaae036a1ab0b99d4f7c40af10ef8e9374eecd3b2c5019f261b753dd8a8c69f9e34043a2f5923a529104ddcd987fcee433c0d7a182314f9acc
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
@@ -29,8 +29,8 @@ deps:
   - remote: buf.build
     owner: opencensus
     repository: opencensus
-    commit: bc2645b085534e4f8ebae3ef20088165
-    digest: shake256:a267651fc56795fed4cc8b02976332c60eae30e3adfca1a1786ef07ed723df166c3118d59b12f3e71be07a54f9e2201f935849e544789a3899626b9662e69310
+    commit: 7e475551350545bda1ccb1e258c7b125
+    digest: shake256:22499ad9824a29151f38e3ea026166bd2258f1f1b40d11246cb80718bff5d4a7fecd47ef857f5cd98609d7847c93329f603a4e43348abd7ac1ead22a6a964b05
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -4443,7 +4443,7 @@ type AdaptiveLoadScheduler_Ins struct {
 	Signal *InPort `protobuf:"bytes,1,opt,name=signal,proto3" json:"signal,omitempty"`
 	// Setpoint input to the controller.
 	Setpoint *InPort `protobuf:"bytes,2,opt,name=setpoint,proto3" json:"setpoint,omitempty"`
-	// Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
+	// Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.
 	OverloadConfirmation *InPort `protobuf:"bytes,3,opt,name=overload_confirmation,json=overloadConfirmation,proto3" json:"overload_confirmation,omitempty"`
 }
 

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -4439,11 +4439,11 @@ type AdaptiveLoadScheduler_Ins struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The input signal to the controller.
+	// Input signal to the controller.
 	Signal *InPort `protobuf:"bytes,1,opt,name=signal,proto3" json:"signal,omitempty"`
-	// The setpoint input to the controller.
+	// Setpoint input to the controller.
 	Setpoint *InPort `protobuf:"bytes,2,opt,name=setpoint,proto3" json:"setpoint,omitempty"`
-	// The overload_confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
+	// Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
 	OverloadConfirmation *InPort `protobuf:"bytes,3,opt,name=overload_confirmation,json=overloadConfirmation,proto3" json:"overload_confirmation,omitempty"`
 }
 

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -4443,7 +4443,7 @@ type AdaptiveLoadScheduler_Ins struct {
 	Signal *InPort `protobuf:"bytes,1,opt,name=signal,proto3" json:"signal,omitempty"`
 	// Setpoint input to the controller.
 	Setpoint *InPort `protobuf:"bytes,2,opt,name=setpoint,proto3" json:"setpoint,omitempty"`
-	// Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.
+	// Overload confirmation port provides additional criteria to determine overload state which results in flow throttling at the service.
 	OverloadConfirmation *InPort `protobuf:"bytes,3,opt,name=overload_confirmation,json=overloadConfirmation,proto3" json:"overload_confirmation,omitempty"`
 }
 

--- a/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
@@ -183,8 +183,8 @@ func (x *K8SLabelMatcherRequirement) GetValues() []string {
 //	of:
 //	  - label_exists: foo
 //	  - label_equals:
-//	       label: app
-//	       value: frobnicator
+//	      label: app
+//	      value: frobnicator
 //
 // ```
 type MatchExpression struct {

--- a/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
@@ -182,7 +182,9 @@ func (x *K8SLabelMatcherRequirement) GetValues() []string {
 //
 //	of:
 //	  - label_exists: foo
-//	  - label_equals: { label = app, value = frobnicator }
+//	  - label_equals:
+//	       label: app
+//	       value: frobnicator
 //
 // ```
 type MatchExpression struct {
@@ -305,7 +307,7 @@ type MatchExpression_Any struct {
 
 type MatchExpression_LabelExists struct {
 	// The expression is true when label with given name exists.
-	LabelExists string `protobuf:"bytes,4,opt,name=label_exists,json=labelExists,proto3,oneof" validate:"required"` // @gotags: validate:"required"
+	LabelExists string `protobuf:"bytes,4,opt,name=label_exists,json=labelExists,proto3,oneof"`
 }
 
 type MatchExpression_LabelEquals struct {

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -209,7 +209,7 @@
       "properties": {
         "overload_confirmation": {
           "$ref": "#/definitions/InPort",
-          "description": "Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.",
+          "description": "Overload confirmation port provides additional criteria to determine overload state which results in flow throttling at the service.",
           "x-order": 0
         },
         "setpoint": {

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -2823,7 +2823,7 @@
       "additionalProperties": false
     },
     "MatchExpression": {
-      "description": "MatchExpression has multiple variants, exactly one should be set.\n\nExample:\n```yaml\nall:\n  of:\n    - label_exists: foo\n    - label_equals: { label = app, value = frobnicator }\n```",
+      "description": "MatchExpression has multiple variants, exactly one should be set.\n\nExample:\n```yaml\nall:\n  of:\n    - label_exists: foo\n    - label_equals:\n         label: app\n         value: frobnicator\n```",
       "properties": {
         "all": {
           "$ref": "#/definitions/MatchExpressionList",
@@ -2841,9 +2841,8 @@
           "x-order": 2
         },
         "label_exists": {
-          "description": "The expression is true when label with given name exists.\n\n",
+          "description": "The expression is true when label with given name exists.",
           "type": "string",
-          "x-go-tag-validate": "required",
           "x-order": 3
         },
         "label_matches": {
@@ -2857,7 +2856,6 @@
           "x-order": 5
         }
       },
-      "required": ["label_exists"],
       "title": "Defines a `[map<string, string> \u2192\u00a0bool]` expression to be evaluated on labels",
       "type": "object",
       "additionalProperties": false

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -209,7 +209,7 @@
       "properties": {
         "overload_confirmation": {
           "$ref": "#/definitions/InPort",
-          "description": "Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.",
+          "description": "Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.",
           "x-order": 0
         },
         "setpoint": {
@@ -2823,7 +2823,7 @@
       "additionalProperties": false
     },
     "MatchExpression": {
-      "description": "MatchExpression has multiple variants, exactly one should be set.\n\nExample:\n```yaml\nall:\n  of:\n    - label_exists: foo\n    - label_equals:\n         label: app\n         value: frobnicator\n```",
+      "description": "MatchExpression has multiple variants, exactly one should be set.\n\nExample:\n```yaml\nall:\n  of:\n    - label_exists: foo\n    - label_equals:\n        label: app\n        value: frobnicator\n```",
       "properties": {
         "all": {
           "$ref": "#/definitions/MatchExpressionList",

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -209,17 +209,17 @@
       "properties": {
         "overload_confirmation": {
           "$ref": "#/definitions/InPort",
-          "description": "The overload_confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.",
+          "description": "Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.",
           "x-order": 0
         },
         "setpoint": {
           "$ref": "#/definitions/InPort",
-          "description": "The setpoint input to the controller.",
+          "description": "Setpoint input to the controller.",
           "x-order": 1
         },
         "signal": {
           "$ref": "#/definitions/InPort",
-          "description": "The input signal to the controller.",
+          "description": "Input signal to the controller.",
           "x-order": 2
         }
       },

--- a/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
@@ -716,13 +716,13 @@ definitions:
       all:
         of:
           - label_exists: foo
-          - label_equals: { label = app, value = frobnicator }
+          - label_equals:
+               label: app
+               value: frobnicator
       ```
     type: object
     title: Defines a `[map<string, string> → bool]` expression to be evaluated on
       labels
-    required:
-    - label_exists
     properties:
       all:
         description: The expression is true when all sub expressions are true.
@@ -734,11 +734,8 @@ definitions:
         description: The expression is true when label value equals given value.
         $ref: '#/definitions/EqualsMatchExpression'
       label_exists:
-        description: |+
-          The expression is true when label with given name exists.
-
+        description: The expression is true when label with given name exists.
         type: string
-        x-go-tag-validate: required
       label_matches:
         description: The expression is true when label matches given regular expression.
         $ref: '#/definitions/MatchesMatchExpression'

--- a/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
@@ -717,8 +717,8 @@ definitions:
         of:
           - label_exists: foo
           - label_equals:
-               label: app
-               value: frobnicator
+              label: app
+              value: frobnicator
       ```
     type: object
     title: Defines a `[map<string, string> → bool]` expression to be evaluated on

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -400,7 +400,7 @@ definitions:
     properties:
       overload_confirmation:
         description: Overload confirmation port provides additional criteria to determine
-          overload state which results in Flow throttling at the service.
+          overload state which results in flow throttling at the service.
         $ref: '#/definitions/InPort'
       setpoint:
         description: Setpoint input to the controller.

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -399,14 +399,14 @@ definitions:
     type: object
     properties:
       overload_confirmation:
-        description: The overload_confirmation port provides additional criteria to
-          determine overload state which results in _Flow_ throttling at the service.
+        description: Overload confirmation port provides additional criteria to determine
+          overload state which results in _Flow_ throttling at the service.
         $ref: '#/definitions/InPort'
       setpoint:
-        description: The setpoint input to the controller.
+        description: Setpoint input to the controller.
         $ref: '#/definitions/InPort'
       signal:
-        description: The input signal to the controller.
+        description: Input signal to the controller.
         $ref: '#/definitions/InPort'
   AdaptiveLoadSchedulerOuts:
     description: Output ports for the _Adaptive Load Scheduler_ component.

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2959,13 +2959,13 @@ definitions:
       all:
         of:
           - label_exists: foo
-          - label_equals: { label = app, value = frobnicator }
+          - label_equals:
+               label: app
+               value: frobnicator
       ```
     type: object
     title: Defines a `[map<string, string> → bool]` expression to be evaluated on
       labels
-    required:
-    - label_exists
     properties:
       all:
         description: The expression is true when all sub expressions are true.
@@ -2977,11 +2977,8 @@ definitions:
         description: The expression is true when label value equals given value.
         $ref: '#/definitions/EqualsMatchExpression'
       label_exists:
-        description: |+
-          The expression is true when label with given name exists.
-
+        description: The expression is true when label with given name exists.
         type: string
-        x-go-tag-validate: required
       label_matches:
         description: The expression is true when label matches given regular expression.
         $ref: '#/definitions/MatchesMatchExpression'

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -400,7 +400,7 @@ definitions:
     properties:
       overload_confirmation:
         description: Overload confirmation port provides additional criteria to determine
-          overload state which results in _Flow_ throttling at the service.
+          overload state which results in Flow throttling at the service.
         $ref: '#/definitions/InPort'
       setpoint:
         description: Setpoint input to the controller.
@@ -2960,8 +2960,8 @@ definitions:
         of:
           - label_exists: foo
           - label_equals:
-               label: app
-               value: frobnicator
+              label: app
+              value: frobnicator
       ```
     type: object
     title: Defines a `[map<string, string> → bool]` expression to be evaluated on

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -160,7 +160,7 @@ definitions:
         properties:
             overload_confirmation:
                 $ref: '#/definitions/InPort'
-                description: Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
+                description: Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.
             setpoint:
                 $ref: '#/definitions/InPort'
                 description: Setpoint input to the controller.
@@ -3143,8 +3143,8 @@ definitions:
               of:
                 - label_exists: foo
                 - label_equals:
-                     label: app
-                     value: frobnicator
+                    label: app
+                    value: frobnicator
             ```
         properties:
             all:

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -160,13 +160,13 @@ definitions:
         properties:
             overload_confirmation:
                 $ref: '#/definitions/InPort'
-                description: The overload_confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
+                description: Overload confirmation port provides additional criteria to determine overload state which results in _Flow_ throttling at the service.
             setpoint:
                 $ref: '#/definitions/InPort'
-                description: The setpoint input to the controller.
+                description: Setpoint input to the controller.
             signal:
                 $ref: '#/definitions/InPort'
-                description: The input signal to the controller.
+                description: Input signal to the controller.
         type: object
     AdaptiveLoadSchedulerOuts:
         description: Output ports for the _Adaptive Load Scheduler_ component.

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -160,7 +160,7 @@ definitions:
         properties:
             overload_confirmation:
                 $ref: '#/definitions/InPort'
-                description: Overload confirmation port provides additional criteria to determine overload state which results in Flow throttling at the service.
+                description: Overload confirmation port provides additional criteria to determine overload state which results in flow throttling at the service.
             setpoint:
                 $ref: '#/definitions/InPort'
                 description: Setpoint input to the controller.

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -3142,7 +3142,9 @@ definitions:
             all:
               of:
                 - label_exists: foo
-                - label_equals: { label = app, value = frobnicator }
+                - label_equals:
+                     label: app
+                     value: frobnicator
             ```
         properties:
             all:
@@ -3155,19 +3157,14 @@ definitions:
                 $ref: '#/definitions/EqualsMatchExpression'
                 description: The expression is true when label value equals given value.
             label_exists:
-                description: |+
-                    The expression is true when label with given name exists.
-
+                description: The expression is true when label with given name exists.
                 type: string
-                x-go-tag-validate: required
             label_matches:
                 $ref: '#/definitions/MatchesMatchExpression'
                 description: The expression is true when label matches given regular expression.
             not:
                 $ref: '#/definitions/MatchExpression'
                 description: The expression negates the result of sub expression.
-        required:
-            - label_exists
         title: Defines a `[map<string, string> → bool]` expression to be evaluated on labels
         type: object
     MatchExpressionList:

--- a/docs/content/reference/policies/spec.md
+++ b/docs/content/reference/policies/spec.md
@@ -474,8 +474,8 @@ Input ports for the _Adaptive Load Scheduler_ component.
 
 <!-- vale on -->
 
-The overload*confirmation port provides additional criteria to determine
-overload state which results in \_Flow* throttling at the service.
+Overload confirmation port provides additional criteria to determine overload
+state which results in _Flow_ throttling at the service.
 
 </dd>
 <dt>setpoint</dt>
@@ -487,7 +487,7 @@ overload state which results in \_Flow* throttling at the service.
 
 <!-- vale on -->
 
-The setpoint input to the controller.
+Setpoint input to the controller.
 
 </dd>
 <dt>signal</dt>
@@ -499,7 +499,7 @@ The setpoint input to the controller.
 
 <!-- vale on -->
 
-The input signal to the controller.
+Input signal to the controller.
 
 </dd>
 </dl>

--- a/docs/content/reference/policies/spec.md
+++ b/docs/content/reference/policies/spec.md
@@ -475,7 +475,7 @@ Input ports for the _Adaptive Load Scheduler_ component.
 <!-- vale on -->
 
 Overload confirmation port provides additional criteria to determine overload
-state which results in Flow throttling at the service.
+state which results in flow throttling at the service.
 
 </dd>
 <dt>setpoint</dt>

--- a/docs/content/reference/policies/spec.md
+++ b/docs/content/reference/policies/spec.md
@@ -6271,7 +6271,9 @@ Example:
 all:
   of:
     - label_exists: foo
-    - label_equals: { label = app, value = frobnicator }
+    - label_equals:
+        label: app
+        value: frobnicator
 ```
 
 <dl>
@@ -6316,7 +6318,7 @@ The expression is true when label value equals given value.
 
 <!-- vale off -->
 
-(string, **required**)
+(string)
 
 <!-- vale on -->
 

--- a/docs/content/reference/policies/spec.md
+++ b/docs/content/reference/policies/spec.md
@@ -475,7 +475,7 @@ Input ports for the _Adaptive Load Scheduler_ component.
 <!-- vale on -->
 
 Overload confirmation port provides additional criteria to determine overload
-state which results in _Flow_ throttling at the service.
+state which results in Flow throttling at the service.
 
 </dd>
 <dt>setpoint</dt>

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -221,16 +221,16 @@ definitions:
     type: object
     properties:
       overload_confirmation:
-        description: The overload_confirmation port provides additional criteria to
-          determine overload state which results in _Flow_ throttling at the service.
+        description: Overload confirmation port provides additional criteria to determine
+          overload state which results in _Flow_ throttling at the service.
         x-order: 0
         $ref: '#/definitions/InPort'
       setpoint:
-        description: The setpoint input to the controller.
+        description: Setpoint input to the controller.
         x-order: 1
         $ref: '#/definitions/InPort'
       signal:
-        description: The input signal to the controller.
+        description: Input signal to the controller.
         x-order: 2
         $ref: '#/definitions/InPort'
   AdaptiveLoadSchedulerOuts:

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -222,7 +222,7 @@ definitions:
     properties:
       overload_confirmation:
         description: Overload confirmation port provides additional criteria to determine
-          overload state which results in _Flow_ throttling at the service.
+          overload state which results in Flow throttling at the service.
         x-order: 0
         $ref: '#/definitions/InPort'
       setpoint:
@@ -3061,8 +3061,8 @@ definitions:
         of:
           - label_exists: foo
           - label_equals:
-               label: app
-               value: frobnicator
+              label: app
+              value: frobnicator
       ```
     type: object
     title: Defines a `[map<string, string> → bool]` expression to be evaluated on

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -222,7 +222,7 @@ definitions:
     properties:
       overload_confirmation:
         description: Overload confirmation port provides additional criteria to determine
-          overload state which results in Flow throttling at the service.
+          overload state which results in flow throttling at the service.
         x-order: 0
         $ref: '#/definitions/InPort'
       setpoint:

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -3060,13 +3060,13 @@ definitions:
       all:
         of:
           - label_exists: foo
-          - label_equals: { label = app, value = frobnicator }
+          - label_equals:
+               label: app
+               value: frobnicator
       ```
     type: object
     title: Defines a `[map<string, string> → bool]` expression to be evaluated on
       labels
-    required:
-    - label_exists
     properties:
       all:
         description: The expression is true when all sub expressions are true.
@@ -3081,11 +3081,8 @@ definitions:
         x-order: 2
         $ref: '#/definitions/EqualsMatchExpression'
       label_exists:
-        description: |+
-          The expression is true when label with given name exists.
-
+        description: The expression is true when label with given name exists.
         type: string
-        x-go-tag-validate: required
         x-order: 3
       label_matches:
         description: The expression is true when label matches given regular expression.

--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -40,10 +40,10 @@ const (
 	FlowDurationLabel = "flow_duration_ms"
 	// ApertureProcessingDurationLabel describes Aperture's processing duration in milliseconds.
 	ApertureProcessingDurationLabel = "aperture_processing_duration_ms"
-	// ApertureSourceServiceLabel describes the source service of the flow.
-	ApertureSourceServiceLabel = "aperture.source_service"
-	// ApertureDestinationServiceLabel describes the destination service of the flow.
-	ApertureDestinationServiceLabel = "aperture.destination_service"
+	// ApertureSourceServiceLabel describes the source service FQDNs of the flow.
+	ApertureSourceServiceLabel = "aperture.source_fqdns"
+	// ApertureDestinationServiceLabel describes the destination service FQDNs of the flow.
+	ApertureDestinationServiceLabel = "aperture.destination_fqdns"
 
 	/* The following are derived labels that are applied based on contents of check response. */
 

--- a/playground/scenarios/demo-app-fan-in/dashboards/main.jsonnet
+++ b/playground/scenarios/demo-app-fan-in/dashboards/main.jsonnet
@@ -1,0 +1,3 @@
+local apertureDashboard = import '../../../resources/grafana-dashboard/main.libsonnet';
+
+apertureDashboard(std.parseJson(std.extVar('APERTURE_DASHBOARD'))).dashboards

--- a/playground/scenarios/demo-app-fan-in/load_generator/test.js
+++ b/playground/scenarios/demo-app-fan-in/load_generator/test.js
@@ -1,0 +1,102 @@
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { check, sleep } from "k6";
+import { vu } from "k6/execution";
+import http from "k6/http";
+
+export let vuStages = [
+    { duration: "10s", target: 5 },
+    { duration: "2m", target: 5 },
+    { duration: "1m", target: 50 },
+    { duration: "2m", target: 50 },
+    { duration: "10s", target: 5 },
+    { duration: "2m", target: 5 },
+];
+
+export let options = {
+    discardResponseBodies: true,
+    scenarios: {
+        guests: {
+            executor: "ramping-vus",
+            stages: vuStages,
+            env: { USER_TYPE: "guest" },
+        },
+        subscribers: {
+            executor: "ramping-vus",
+            stages: vuStages,
+            env: { USER_TYPE: "subscriber" },
+        },
+        crawlers: {
+            executor: "ramping-vus",
+            stages: vuStages,
+            env: { USER_TYPE: "crawlers" },
+        },
+    },
+};
+
+export default function () {
+    let userType = __ENV.USER_TYPE;
+    let userId = vu.idInTest;
+
+    const headers = {
+        "Content-Type": "application/json",
+        Cookie:
+            "session=eyJ1c2VyIjoia2Vub2JpIn0.YbsY4Q.kTaKRTyOIfVlIbNB48d9YH6Q0wo",
+        "User-Type": userType,
+        "User-Id": userId,
+    };
+
+    const requests = {
+        'svc1': {
+            method: 'POST',
+            url: 'http://service1-demo-app.demoapp.svc.cluster.local/request',
+            body: {
+                request: [
+                    [
+                        {
+                            destination: "service1-demo-app.demoapp.svc.cluster.local/request",
+                        },
+                        {
+                            destination: "service3-demo-app.demoapp.svc.cluster.local/request",
+                        },
+                    ],
+                ],
+            },
+            params: {
+                headers: headers,
+            }
+        },
+        'svc2': {
+            method: 'POST',
+            url: 'http://service2-demo-app.demoapp.svc.cluster.local/request',
+            body: {
+                request: [
+                    [
+                        {
+                            destination: "service2-demo-app.demoapp.svc.cluster.local/request",
+                        },
+                        {
+                            destination: "service3-demo-app.demoapp.svc.cluster.local/request",
+                        },
+                    ],
+                ],
+            },
+            params: {
+                headers: headers,
+            }
+        },
+    };
+
+    const responses = http.batch(requests);
+
+    const svc1ret = check(responses[0], {
+        "http status was 200": responses[0].status === 200,
+    });
+    const svc2ret = check(responses[1], {
+        "http status was 200": responses[1].status === 200,
+    });
+
+    if (!svc1ret && !svc2ret) {
+        // sleep for 10ms to 25ms
+        sleep(randomIntBetween(0.01, 0.025));
+    }
+}

--- a/playground/scenarios/demo-app-fan-in/load_generator/test.js
+++ b/playground/scenarios/demo-app-fan-in/load_generator/test.js
@@ -15,20 +15,10 @@ export let vuStages = [
 export let options = {
     discardResponseBodies: true,
     scenarios: {
-        guests: {
+        user: {
             executor: "ramping-vus",
             stages: vuStages,
-            env: { USER_TYPE: "guest" },
-        },
-        subscribers: {
-            executor: "ramping-vus",
-            stages: vuStages,
-            env: { USER_TYPE: "subscriber" },
-        },
-        crawlers: {
-            executor: "ramping-vus",
-            stages: vuStages,
-            env: { USER_TYPE: "crawlers" },
+            env: { USER_TYPE: "user" },
         },
     },
 };
@@ -38,11 +28,10 @@ export default function () {
     let userId = vu.idInTest;
 
     const headers = {
-        "Content-Type": "application/json",
-        Cookie:
-            "session=eyJ1c2VyIjoia2Vub2JpIn0.YbsY4Q.kTaKRTyOIfVlIbNB48d9YH6Q0wo",
-        "User-Type": userType,
-        "User-Id": userId,
+        'Content-Type': 'application/json',
+        'Cookie': 'session=eyJ1c2VyIjoia2Vub2JpIn0.YbsY4Q.kTaKRTyOIfVlIbNB48d9YH6Q0wo',
+        'User-Type': userType,
+        'User-Id': userId,
     };
 
 
@@ -58,7 +47,7 @@ export default function () {
             ],
         ],
     };
-    let svc1 = {
+    const svc1 = {
         method: 'POST',
         url: 'http://service1-demo-app.demoapp.svc.cluster.local/request',
         body: JSON.stringify(svc1Body),
@@ -79,7 +68,7 @@ export default function () {
             ],
         ],
     };
-    let svc2 = {
+    const svc2 = {
         method: 'POST',
         url: 'http://service2-demo-app.demoapp.svc.cluster.local/request',
         body: JSON.stringify(svc2Body),
@@ -99,6 +88,6 @@ export default function () {
 
     if (!svc1ret && !svc2ret) {
         // sleep for 10ms to 25ms
-        sleep(randomIntBetween(0.01, 0.025));
+        sleep(randomIntBetween(10, 25) / 1000);
     };
 }

--- a/playground/scenarios/demo-app-fan-in/load_generator/test.js
+++ b/playground/scenarios/demo-app-fan-in/load_generator/test.js
@@ -45,48 +45,50 @@ export default function () {
         "User-Id": userId,
     };
 
-    const requests = {
-        'svc1': {
-            method: 'POST',
-            url: 'http://service1-demo-app.demoapp.svc.cluster.local/request',
-            body: {
-                request: [
-                    [
-                        {
-                            destination: "service1-demo-app.demoapp.svc.cluster.local/request",
-                        },
-                        {
-                            destination: "service3-demo-app.demoapp.svc.cluster.local/request",
-                        },
-                    ],
-                ],
-            },
-            params: {
-                headers: headers,
-            }
-        },
-        'svc2': {
-            method: 'POST',
-            url: 'http://service2-demo-app.demoapp.svc.cluster.local/request',
-            body: {
-                request: [
-                    [
-                        {
-                            destination: "service2-demo-app.demoapp.svc.cluster.local/request",
-                        },
-                        {
-                            destination: "service3-demo-app.demoapp.svc.cluster.local/request",
-                        },
-                    ],
-                ],
-            },
-            params: {
-                headers: headers,
-            }
+
+    const svc1Body = {
+        request: [
+            [
+                {
+                    destination: "service1-demo-app.demoapp.svc.cluster.local/request",
+                },
+                {
+                    destination: "service3-demo-app.demoapp.svc.cluster.local/request",
+                },
+            ],
+        ],
+    };
+    let svc1 = {
+        method: 'POST',
+        url: 'http://service1-demo-app.demoapp.svc.cluster.local/request',
+        body: JSON.stringify(svc1Body),
+        params: {
+            headers: headers,
         },
     };
 
-    const responses = http.batch(requests);
+    const svc2Body = {
+        request: [
+            [
+                {
+                    destination: "service2-demo-app.demoapp.svc.cluster.local/request",
+                },
+                {
+                    destination: "service3-demo-app.demoapp.svc.cluster.local/request",
+                },
+            ],
+        ],
+    };
+    let svc2 = {
+        method: 'POST',
+        url: 'http://service2-demo-app.demoapp.svc.cluster.local/request',
+        body: JSON.stringify(svc2Body),
+        params: {
+            headers: headers,
+        },
+    };
+
+    const responses = http.batch([svc1, svc2]);
 
     const svc1ret = check(responses[0], {
         "http status was 200": responses[0].status === 200,
@@ -98,5 +100,5 @@ export default function () {
     if (!svc1ret && !svc2ret) {
         // sleep for 10ms to 25ms
         sleep(randomIntBetween(0.01, 0.025));
-    }
+    };
 }

--- a/playground/scenarios/demo-app-fan-in/metadata.json
+++ b/playground/scenarios/demo-app-fan-in/metadata.json
@@ -1,0 +1,37 @@
+{
+  "renderer": "tanka",
+  "tkenv": "playground/tanka/apps/demo-app",
+  "needs": ["istio"],
+  "aperture_policies": [
+    {
+      "blueprint_name": "policies/service-protection/average-latency",
+      "policy_name": "weighted-service-protection",
+      "values_file": "policies/weighted-service-protection.yaml",
+      "dashboard_mixin_dir": "dashboards/"
+    }
+  ],
+  "images": [
+    {
+      "ref": "demo-app",
+      "context": "playground/resources/demo-app/",
+      "ssh": "default"
+    }
+  ],
+  "child_resources": [
+    {
+      "workload": "service1-demo-app",
+      "resource_deps": ["cluster-bootstrap", "istiod"],
+      "extra_objects": ["service1-demo-app:serviceaccount"]
+    },
+    {
+      "workload": "service2-demo-app",
+      "resource_deps": ["cluster-bootstrap", "istiod"],
+      "extra_objects": ["service2-demo-app:serviceaccount"]
+    },
+    {
+      "workload": "service3-demo-app",
+      "resource_deps": ["cluster-bootstrap", "istiod"],
+      "extra_objects": ["service3-demo-app:serviceaccount"]
+    }
+  ]
+}

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
@@ -130,7 +130,3 @@ spec:
           selectors:
           - control_point: ingress
             service: service3-demo-app.demoapp.svc.cluster.local
-          - control_point: egress
-            service: service1-demo-app.demoapp.svc.cluster.local
-          - control_point: egress
-            service: service2-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
@@ -45,11 +45,11 @@ spec:
                   all:
                     of:
                     - label_matches:
-                        label: source_fqdns
+                        label: aperture.source_fqdns
                         regex: service1-demo-app.demoapp.svc.cluster.local
-                    - label_equals:
-                        label: user_type
-                        value: guest
+                    - label_matches:
+                        label: aperture.destination_fqdns
+                        regex: service3-demo-app.demoapp.svc.cluster.local
               parameters:
                 priority: 200
             - label_matcher:
@@ -57,11 +57,11 @@ spec:
                   all:
                     of:
                     - label_matches:
-                        label: destination_fqdns
+                        label: aperture.source_fqdns
                         regex: service2-demo-app.demoapp.svc.cluster.local
-                    - label_equals:
-                        label: user_type
-                        value: guest
+                    - label_matches:
+                        label: aperture.destination_fqdns
+                        regex: service3-demo-app.demoapp.svc.cluster.local
               parameters:
                 priority: 50
           selectors:
@@ -115,16 +115,7 @@ spec:
     evaluation_interval: 1s
   resources:
     flow_control:
-      classifiers:
-      - rules:
-          user_type:
-            extractor:
-              from: request.http.headers.user-type
-        selectors:
-        - control_point: egress
-          service: service1-demo-app.demoapp.svc.cluster.local
-        - control_point: egress
-          service: service2-demo-app.demoapp.svc.cluster.local
+      classifiers: []
       flux_meters:
         weighted-service-protection:
           selectors:

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
@@ -1,0 +1,136 @@
+apiVersion: fluxninja.com/v1alpha1
+kind: Policy
+metadata:
+  labels:
+    fluxninja.com/validate: "true"
+  name: weighted-service-protection
+spec:
+  circuit:
+    components:
+    - flow_control:
+        adaptive_load_scheduler:
+          alerter_parameters:
+            alert_name: Load Throttling Event
+          default_config:
+            dry_run: false
+          dynamic_config_key: load_scheduler
+          gradient_parameters:
+            max_gradient: 1
+            min_gradient: 0.1
+            slope: -1
+          in_ports:
+            overload_confirmation:
+              constant_signal:
+                value: 1
+            setpoint:
+              signal_name: SETPOINT
+            signal:
+              signal_name: SIGNAL
+          load_multiplier_linear_increment: 0.0025
+          max_load_multiplier: 2
+          out_ports:
+            accepted_token_rate:
+              signal_name: ACCEPTED_CONCURRENCY
+            desired_load_multiplier:
+              signal_name: DESIRED_LOAD_MULTIPLIER
+            incoming_token_rate:
+              signal_name: INCOMING_CONCURRENCY
+            observed_load_multiplier:
+              signal_name: OBSERVED_LOAD_MULTIPLIER
+          scheduler_parameters:
+            auto_tokens: true
+            workloads:
+            - label_matcher:
+                expression:
+                  all:
+                    of:
+                    - label_matches:
+                        label: service_fqdns
+                        regex: service1-demo-app.demoapp.svc.cluster.local
+                    - label_equals:
+                        label: user_type
+                        value: guest
+              parameters:
+                priority: 200
+            - label_matcher:
+                expression:
+                  all:
+                    of:
+                    - label_matches:
+                        label: service_fqdns
+                        regex: service2-demo-app.demoapp.svc.cluster.local
+                    - label_equals:
+                        label: user_type
+                        value: guest
+              parameters:
+                priority: 50
+          selectors:
+          - control_point: egress
+            service: service1-demo-app.demoapp.svc.cluster.local
+          - control_point: egress
+            service: service2-demo-app.demoapp.svc.cluster.local
+    - query:
+        promql:
+          evaluation_interval: 1s
+          out_ports:
+            output:
+              signal_name: SIGNAL
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="weighted-service-protection"}[5s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="weighted-service-protection"}[5s]))
+    - arithmetic_combinator:
+        in_ports:
+          lhs:
+            signal_name: SIGNAL
+          rhs:
+            constant_signal:
+              value: 2
+        operator: mul
+        out_ports:
+          output:
+            signal_name: MAX_EMA
+    - arithmetic_combinator:
+        in_ports:
+          lhs:
+            signal_name: SIGNAL_EMA
+          rhs:
+            constant_signal:
+              value: 1.1
+        operator: mul
+        out_ports:
+          output:
+            signal_name: SETPOINT
+    - ema:
+        in_ports:
+          input:
+            signal_name: SIGNAL
+          max_envelope:
+            signal_name: MAX_EMA
+        out_ports:
+          output:
+            signal_name: SIGNAL_EMA
+        parameters:
+          correction_factor_on_max_envelope_violation: 0.95
+          ema_window: 1500s
+          warmup_window: 60s
+    evaluation_interval: 1s
+  resources:
+    flow_control:
+      classifiers:
+      - rules:
+          user_type:
+            extractor:
+              from: request.http.headers.user-type
+        selectors:
+        - control_point: egress
+          service: service1-demo-app.demoapp.svc.cluster.local
+        - control_point: egress
+          service: service2-demo-app.demoapp.svc.cluster.local
+      flux_meters:
+        weighted-service-protection:
+          selectors:
+          - control_point: ingress
+            service: service3-demo-app.demoapp.svc.cluster.local
+          - control_point: egress
+            service: service1-demo-app.demoapp.svc.cluster.local
+          - control_point: egress
+            service: service2-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
@@ -45,7 +45,7 @@ spec:
                   all:
                     of:
                     - label_matches:
-                        label: service_fqdns
+                        label: source_fqdns
                         regex: service1-demo-app.demoapp.svc.cluster.local
                     - label_equals:
                         label: user_type
@@ -57,7 +57,7 @@ spec:
                   all:
                     of:
                     - label_matches:
-                        label: service_fqdns
+                        label: destination_fqdns
                         regex: service2-demo-app.demoapp.svc.cluster.local
                     - label_equals:
                         label: user_type

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=../../../../blueprints/policies/service-protection/average-latency/gen/definitions.json
+# Generated values file for policies/service-protection/average-latency blueprint.
+common:
+  # Name of the policy.
+  # Type: string
+  # Required: True
+  policy_name: weighted-service-protection
+
+policy:
+  # Additional resources.
+  # Type: aperture.spec.v1.Resources
+  resources:
+    flow_control:
+      classifiers:
+        - selectors:
+            - service: service1-demo-app.demoapp.svc.cluster.local
+              control_point: egress
+            - service: service2-demo-app.demoapp.svc.cluster.local
+              control_point: egress
+          rules:
+            user_type:
+              extractor:
+                from: request.http.headers.user-type
+  service_protection_core:
+    adaptive_load_scheduler:
+      # The selectors determine the flows that are protected by this policy.
+      # Type: []aperture.spec.v1.Selector
+      # Required: True
+      selectors:
+        - control_point: egress
+          service: service1-demo-app.demoapp.svc.cluster.local
+        - control_point: egress
+          service: service2-demo-app.demoapp.svc.cluster.local
+      scheduler:
+        workloads:
+          - label_matcher:
+              expression:
+                all:
+                  of:
+                    - label_matches:
+                        label: service_fqdns
+                        regex: service1-demo-app.demoapp.svc.cluster.local
+                    - label_equals:
+                        label: user_type
+                        value: "guest"
+            parameters:
+              priority: 200
+          - label_matcher:
+              expression:
+                all:
+                  of:
+                    - label_matches:
+                        label: service_fqdns
+                        regex: service2-demo-app.demoapp.svc.cluster.local
+                    - label_equals:
+                        label: user_type
+                        value: "guest"
+            parameters:
+              priority: 50
+  latency_baseliner:
+    # Flux Meter defines the scope of latency measurements.
+    # Type: aperture.spec.v1.FluxMeter
+    # Required: True
+    flux_meter:
+      selectors:
+        - control_point: ingress
+          service: service3-demo-app.demoapp.svc.cluster.local
+        - control_point: egress
+          service: service1-demo-app.demoapp.svc.cluster.local
+        - control_point: egress
+          service: service2-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
@@ -65,7 +65,3 @@ policy:
       selectors:
         - control_point: ingress
           service: service3-demo-app.demoapp.svc.cluster.local
-        - control_point: egress
-          service: service1-demo-app.demoapp.svc.cluster.local
-        - control_point: egress
-          service: service2-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
@@ -7,20 +7,6 @@ common:
   policy_name: weighted-service-protection
 
 policy:
-  # Additional resources.
-  # Type: aperture.spec.v1.Resources
-  resources:
-    flow_control:
-      classifiers:
-        - selectors:
-            - service: service1-demo-app.demoapp.svc.cluster.local
-              control_point: egress
-            - service: service2-demo-app.demoapp.svc.cluster.local
-              control_point: egress
-          rules:
-            user_type:
-              extractor:
-                from: request.http.headers.user-type
   service_protection_core:
     adaptive_load_scheduler:
       # The selectors determine the flows that are protected by this policy.
@@ -38,11 +24,11 @@ policy:
                 all:
                   of:
                     - label_matches:
-                        label: source_fqdns
+                        label: aperture.source_fqdns
                         regex: service1-demo-app.demoapp.svc.cluster.local
-                    - label_equals:
-                        label: user_type
-                        value: "guest"
+                    - label_matches:
+                        label: aperture.destination_fqdns
+                        regex: service3-demo-app.demoapp.svc.cluster.local
             parameters:
               priority: 200
           - label_matcher:
@@ -50,11 +36,11 @@ policy:
                 all:
                   of:
                     - label_matches:
-                        label: destination_fqdns
+                        label: aperture.source_fqdns
                         regex: service2-demo-app.demoapp.svc.cluster.local
-                    - label_equals:
-                        label: user_type
-                        value: "guest"
+                    - label_matches:
+                        label: aperture.destination_fqdns
+                        regex: service3-demo-app.demoapp.svc.cluster.local
             parameters:
               priority: 50
   latency_baseliner:

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
@@ -38,7 +38,7 @@ policy:
                 all:
                   of:
                     - label_matches:
-                        label: service_fqdns
+                        label: source_fqdns
                         regex: service1-demo-app.demoapp.svc.cluster.local
                     - label_equals:
                         label: user_type
@@ -50,7 +50,7 @@ policy:
                 all:
                   of:
                     - label_matches:
-                        label: service_fqdns
+                        label: destination_fqdns
                         regex: service2-demo-app.demoapp.svc.cluster.local
                     - label_equals:
                         label: user_type


### PR DESCRIPTION
### Description of change
Update source, destination services label
- Rename source_service, destination_service -> source_fqdns, destination_fqdns

Add new scenario
- k6 -> svc1 -> svc3, k6 -> svc2 -> svc3
- add new policy to give higher priority to guest flow from svc1 than guest flow from svc2

Fix label_matcher
- Make `label_exists` not required
- Update example

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Added new scenario to playground
- Updated label_matcher functionality

Bug fix:
- Fixed label_exists requirement in label_matcher

Documentation:
- Updated reference documentation and examples

Refactor:
- Renamed variables for clarity
```

> 🎉 A new scenario takes the stage,
> Label matchers now engage.
> With fixes and updates, we pave the way,
> For better code, hip hip hooray! 🚀
<!-- end of auto-generated comment: release notes by openai -->