### PR TITLE
Java SDK: Make fail-open behavior configurable

### DIFF
--- a/docs/content/get-started/integrations/flow-control/sdk/java/auto-instrumentation.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/java/auto-instrumentation.md
@@ -40,17 +40,18 @@ system properties or environment variables:
 
 <!-- vale off -->
 
-| Property name                          | Environment variable name              | Default value | Description                                                                                         |
-| :------------------------------------- | :------------------------------------- | :------------ | :-------------------------------------------------------------------------------------------------- |
-| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                  |
-| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                            |
-| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                                |
-| aperture.control.point.name            | APERTURE_CONTROL_POINT_NAME            |               | (Required) Name of the control point this agent represents                                          |
-| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether gRPC connection to Aperture Agent should be over plaintext                                  |
-| aperture.javaagent.root.certificate    | APERTURE_JAVAAGENT_ROOT_CERTIFICATE    |               | Path to a file containing root certificate to be used <br /> (insecure connection must be disabled) |
-| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                   |
-| aperture.javaagent.ignored.paths       | APERTURE_JAVAAGENT_IGNORED_PATHS       |               | Comma-separated list of paths that should not start a flow                                          |
-| aperture.javaagent.ignored.paths.regex | APERTURE_JAVAAGENT_IGNORED_PATHS_REGEX |               | Whether the configured ignored paths should be read as regular expressions                          |
+| Property name                          | Environment variable name              | Default value | Description                                                                                                                                                                            |
+| :------------------------------------- | :------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                                                                                                     |
+| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                                                                                                               |
+| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                                                                                                                   |
+| aperture.control.point.name            | APERTURE_CONTROL_POINT_NAME            |               | (Required) Name of the control point this agent represents                                                                                                                             |
+| aperture.javaagent.enable.fail.open    | APERTURE_JAVAAGENT_ENABLE_FAIL_OPEN    | true          | Sets the fail-open behavior for the client when the Aperture Agent is unreachable. <br /> If set to true, all traffic will pass through; if set to false, all traffic will be blocked. |
+| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether gRPC connection to Aperture Agent should be over plaintext                                                                                                                     |
+| aperture.javaagent.root.certificate    | APERTURE_JAVAAGENT_ROOT_CERTIFICATE    |               | Path to a file containing root certificate to be used <br /> (insecure connection must be disabled)                                                                                    |
+| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                                                                                                      |
+| aperture.javaagent.ignored.paths       | APERTURE_JAVAAGENT_IGNORED_PATHS       |               | Comma-separated list of paths that should not start a flow                                                                                                                             |
+| aperture.javaagent.ignored.paths.regex | APERTURE_JAVAAGENT_IGNORED_PATHS_REGEX |               | Whether the configured ignored paths should be read as regular expressions                                                                                                             |
 
 <!-- vale on -->
 

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
@@ -13,6 +13,7 @@ public class ArmeriaClient {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_FAIL_OPEN = "true";
     public static final String DEFAULT_CONTROL_POINT_NAME = "awesome_feature";
     public static final String DEFAULT_INSECURE_GRPC = "true";
     public static final String DEFAULT_ROOT_CERT = "";
@@ -26,6 +27,12 @@ public class ArmeriaClient {
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }
+        String failOpenString = System.getenv("FN_ENABLE_FAIL_OPEN");
+        if (failOpenString == null) {
+            failOpenString = DEFAULT_FAIL_OPEN;
+        }
+        boolean failOpen = Boolean.parseBoolean(failOpenString);
+
         String controlPointName = System.getenv("FN_CONTROL_POINT_NAME");
         if (controlPointName == null) {
             controlPointName = DEFAULT_CONTROL_POINT_NAME;
@@ -58,7 +65,9 @@ public class ArmeriaClient {
 
         WebClient client =
                 Clients.builder("http://localhost:8080")
-                        .decorator(ApertureHTTPClient.newDecorator(apertureSDK, controlPointName))
+                        .decorator(
+                                ApertureHTTPClient.newDecorator(
+                                        apertureSDK, controlPointName, failOpen))
                         .build(WebClient.class);
 
         HttpResponse res = client.get("notsuper");

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
@@ -14,6 +14,7 @@ public class ArmeriaServer {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_FAIL_OPEN = "true";
     public static final String DEFAULT_CONTROL_POINT_NAME = "awesome_feature";
     public static final String DEFAULT_INSECURE_GRPC = "true";
     public static final String DEFAULT_ROOT_CERT = "";
@@ -58,6 +59,12 @@ public class ArmeriaServer {
         if (appPort == null) {
             appPort = DEFAULT_APP_PORT;
         }
+        String failOpenString = System.getenv("FN_ENABLE_FAIL_OPEN");
+        if (failOpenString == null) {
+            failOpenString = DEFAULT_FAIL_OPEN;
+        }
+        boolean failOpen = Boolean.parseBoolean(failOpenString);
+
         String controlPointName = System.getenv("FN_CONTROL_POINT_NAME");
         if (controlPointName == null) {
             controlPointName = DEFAULT_CONTROL_POINT_NAME;
@@ -95,7 +102,9 @@ public class ArmeriaServer {
 
         ApertureHTTPService decoratedService =
                 createHelloHTTPService()
-                        .decorate(ApertureHTTPService.newDecorator(apertureSDK, controlPointName));
+                        .decorate(
+                                ApertureHTTPService.newDecorator(
+                                        apertureSDK, controlPointName, failOpen));
         serverBuilder.service("/super", decoratedService);
 
         Server server = serverBuilder.build();

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
@@ -12,6 +12,7 @@ public class NettyServer {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_FAIL_OPEN = "true";
     public static final String DEFAULT_CONTROL_POINT_NAME = "awesome_feature";
     public static final String DEFAULT_INSECURE_GRPC = "true";
     public static final String DEFAULT_ROOT_CERT = "";
@@ -29,6 +30,12 @@ public class NettyServer {
         if (appPort == null) {
             appPort = DEFAULT_APP_PORT;
         }
+        String failOpenString = System.getenv("FN_ENABLE_FAIL_OPEN");
+        if (failOpenString == null) {
+            failOpenString = DEFAULT_FAIL_OPEN;
+        }
+        boolean failOpen = Boolean.parseBoolean(failOpenString);
+
         String controlPointName = System.getenv("FN_CONTROL_POINT_NAME");
         if (controlPointName == null) {
             controlPointName = DEFAULT_CONTROL_POINT_NAME;
@@ -58,6 +65,7 @@ public class NettyServer {
                             new ServerInitializer(
                                     agentHost,
                                     agentPort,
+                                    failOpen,
                                     controlPointName,
                                     insecureGrpc,
                                     rootCertFile))

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/ServerInitializer.java
@@ -14,6 +14,7 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
     ApertureSDK sdk;
     String agentHost;
     int agentPort;
+    boolean failOpen;
     String controlPointName;
     boolean insecureGrpc;
     String rootCertFile;
@@ -21,11 +22,13 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
     public ServerInitializer(
             String agentHost,
             String agentPort,
+            boolean failOpen,
             String controlPointName,
             boolean insecureGrpc,
             String rootCertFile) {
         this.agentHost = agentHost;
         this.agentPort = Integer.parseInt(agentPort);
+        this.failOpen = failOpen;
         this.controlPointName = controlPointName;
         this.insecureGrpc = insecureGrpc;
         this.rootCertFile = rootCertFile;
@@ -50,7 +53,7 @@ public class ServerInitializer extends ChannelInitializer<Channel> {
         pipeline.addLast(new HttpObjectAggregator(Integer.MAX_VALUE));
         // ApertureServerHandler must be added before the response-generating HelloWorldHandler,
         //    but after the codec handler.
-        pipeline.addLast(new ApertureServerHandler(sdk, controlPointName));
+        pipeline.addLast(new ApertureServerHandler(sdk, controlPointName, failOpen));
         pipeline.addLast(new HelloWorldHandler());
     }
 }

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
@@ -10,6 +10,7 @@ public class SpringBootApp {
     public static final String DEFAULT_APP_PORT = "8080";
     public static final String DEFAULT_AGENT_HOST = "localhost";
     public static final String DEFAULT_AGENT_PORT = "8089";
+    public static final String DEFAULT_FAIL_OPEN = "true";
     public static final String DEFAULT_CONTROL_POINT_NAME = "awesome_feature";
     public static final String DEFAULT_GRPC_TIMEOUT_MS = "1000";
     public static final String DEFAULT_INSECURE_GRPC = "true";
@@ -36,6 +37,11 @@ public class SpringBootApp {
             controlPointName = DEFAULT_CONTROL_POINT_NAME;
         }
         System.setProperty("FN_CONTROL_POINT_NAME", controlPointName);
+        String failOpen = System.getenv("FN_ENABLE_FAIL_OPEN");
+        if (failOpen == null) {
+            failOpen = DEFAULT_FAIL_OPEN;
+        }
+        System.setProperty("FN_ENABLE_FAIL_OPEN", failOpen);
         String grpcTimeoutMs = System.getenv("FN_GRPC_TIMEOUT_MS");
         if (grpcTimeoutMs == null) {
             grpcTimeoutMs = DEFAULT_GRPC_TIMEOUT_MS;

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
@@ -45,6 +45,8 @@ public class AppController {
         registrationBean.addInitParameter("agent_host", agentHost);
         String agentPort = env.getProperty("FN_AGENT_PORT");
         registrationBean.addInitParameter("agent_port", agentPort);
+        String failOpen = env.getProperty("FN_ENABLE_FAIL_OPEN");
+        registrationBean.addInitParameter("enable_fail_open", failOpen);
         String controlPointName = env.getProperty("FN_CONTROL_POINT_NAME");
         registrationBean.addInitParameter("control_point_name", controlPointName);
         String grpcTimeoutMs = env.getProperty("FN_GRPC_TIMEOUT_MS");
@@ -70,6 +72,8 @@ public class AppController {
         registrationBean.addInitParameter("agent_host", agentHost);
         String agentPort = env.getProperty("FN_AGENT_PORT");
         registrationBean.addInitParameter("agent_port", agentPort);
+        String failOpen = env.getProperty("FN_ENABLE_FAIL_OPEN");
+        registrationBean.addInitParameter("enable_fail_open", failOpen);
         String insecureGrpc = env.getProperty("FN_INSECURE_GRPC");
         registrationBean.addInitParameter("insecure_grpc", insecureGrpc);
         String rootCertificateFile = env.getProperty("FN_ROOT_CERTIFICATE_FILE");

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -1,9 +1,6 @@
 package com.fluxninja.example;
 
-import com.fluxninja.aperture.sdk.ApertureSDK;
-import com.fluxninja.aperture.sdk.ApertureSDKException;
-import com.fluxninja.aperture.sdk.Flow;
-import com.fluxninja.aperture.sdk.FlowStatus;
+import com.fluxninja.aperture.sdk.*;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -94,8 +91,9 @@ public class App {
         // Flow.
         Flow flow = this.apertureSDK.startFlow(this.featureName, labels);
 
+        FlowResult flowResult = flow.result();
         // See whether flow was accepted by Aperture Agent.
-        if (flow.accepted()) {
+        if (flowResult != FlowResult.Rejected) {
             // Simulate work being done
             try {
                 res.status(202);

--- a/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -1,9 +1,6 @@
 package com.fluxninja.example.filter;
 
-import com.fluxninja.aperture.sdk.ApertureSDK;
-import com.fluxninja.aperture.sdk.ApertureSDKException;
-import com.fluxninja.aperture.sdk.Flow;
-import com.fluxninja.aperture.sdk.FlowStatus;
+import com.fluxninja.aperture.sdk.*;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -32,8 +29,9 @@ public class ApertureFeatureFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
 
+        FlowResult flowResult = flow.result();
         // See whether flow was accepted by Aperture Agent.
-        if (flow.accepted()) {
+        if (flowResult != FlowResult.Rejected) {
             try {
                 chain.doFilter(request, response);
                 flow.end(FlowStatus.OK);

--- a/sdks/aperture-java/examples/tomcat-example/src/main/webapp/WEB-INF/web.xml
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/webapp/WEB-INF/web.xml
@@ -54,6 +54,10 @@
             <param-name>control_point_name</param-name>
             <param-value>awesome_feature</param-value>
         </init-param>
+        <init-param>
+            <param-name>enable_fail_open</param-name>
+            <param-value>true</param-value>
+        </init-param>
     </filter>
     <filter-mapping>
         <filter-name>ApertureFeatureFilter</filter-name>

--- a/sdks/aperture-java/javaagent/README.md
+++ b/sdks/aperture-java/javaagent/README.md
@@ -49,17 +49,18 @@ following command:
 Aperture Java Instrumentation Agent can be configured using a properties file,
 system properties or environment variables:
 
-| Property name                          | Environment variable name              | Default value | Description                                                                                         |
-| :------------------------------------- | :------------------------------------- | :------------ | :-------------------------------------------------------------------------------------------------- |
-| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                  |
-| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                            |
-| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                                |
-| aperture.control.point.name            | APERTURE_CONTROL_POINT_NAME            |               | (Required) Name of the control point this agent represents                                          |
-| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether gRPC connection to Aperture Agent should be over plaintext                                  |
-| aperture.javaagent.root.certificate    | APERTURE_JAVAAGENT_ROOT_CERTIFICATE    |               | Path to a file containing root certificate to be used <br /> (insecure connection must be disabled) |
-| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                   |
-| aperture.javaagent.ignored.paths       | APERTURE_JAVAAGENT_IGNORED_PATHS       |               | Comma-separated list of paths that should not start a flow                                          |
-| aperture.javaagent.ignored.paths.regex | APERTURE_JAVAAGENT_IGNORED_PATHS_REGEX |               | Whether the configured ignored paths should be read as regular expressions                          |
+| Property name                          | Environment variable name              | Default value | Description                                                                                                                                                                            |
+| :------------------------------------- | :------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| aperture.javaagent.config.file         | APERTURE_JAVAAGENT_CONFIG_FILE         |               | Path to a file containing configuration properties                                                                                                                                     |
+| aperture.agent.hostname                | APERTURE_AGENT_HOSTNAME                | localhost     | Hostname of Aperture Agent to connect to                                                                                                                                               |
+| aperture.agent.port                    | APERTURE_AGENT_PORT                    | 8089          | Port of Aperture Agent to connect to                                                                                                                                                   |
+| aperture.control.point.name            | APERTURE_CONTROL_POINT_NAME            |               | (Required) Name of the control point this agent represents                                                                                                                             |
+| aperture.javaagent.enable.fail.open    | APERTURE_JAVAAGENT_ENABLE_FAIL_OPEN    | true          | Sets the fail-open behavior for the client when the Aperture Agent is unreachable. <br /> If set to true, all traffic will pass through; if set to false, all traffic will be blocked. |
+| aperture.javaagent.insecure.grpc       | APERTURE_JAVAAGENT_INSECURE_GRPC       | true          | Whether gRPC connection to Aperture Agent should be over plaintext                                                                                                                     |
+| aperture.javaagent.root.certificate    | APERTURE_JAVAAGENT_ROOT_CERTIFICATE    |               | Path to a file containing root certificate to be used <br /> (insecure connection must be disabled)                                                                                    |
+| aperture.connection.timeout.millis     | APERTURE_CONNECTION_TIMEOUT_MILLIS     | 1000          | Aperture Agent connection timeout in milliseconds                                                                                                                                      |
+| aperture.javaagent.ignored.paths       | APERTURE_JAVAAGENT_IGNORED_PATHS       |               | Comma-separated list of paths that should not start a flow                                                                                                                             |
+| aperture.javaagent.ignored.paths.regex | APERTURE_JAVAAGENT_IGNORED_PATHS_REGEX |               | Whether the configured ignored paths should be read as regular expressions                                                                                                             |
 
 The priority order is `system.property` > `ENV_VARIABLE` > `properties file`.
 

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/ApertureSDKWrapper.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/ApertureSDKWrapper.java
@@ -1,0 +1,13 @@
+package com.fluxninja.aperture.instrumentation;
+
+import com.fluxninja.aperture.sdk.ApertureSDK;
+
+public class ApertureSDKWrapper {
+    public ApertureSDK apertureSDK;
+    public String controlPointName;
+
+    public ApertureSDKWrapper(ApertureSDK apertureSDK, String controlPointName) {
+        this.apertureSDK = apertureSDK;
+        this.controlPointName = controlPointName;
+    }
+}

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/ApertureSDKWrapper.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/ApertureSDKWrapper.java
@@ -5,9 +5,11 @@ import com.fluxninja.aperture.sdk.ApertureSDK;
 public class ApertureSDKWrapper {
     public ApertureSDK apertureSDK;
     public String controlPointName;
+    public boolean failOpen;
 
-    public ApertureSDKWrapper(ApertureSDK apertureSDK, String controlPointName) {
+    public ApertureSDKWrapper(ApertureSDK apertureSDK, String controlPointName, boolean failOpen) {
         this.apertureSDK = apertureSDK;
         this.controlPointName = controlPointName;
+        this.failOpen = failOpen;
     }
 }

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -15,6 +15,7 @@ public class Config {
 
     public static final String AGENT_HOST_PROPERTY = "aperture.agent.hostname";
     public static final String AGENT_PORT_PROPERTY = "aperture.agent.port";
+    public static final String FAIL_OPEN_PROPERTY = "aperture.javaagent.enable.fail.open";
     public static final String CONNECTION_TIMEOUT_MILLIS_PROPERTY =
             "aperture.connection.timeout.millis";
     public static final String CONTROL_POINT_NAME_PROPERTY = "aperture.control.point.name";
@@ -27,6 +28,7 @@ public class Config {
 
     private static final String AGENT_HOST_DEFAULT_VALUE = "localhost";
     private static final String AGENT_PORT_DEFAULT_VALUE = "8089";
+    private static final String FAIL_OPEN_PROPERTY_DEFAULT_VALUE = "true";
     private static final String CONNECTION_TIMEOUT_MILLIS_DEFAULT_VALUE = "1000";
     private static final String IGNORED_PATHS_DEFAULT_VALUE = "";
     private static final String IGNORED_PATHS_REGEX_DEFAULT_VALUE = "false";
@@ -38,6 +40,7 @@ public class Config {
                 {
                     add(AGENT_HOST_PROPERTY);
                     add(AGENT_PORT_PROPERTY);
+                    add(FAIL_OPEN_PROPERTY);
                     add(CONNECTION_TIMEOUT_MILLIS_PROPERTY);
                     add(CONTROL_POINT_NAME_PROPERTY);
                     add(IGNORED_PATHS_PROPERTY);
@@ -87,8 +90,13 @@ public class Config {
         Properties config = loadProperties();
         ApertureSDK sdk;
         String controlPointName;
+        boolean failOpen;
         try {
             controlPointName = config.getProperty(CONTROL_POINT_NAME_PROPERTY);
+            failOpen =
+                    Boolean.parseBoolean(
+                            config.getProperty(
+                                    FAIL_OPEN_PROPERTY, FAIL_OPEN_PROPERTY_DEFAULT_VALUE));
 
             ApertureSDKBuilder sdkBuilder =
                     builder.setHost(
@@ -135,7 +143,7 @@ public class Config {
             throw new IllegalArgumentException("Control Point name must be set");
         }
 
-        return new ApertureSDKWrapper(sdk, controlPointName);
+        return new ApertureSDKWrapper(sdk, controlPointName, failOpen);
     }
 
     private static String envNameFromPropertyName(String propertyName) {

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -82,15 +82,14 @@ public class Config {
         return System.getenv(envVariableName);
     }
 
-    public static ApertureSDK newSDKFromConfig() {
+    public static ApertureSDKWrapper newSDKWrapperFromConfig() {
         ApertureSDKBuilder builder = ApertureSDK.builder();
         Properties config = loadProperties();
         ApertureSDK sdk;
+        String controlPointName;
         try {
-            if (config.getProperty(CONTROL_POINT_NAME_PROPERTY) == null
-                    || config.getProperty(CONTROL_POINT_NAME_PROPERTY).trim().isEmpty()) {
-                throw new IllegalArgumentException("Control Point name must be set");
-            }
+            controlPointName = config.getProperty(CONTROL_POINT_NAME_PROPERTY);
+
             ApertureSDKBuilder sdkBuilder =
                     builder.setHost(
                                     config.getProperty(
@@ -112,8 +111,7 @@ public class Config {
                                     Boolean.parseBoolean(
                                             config.getProperty(
                                                     IGNORED_PATHS_REGEX_PROPERTY,
-                                                    IGNORED_PATHS_REGEX_DEFAULT_VALUE)))
-                            .setControlPointName(config.getProperty(CONTROL_POINT_NAME_PROPERTY));
+                                                    IGNORED_PATHS_REGEX_DEFAULT_VALUE)));
 
             boolean insecureGrpc =
                     Boolean.parseBoolean(
@@ -132,7 +130,12 @@ public class Config {
         } catch (Exception e) {
             throw new RuntimeException("failed to create Aperture SDK from config", e);
         }
-        return sdk;
+
+        if (controlPointName == null || controlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must be set");
+        }
+
+        return new ApertureSDKWrapper(sdk, controlPointName);
     }
 
     private static String envNameFromPropertyName(String propertyName) {

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaClientAdvice.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaClientAdvice.java
@@ -1,16 +1,17 @@
 package com.fluxninja.aperture.instrumentation.armeria;
 
 import com.fluxninja.aperture.armeria.ApertureHTTPClient;
+import com.fluxninja.aperture.instrumentation.ApertureSDKWrapper;
 import com.fluxninja.aperture.instrumentation.Config;
 import com.fluxninja.aperture.sdk.ApertureSDK;
 import com.linecorp.armeria.client.WebClientBuilder;
 import net.bytebuddy.asm.Advice;
 
 public class ArmeriaClientAdvice {
-    public static ApertureSDK apertureSDK = Config.newSDKFromConfig();
+    public static ApertureSDKWrapper wrapper = Config.newSDKWrapperFromConfig();
 
     @Advice.OnMethodEnter
     public static void onEnter(@Advice.This WebClientBuilder builder) {
-        builder.decorator(ApertureHTTPClient.newDecorator(apertureSDK));
+        builder.decorator(ApertureHTTPClient.newDecorator(wrapper.apertureSDK, wrapper.controlPointName));
     }
 }

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaClientAdvice.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaClientAdvice.java
@@ -3,7 +3,6 @@ package com.fluxninja.aperture.instrumentation.armeria;
 import com.fluxninja.aperture.armeria.ApertureHTTPClient;
 import com.fluxninja.aperture.instrumentation.ApertureSDKWrapper;
 import com.fluxninja.aperture.instrumentation.Config;
-import com.fluxninja.aperture.sdk.ApertureSDK;
 import com.linecorp.armeria.client.WebClientBuilder;
 import net.bytebuddy.asm.Advice;
 
@@ -12,6 +11,8 @@ public class ArmeriaClientAdvice {
 
     @Advice.OnMethodEnter
     public static void onEnter(@Advice.This WebClientBuilder builder) {
-        builder.decorator(ApertureHTTPClient.newDecorator(wrapper.apertureSDK, wrapper.controlPointName));
+        builder.decorator(
+                ApertureHTTPClient.newDecorator(
+                        wrapper.apertureSDK, wrapper.controlPointName, wrapper.failOpen));
     }
 }

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaServerAdvice.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaServerAdvice.java
@@ -3,7 +3,6 @@ package com.fluxninja.aperture.instrumentation.armeria;
 import com.fluxninja.aperture.armeria.ApertureHTTPService;
 import com.fluxninja.aperture.instrumentation.ApertureSDKWrapper;
 import com.fluxninja.aperture.instrumentation.Config;
-import com.fluxninja.aperture.sdk.ApertureSDK;
 import com.linecorp.armeria.server.ServerBuilder;
 import net.bytebuddy.asm.Advice;
 
@@ -12,6 +11,8 @@ public class ArmeriaServerAdvice {
 
     @Advice.OnMethodEnter
     public static void onEnter(@Advice.This ServerBuilder builder) {
-        builder.decorator(ApertureHTTPService.newDecorator(wrapper.apertureSDK, wrapper.controlPointName));
+        builder.decorator(
+                ApertureHTTPService.newDecorator(
+                        wrapper.apertureSDK, wrapper.controlPointName, wrapper.failOpen));
     }
 }

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaServerAdvice.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/armeria/ArmeriaServerAdvice.java
@@ -1,16 +1,17 @@
 package com.fluxninja.aperture.instrumentation.armeria;
 
 import com.fluxninja.aperture.armeria.ApertureHTTPService;
+import com.fluxninja.aperture.instrumentation.ApertureSDKWrapper;
 import com.fluxninja.aperture.instrumentation.Config;
 import com.fluxninja.aperture.sdk.ApertureSDK;
 import com.linecorp.armeria.server.ServerBuilder;
 import net.bytebuddy.asm.Advice;
 
 public class ArmeriaServerAdvice {
-    public static ApertureSDK apertureSDK = Config.newSDKFromConfig();
+    public static ApertureSDKWrapper wrapper = Config.newSDKWrapperFromConfig();
 
     @Advice.OnMethodEnter
     public static void onEnter(@Advice.This ServerBuilder builder) {
-        builder.decorator(ApertureHTTPService.newDecorator(apertureSDK));
+        builder.decorator(ApertureHTTPService.newDecorator(wrapper.apertureSDK, wrapper.controlPointName));
     }
 }

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/netty/NettyServerAdvice.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/netty/NettyServerAdvice.java
@@ -1,5 +1,6 @@
 package com.fluxninja.aperture.instrumentation.netty;
 
+import com.fluxninja.aperture.instrumentation.ApertureSDKWrapper;
 import com.fluxninja.aperture.instrumentation.Config;
 import com.fluxninja.aperture.netty.ApertureServerHandler;
 import com.fluxninja.aperture.sdk.ApertureSDK;
@@ -11,7 +12,7 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import net.bytebuddy.asm.Advice;
 
 public class NettyServerAdvice {
-    public static ApertureSDK apertureSDK = Config.newSDKFromConfig();
+    public static ApertureSDKWrapper wrapper = Config.newSDKWrapperFromConfig();
 
     @Advice.OnMethodExit
     public static void onExit(
@@ -20,7 +21,7 @@ public class NettyServerAdvice {
             @Advice.Argument(2) ChannelHandler handler) {
         if (handler instanceof HttpServerCodec || handler instanceof HttpRequestDecoder) {
             // only add the aperture handler after the HttpRequestDecoder or HttpServerCodec
-            ApertureServerHandler apertureHandler = new ApertureServerHandler(apertureSDK);
+            ApertureServerHandler apertureHandler = new ApertureServerHandler(wrapper.apertureSDK, wrapper.controlPointName);
             String hname = handlerName;
             if (hname == null) {
                 ChannelHandlerContext ctx = pipeline.context(handler);

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/netty/NettyServerAdvice.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/netty/NettyServerAdvice.java
@@ -3,7 +3,6 @@ package com.fluxninja.aperture.instrumentation.netty;
 import com.fluxninja.aperture.instrumentation.ApertureSDKWrapper;
 import com.fluxninja.aperture.instrumentation.Config;
 import com.fluxninja.aperture.netty.ApertureServerHandler;
-import com.fluxninja.aperture.sdk.ApertureSDK;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -21,7 +20,8 @@ public class NettyServerAdvice {
             @Advice.Argument(2) ChannelHandler handler) {
         if (handler instanceof HttpServerCodec || handler instanceof HttpRequestDecoder) {
             // only add the aperture handler after the HttpRequestDecoder or HttpServerCodec
-            ApertureServerHandler apertureHandler = new ApertureServerHandler(wrapper.apertureSDK, wrapper.controlPointName);
+            ApertureServerHandler apertureHandler =
+                    new ApertureServerHandler(wrapper.apertureSDK, wrapper.controlPointName);
             String hname = handlerName;
             if (hname == null) {
                 ChannelHandlerContext ctx = pipeline.context(handler);

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
@@ -1,9 +1,6 @@
 package com.fluxninja.aperture.armeria;
 
-import com.fluxninja.aperture.sdk.ApertureSDK;
-import com.fluxninja.aperture.sdk.ApertureSDKException;
-import com.fluxninja.aperture.sdk.FlowStatus;
-import com.fluxninja.aperture.sdk.TrafficFlow;
+import com.fluxninja.aperture.sdk.*;
 import com.fluxninja.generated.aperture.flowcontrol.checkhttp.v1.CheckHTTPRequest;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
@@ -19,6 +16,7 @@ import java.util.function.Function;
 public class ApertureHTTPClient extends SimpleDecoratingHttpClient {
     private final ApertureSDK apertureSDK;
     private final String controlPointName;
+    private final boolean failOpen;
 
     public static Function<? super HttpClient, ApertureHTTPClient> newDecorator(
             ApertureSDK apertureSDK, String controlPointName) {
@@ -27,11 +25,24 @@ public class ApertureHTTPClient extends SimpleDecoratingHttpClient {
         return builder::build;
     }
 
+    public static Function<? super HttpClient, ApertureHTTPClient> newDecorator(
+            ApertureSDK apertureSDK, String controlPointName, boolean failOpen) {
+        ApertureHTTPClientBuilder builder = new ApertureHTTPClientBuilder();
+        builder.setApertureSDK(apertureSDK)
+                .setControlPointName(controlPointName)
+                .setEnableFailOpen(failOpen);
+        return builder::build;
+    }
+
     public ApertureHTTPClient(
-            HttpClient delegate, ApertureSDK apertureSDK, String controlPointName) {
+            HttpClient delegate,
+            ApertureSDK apertureSDK,
+            String controlPointName,
+            boolean failOpen) {
         super(delegate);
         this.apertureSDK = apertureSDK;
         this.controlPointName = controlPointName;
+        this.failOpen = failOpen;
     }
 
     @Override
@@ -44,7 +55,12 @@ public class ApertureHTTPClient extends SimpleDecoratingHttpClient {
             return unwrap().execute(ctx, req);
         }
 
-        if (flow.accepted()) {
+        FlowResult flowResult = flow.result();
+        boolean flowAccepted =
+                (flowResult == FlowResult.Accepted
+                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+
+        if (flowAccepted) {
             HttpResponse res;
             try {
                 Map<String, String> newHeaders = Collections.emptyMap();

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
@@ -21,13 +21,6 @@ public class ApertureHTTPClient extends SimpleDecoratingHttpClient {
     private final String controlPointName;
 
     public static Function<? super HttpClient, ApertureHTTPClient> newDecorator(
-            ApertureSDK apertureSDK) {
-        ApertureHTTPClientBuilder builder = new ApertureHTTPClientBuilder();
-        builder.setApertureSDK(apertureSDK);
-        return builder::build;
-    }
-
-    public static Function<? super HttpClient, ApertureHTTPClient> newDecorator(
             ApertureSDK apertureSDK, String controlPointName) {
         ApertureHTTPClientBuilder builder = new ApertureHTTPClientBuilder();
         builder.setApertureSDK(apertureSDK).setControlPointName(controlPointName);

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClientBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClientBuilder.java
@@ -6,8 +6,14 @@ import com.linecorp.armeria.client.HttpClient;
 /** A builder for configuring an {@link ApertureHTTPClient}. */
 public class ApertureHTTPClientBuilder {
     private ApertureSDK apertureSDK;
-    private String controlPointName = "";
+    private String controlPointName;
 
+    /**
+     * Sets the Aperture SDK used by this service.
+     *
+     * @param apertureSDK instance of Aperture SDK to be used
+     * @return the builder object.
+     */
     public ApertureHTTPClientBuilder setApertureSDK(ApertureSDK apertureSDK) {
         this.apertureSDK = apertureSDK;
         return this;
@@ -25,6 +31,12 @@ public class ApertureHTTPClientBuilder {
     }
 
     public ApertureHTTPClient build(HttpClient delegate) {
+        if (this.controlPointName == null || this.controlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must be set");
+        }
+        if (this.apertureSDK == null) {
+            throw new IllegalArgumentException("Aperture SDK must be set");
+        }
         return new ApertureHTTPClient(delegate, apertureSDK, controlPointName);
     }
 }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClientBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClientBuilder.java
@@ -32,8 +32,8 @@ public class ApertureHTTPClientBuilder {
     }
 
     /**
-     * Defines client behavior when Aperture Agent is unreachable. true - pass all traffic through
-     * false - block all traffic
+     * Sets the fail-open behavior for the client when the Aperture Agent is unreachable. If set to
+     * true, all traffic will pass through; if set to false, all traffic will be blocked.
      *
      * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
      *     unreachable

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClientBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClientBuilder.java
@@ -7,6 +7,7 @@ import com.linecorp.armeria.client.HttpClient;
 public class ApertureHTTPClientBuilder {
     private ApertureSDK apertureSDK;
     private String controlPointName;
+    private boolean enableFailOpen = true;
 
     /**
      * Sets the Aperture SDK used by this service.
@@ -30,6 +31,19 @@ public class ApertureHTTPClientBuilder {
         return this;
     }
 
+    /**
+     * Defines client behavior when Aperture Agent is unreachable. true - pass all traffic through
+     * false - block all traffic
+     *
+     * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
+     *     unreachable
+     * @return the builder object.
+     */
+    public ApertureHTTPClientBuilder setEnableFailOpen(boolean enableFailOpen) {
+        this.enableFailOpen = enableFailOpen;
+        return this;
+    }
+
     public ApertureHTTPClient build(HttpClient delegate) {
         if (this.controlPointName == null || this.controlPointName.trim().isEmpty()) {
             throw new IllegalArgumentException("Control Point name must be set");
@@ -37,6 +51,6 @@ public class ApertureHTTPClientBuilder {
         if (this.apertureSDK == null) {
             throw new IllegalArgumentException("Aperture SDK must be set");
         }
-        return new ApertureHTTPClient(delegate, apertureSDK, controlPointName);
+        return new ApertureHTTPClient(delegate, apertureSDK, controlPointName, enableFailOpen);
     }
 }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
@@ -21,13 +21,6 @@ public class ApertureHTTPService extends SimpleDecoratingHttpService {
     private final String controlPointName;
 
     public static Function<? super HttpService, ApertureHTTPService> newDecorator(
-            ApertureSDK apertureSDK) {
-        ApertureHTTPServiceBuilder builder = new ApertureHTTPServiceBuilder();
-        builder.setApertureSDK(apertureSDK);
-        return builder::build;
-    }
-
-    public static Function<? super HttpService, ApertureHTTPService> newDecorator(
             ApertureSDK apertureSDK, String controlPointName) {
         ApertureHTTPServiceBuilder builder = new ApertureHTTPServiceBuilder();
         builder.setApertureSDK(apertureSDK).setControlPointName(controlPointName);

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
@@ -1,9 +1,6 @@
 package com.fluxninja.aperture.armeria;
 
-import com.fluxninja.aperture.sdk.ApertureSDK;
-import com.fluxninja.aperture.sdk.ApertureSDKException;
-import com.fluxninja.aperture.sdk.FlowStatus;
-import com.fluxninja.aperture.sdk.TrafficFlow;
+import com.fluxninja.aperture.sdk.*;
 import com.fluxninja.generated.aperture.flowcontrol.checkhttp.v1.CheckHTTPRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -19,6 +16,7 @@ import java.util.function.Function;
 public class ApertureHTTPService extends SimpleDecoratingHttpService {
     private final ApertureSDK apertureSDK;
     private final String controlPointName;
+    private final boolean failOpen;
 
     public static Function<? super HttpService, ApertureHTTPService> newDecorator(
             ApertureSDK apertureSDK, String controlPointName) {
@@ -27,11 +25,24 @@ public class ApertureHTTPService extends SimpleDecoratingHttpService {
         return builder::build;
     }
 
+    public static Function<? super HttpService, ApertureHTTPService> newDecorator(
+            ApertureSDK apertureSDK, String controlPointName, boolean failOpen) {
+        ApertureHTTPServiceBuilder builder = new ApertureHTTPServiceBuilder();
+        builder.setApertureSDK(apertureSDK)
+                .setControlPointName(controlPointName)
+                .setEnableFailOpen(failOpen);
+        return builder::build;
+    }
+
     public ApertureHTTPService(
-            HttpService delegate, ApertureSDK apertureSDK, String controlPointName) {
+            HttpService delegate,
+            ApertureSDK apertureSDK,
+            String controlPointName,
+            boolean failOpen) {
         super(delegate);
         this.apertureSDK = apertureSDK;
         this.controlPointName = controlPointName;
+        this.failOpen = failOpen;
     }
 
     @Override
@@ -43,7 +54,12 @@ public class ApertureHTTPService extends SimpleDecoratingHttpService {
             return unwrap().serve(ctx, req);
         }
 
-        if (flow.accepted()) {
+        FlowResult flowResult = flow.result();
+        boolean flowAccepted =
+                (flowResult == FlowResult.Accepted
+                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+
+        if (flowAccepted) {
             HttpResponse res;
             try {
                 Map<String, String> newHeaders = Collections.emptyMap();

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPServiceBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPServiceBuilder.java
@@ -6,8 +6,14 @@ import com.linecorp.armeria.server.HttpService;
 /** A builder for configuring an {@link ApertureHTTPService}. */
 public class ApertureHTTPServiceBuilder {
     private ApertureSDK apertureSDK;
-    private String controlPointName = "";
+    private String controlPointName;
 
+    /**
+     * Sets the Aperture SDK used by this service.
+     *
+     * @param apertureSDK instance of Aperture SDK to be used
+     * @return the builder object.
+     */
     public ApertureHTTPServiceBuilder setApertureSDK(ApertureSDK apertureSDK) {
         this.apertureSDK = apertureSDK;
         return this;
@@ -25,6 +31,12 @@ public class ApertureHTTPServiceBuilder {
     }
 
     public ApertureHTTPService build(HttpService delegate) {
+        if (this.controlPointName == null || this.controlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must be set");
+        }
+        if (this.apertureSDK == null) {
+            throw new IllegalArgumentException("Aperture SDK must be set");
+        }
         return new ApertureHTTPService(delegate, apertureSDK, controlPointName);
     }
 }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPServiceBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPServiceBuilder.java
@@ -7,6 +7,7 @@ import com.linecorp.armeria.server.HttpService;
 public class ApertureHTTPServiceBuilder {
     private ApertureSDK apertureSDK;
     private String controlPointName;
+    private boolean enableFailOpen = true;
 
     /**
      * Sets the Aperture SDK used by this service.
@@ -30,6 +31,19 @@ public class ApertureHTTPServiceBuilder {
         return this;
     }
 
+    /**
+     * Defines service behavior when Aperture Agent is unreachable. true - pass all traffic through
+     * false - block all traffic
+     *
+     * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
+     *     unreachable
+     * @return the builder object.
+     */
+    public ApertureHTTPServiceBuilder setEnableFailOpen(boolean enableFailOpen) {
+        this.enableFailOpen = enableFailOpen;
+        return this;
+    }
+
     public ApertureHTTPService build(HttpService delegate) {
         if (this.controlPointName == null || this.controlPointName.trim().isEmpty()) {
             throw new IllegalArgumentException("Control Point name must be set");
@@ -37,6 +51,6 @@ public class ApertureHTTPServiceBuilder {
         if (this.apertureSDK == null) {
             throw new IllegalArgumentException("Aperture SDK must be set");
         }
-        return new ApertureHTTPService(delegate, apertureSDK, controlPointName);
+        return new ApertureHTTPService(delegate, apertureSDK, controlPointName, enableFailOpen);
     }
 }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPServiceBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPServiceBuilder.java
@@ -32,8 +32,8 @@ public class ApertureHTTPServiceBuilder {
     }
 
     /**
-     * Defines service behavior when Aperture Agent is unreachable. true - pass all traffic through
-     * false - block all traffic
+     * Sets the fail-open behavior for the service when the Aperture Agent is unreachable. If set to
+     * true, all traffic will pass through; if set to false, all traffic will be blocked.
      *
      * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
      *     unreachable

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClientBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClientBuilder.java
@@ -7,6 +7,7 @@ import com.linecorp.armeria.client.RpcClient;
 public class ApertureRPCClientBuilder {
     private ApertureSDK apertureSDK;
     private String controlPointName;
+    private boolean enableFailOpen = true;
 
     /**
      * Sets the Aperture SDK used by this service.
@@ -19,8 +20,27 @@ public class ApertureRPCClientBuilder {
         return this;
     }
 
+    /**
+     * Sets the control point name for traffic produced by this client.
+     *
+     * @param controlPointName control point name to be used
+     * @return the builder object.
+     */
     public ApertureRPCClientBuilder setControlPointName(String controlPointName) {
         this.controlPointName = controlPointName;
+        return this;
+    }
+
+    /**
+     * Defines client behavior when Aperture Agent is unreachable. true - pass all traffic through
+     * false - block all traffic
+     *
+     * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
+     *     unreachable
+     * @return the builder object.
+     */
+    public ApertureRPCClientBuilder setEnableFailOpen(boolean enableFailOpen) {
+        this.enableFailOpen = enableFailOpen;
         return this;
     }
 
@@ -31,6 +51,6 @@ public class ApertureRPCClientBuilder {
         if (this.apertureSDK == null) {
             throw new IllegalArgumentException("Aperture SDK must be set");
         }
-        return new ApertureRPCClient(delegate, apertureSDK, controlPointName);
+        return new ApertureRPCClient(delegate, apertureSDK, controlPointName, enableFailOpen);
     }
 }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClientBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClientBuilder.java
@@ -5,9 +5,15 @@ import com.linecorp.armeria.client.RpcClient;
 
 /** A builder for configuring an {@link ApertureRPCClient}. */
 public class ApertureRPCClientBuilder {
-    ApertureSDK apertureSDK;
-    String controlPointName;
+    private ApertureSDK apertureSDK;
+    private String controlPointName;
 
+    /**
+     * Sets the Aperture SDK used by this service.
+     *
+     * @param apertureSDK instance of Aperture SDK to be used
+     * @return the builder object.
+     */
     public ApertureRPCClientBuilder setApertureSDK(ApertureSDK apertureSDK) {
         this.apertureSDK = apertureSDK;
         return this;
@@ -19,6 +25,12 @@ public class ApertureRPCClientBuilder {
     }
 
     public ApertureRPCClient build(RpcClient delegate) {
+        if (this.controlPointName == null || this.controlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must be set");
+        }
+        if (this.apertureSDK == null) {
+            throw new IllegalArgumentException("Aperture SDK must be set");
+        }
         return new ApertureRPCClient(delegate, apertureSDK, controlPointName);
     }
 }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClientBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClientBuilder.java
@@ -32,8 +32,8 @@ public class ApertureRPCClientBuilder {
     }
 
     /**
-     * Defines client behavior when Aperture Agent is unreachable. true - pass all traffic through
-     * false - block all traffic
+     * Sets the fail-open behavior for the client when the Aperture Agent is unreachable. If set to
+     * true, all traffic will pass through; if set to false, all traffic will be blocked.
      *
      * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
      *     unreachable

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCServiceBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCServiceBuilder.java
@@ -5,9 +5,15 @@ import com.linecorp.armeria.server.RpcService;
 
 /** A builder for configuring an {@link ApertureRPCService}. */
 public class ApertureRPCServiceBuilder {
-    ApertureSDK apertureSDK;
-    String controlPointName;
+    private ApertureSDK apertureSDK;
+    private String controlPointName;
 
+    /**
+     * Sets the Aperture SDK used by this service.
+     *
+     * @param apertureSDK instance of Aperture SDK to be used
+     * @return the builder object.
+     */
     public ApertureRPCServiceBuilder setApertureSDK(ApertureSDK apertureSDK) {
         this.apertureSDK = apertureSDK;
         return this;
@@ -19,6 +25,12 @@ public class ApertureRPCServiceBuilder {
     }
 
     public ApertureRPCService build(RpcService delegate) {
+        if (this.controlPointName == null || this.controlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must be set");
+        }
+        if (this.apertureSDK == null) {
+            throw new IllegalArgumentException("Aperture SDK must be set");
+        }
         return new ApertureRPCService(delegate, apertureSDK, controlPointName);
     }
 }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCServiceBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCServiceBuilder.java
@@ -32,8 +32,8 @@ public class ApertureRPCServiceBuilder {
     }
 
     /**
-     * Defines service behavior when Aperture Agent is unreachable. true - pass all traffic through
-     * false - block all traffic
+     * Sets the fail-open behavior for the service when the Aperture Agent is unreachable. If set to
+     * true, all traffic will pass through; if set to false, all traffic will be blocked.
      *
      * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
      *     unreachable

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCServiceBuilder.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCServiceBuilder.java
@@ -7,6 +7,7 @@ import com.linecorp.armeria.server.RpcService;
 public class ApertureRPCServiceBuilder {
     private ApertureSDK apertureSDK;
     private String controlPointName;
+    private boolean enableFailOpen = true;
 
     /**
      * Sets the Aperture SDK used by this service.
@@ -19,8 +20,27 @@ public class ApertureRPCServiceBuilder {
         return this;
     }
 
+    /**
+     * Sets the control point name for traffic handled by this service.
+     *
+     * @param controlPointName control point name to be used
+     * @return the builder object.
+     */
     public ApertureRPCServiceBuilder setControlPointName(String controlPointName) {
         this.controlPointName = controlPointName;
+        return this;
+    }
+
+    /**
+     * Defines service behavior when Aperture Agent is unreachable. true - pass all traffic through
+     * false - block all traffic
+     *
+     * @param enableFailOpen whether all traffic should be accepted when Aperture Agent is
+     *     unreachable
+     * @return the builder object.
+     */
+    public ApertureRPCServiceBuilder setEnableFailOpen(boolean enableFailOpen) {
+        this.enableFailOpen = enableFailOpen;
         return this;
     }
 
@@ -31,6 +51,6 @@ public class ApertureRPCServiceBuilder {
         if (this.apertureSDK == null) {
             throw new IllegalArgumentException("Aperture SDK must be set");
         }
-        return new ApertureRPCService(delegate, apertureSDK, controlPointName);
+        return new ApertureRPCService(delegate, apertureSDK, controlPointName, enableFailOpen);
     }
 }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
@@ -28,7 +28,6 @@ public final class ApertureSDK {
             httpFlowControlClient;
     private final Tracer tracer;
     private final Duration timeout;
-    private final String defaultControlPointName;
     private final List<String> ignoredPaths;
     private final boolean ignoredPathsMatchRegex;
 
@@ -37,13 +36,11 @@ public final class ApertureSDK {
             FlowControlServiceHTTPGrpc.FlowControlServiceHTTPBlockingStub httpFlowControlClient,
             Tracer tracer,
             Duration timeout,
-            String defaultControlPointName,
             List<String> ignoredPaths,
             boolean ignoredPathsMatchRegex) {
         this.flowControlClient = flowControlClient;
         this.tracer = tracer;
         this.timeout = timeout;
-        this.defaultControlPointName = defaultControlPointName;
         this.httpFlowControlClient = httpFlowControlClient;
         this.ignoredPaths = ignoredPaths;
         this.ignoredPathsMatchRegex = ignoredPathsMatchRegex;
@@ -55,13 +52,6 @@ public final class ApertureSDK {
      */
     public static ApertureSDKBuilder builder() {
         return new ApertureSDKBuilder();
-    }
-
-    public Flow startFlow(Map<String, String> explicitLabels) {
-        if (this.defaultControlPointName == null || this.defaultControlPointName.isEmpty()) {
-            throw new IllegalArgumentException("No control point name set");
-        }
-        return startFlow(this.defaultControlPointName, explicitLabels);
     }
 
     public Flow startFlow(String controlPoint, Map<String, String> explicitLabels) {
@@ -116,19 +106,7 @@ public final class ApertureSDK {
         return new Flow(res, span, false);
     }
 
-    public TrafficFlow startTrafficFlow(String path, CheckHTTPRequest rawReq) {
-        CheckHTTPRequest req;
-        if (rawReq.getControlPoint().trim().isEmpty()) {
-            if (this.defaultControlPointName == null
-                    || this.defaultControlPointName.trim().isEmpty()) {
-                throw new IllegalArgumentException("No control point name set");
-            } else {
-                req = rawReq.toBuilder().setControlPoint(this.defaultControlPointName).build();
-            }
-        } else {
-            req = rawReq;
-        }
-
+    public TrafficFlow startTrafficFlow(String path, CheckHTTPRequest req) {
         if (isIgnored(path)) {
             return TrafficFlow.ignoredFlow();
         }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -26,7 +26,6 @@ public final class ApertureSDKBuilder {
     private Duration timeout;
     private String host;
     private int port;
-    private String defaultControlPointName;
     private boolean useHttpsInOtlpExporter = false;
     private boolean insecureGrpc = true;
     private String certFile;
@@ -44,17 +43,6 @@ public final class ApertureSDKBuilder {
 
     public ApertureSDKBuilder setPort(int port) {
         this.port = port;
-        return this;
-    }
-
-    /**
-     * Set control point name to be used if not overridden on flow creation.
-     *
-     * @param controlPointName control point name to be used
-     * @return the builder object.
-     */
-    public ApertureSDKBuilder setControlPointName(String controlPointName) {
-        this.defaultControlPointName = controlPointName;
         return this;
     }
 
@@ -243,7 +231,6 @@ public final class ApertureSDKBuilder {
                 httpFlowControlClient,
                 tracer,
                 timeout,
-                defaultControlPointName,
                 ignoredPaths,
                 ignoredPathsMatchRegex);
     }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "1.5.0";
+    public static final String LIBRARY_VERSION = "2.0.0";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
@@ -17,12 +17,30 @@ public final class Flow {
         this.ended = ended;
     }
 
+    /**
+     * Returns 'true' if flow was accepted by Aperture Agent, or if the Agent did not respond.
+     *
+     * @deprecated This method assumes fail-open behavior. Use {@link #result} instead
+     * @return Whether the flow was accepted.
+     */
     public boolean accepted() {
+        return result() == FlowResult.Unreachable || result() == FlowResult.Accepted;
+    }
+
+    /**
+     * Returns Aperture Agent's decision or information on Agent being unreachable.
+     *
+     * @return Result of Check query
+     */
+    public FlowResult result() {
         if (this.checkResponse == null) {
-            return true;
+            return FlowResult.Unreachable;
         }
-        return this.checkResponse.getDecisionType()
-                == CheckResponse.DecisionType.DECISION_TYPE_ACCEPTED;
+        if (this.checkResponse.getDecisionType()
+                == CheckResponse.DecisionType.DECISION_TYPE_ACCEPTED) {
+            return FlowResult.Accepted;
+        }
+        return FlowResult.Rejected;
     }
 
     public CheckResponse checkResponse() {

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowResult.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowResult.java
@@ -1,0 +1,7 @@
+package com.fluxninja.aperture.sdk;
+
+public enum FlowResult {
+    Accepted,
+    Rejected,
+    Unreachable
+}

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/TrafficFlow.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/TrafficFlow.java
@@ -28,11 +28,29 @@ public class TrafficFlow {
         return flow;
     }
 
+    /**
+     * Returns 'true' if flow was accepted by Aperture Agent, or if the agent did not respond.
+     *
+     * @deprecated This method assumes fail-open behavior. Use {@link #result} instead
+     * @return Whether the flow was accepted.
+     */
     public boolean accepted() {
+        return result() == FlowResult.Unreachable || result() == FlowResult.Accepted;
+    }
+
+    /**
+     * Returns Aperture Agent's decision or information on Agent being unreachable.
+     *
+     * @return Result of Check query
+     */
+    public FlowResult result() {
         if (this.checkResponse == null) {
-            return true;
+            return FlowResult.Unreachable;
         }
-        return this.checkResponse.getStatus().getCode() == Code.OK_VALUE;
+        if (this.checkResponse.getStatus().getCode() == Code.OK_VALUE) {
+            return FlowResult.Accepted;
+        }
+        return FlowResult.Rejected;
     }
 
     public boolean ignored() {

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -19,12 +19,13 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
     private final ApertureSDK apertureSDK;
     private final String controlPointName;
 
-    public ApertureServerHandler(ApertureSDK sdk) {
-        this.apertureSDK = sdk;
-        this.controlPointName = "";
-    }
-
     public ApertureServerHandler(ApertureSDK sdk, String controlPointName) {
+        if (controlPointName == null || controlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must not be null or empty");
+        }
+        if (sdk == null) {
+            throw new IllegalArgumentException("Aperture SDK must not be null");
+        }
         this.apertureSDK = sdk;
         this.controlPointName = controlPointName;
     }

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -1,9 +1,6 @@
 package com.fluxninja.aperture.netty;
 
-import com.fluxninja.aperture.sdk.ApertureSDK;
-import com.fluxninja.aperture.sdk.ApertureSDKException;
-import com.fluxninja.aperture.sdk.FlowStatus;
-import com.fluxninja.aperture.sdk.TrafficFlow;
+import com.fluxninja.aperture.sdk.*;
 import com.fluxninja.generated.aperture.flowcontrol.checkhttp.v1.CheckHTTPRequest;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -18,6 +15,7 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
 
     private final ApertureSDK apertureSDK;
     private final String controlPointName;
+    private boolean failOpen = true;
 
     public ApertureServerHandler(ApertureSDK sdk, String controlPointName) {
         if (controlPointName == null || controlPointName.trim().isEmpty()) {
@@ -28,6 +26,18 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
         }
         this.apertureSDK = sdk;
         this.controlPointName = controlPointName;
+    }
+
+    public ApertureServerHandler(ApertureSDK sdk, String controlPointName, boolean failOpen) {
+        if (controlPointName == null || controlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must not be null or empty");
+        }
+        if (sdk == null) {
+            throw new IllegalArgumentException("Aperture SDK must not be null");
+        }
+        this.apertureSDK = sdk;
+        this.controlPointName = controlPointName;
+        this.failOpen = failOpen;
     }
 
     @Override
@@ -43,7 +53,12 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
             return;
         }
 
-        if (flow.accepted()) {
+        FlowResult flowResult = flow.result();
+        boolean flowAccepted =
+                (flowResult == FlowResult.Accepted
+                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+
+        if (flowAccepted) {
             try {
                 Map<String, String> newHeaders = new HashMap<>();
                 if (flow.checkResponse() != null) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -19,6 +19,7 @@ public class ApertureFilter implements Filter {
 
     private ApertureSDK apertureSDK;
     private String controlPointName;
+    private boolean failOpen;
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
@@ -36,7 +37,12 @@ public class ApertureFilter implements Filter {
             return;
         }
 
-        if (flow.accepted()) {
+        FlowResult flowResult = flow.result();
+        boolean flowAccepted =
+                (flowResult == FlowResult.Accepted
+                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+
+        if (flowAccepted) {
             try {
                 Map<String, String> newHeaders = new HashMap<>();
                 if (flow.checkResponse() != null) {
@@ -84,6 +90,9 @@ public class ApertureFilter implements Filter {
             ignoredPathsRegex =
                     Boolean.parseBoolean(
                             filterConfig.getInitParameter("ignored_paths_match_regex"));
+
+            this.failOpen = Boolean.parseBoolean(filterConfig.getInitParameter("enable_fail_open"));
+
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -88,11 +88,10 @@ public class ApertureFilter implements Filter {
             throw new ServletException("Could not read config parameters", e);
         }
 
-        if (initControlPointName != null) {
-            controlPointName = initControlPointName;
-        } else {
-            controlPointName = "";
+        if (initControlPointName == null || initControlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must be set");
         }
+        controlPointName = initControlPointName;
 
         try {
             ApertureSDKBuilder builder = ApertureSDK.builder();

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -19,6 +19,7 @@ public class ApertureFilter implements Filter {
 
     private ApertureSDK apertureSDK;
     private String controlPointName;
+    private boolean failOpen;
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
@@ -36,7 +37,12 @@ public class ApertureFilter implements Filter {
             return;
         }
 
-        if (flow.accepted()) {
+        FlowResult flowResult = flow.result();
+        boolean flowAccepted =
+                (flowResult == FlowResult.Accepted
+                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+
+        if (flowAccepted) {
             try {
                 Map<String, String> newHeaders = new HashMap<>();
                 if (flow.checkResponse() != null) {
@@ -84,6 +90,9 @@ public class ApertureFilter implements Filter {
             ignoredPathsRegex =
                     Boolean.parseBoolean(
                             filterConfig.getInitParameter("ignored_paths_match_regex"));
+
+            this.failOpen = Boolean.parseBoolean(filterConfig.getInitParameter("enable_fail_open"));
+
         } catch (Exception e) {
             throw new ServletException("Could not read config parameters", e);
         }

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -88,11 +88,11 @@ public class ApertureFilter implements Filter {
             throw new ServletException("Could not read config parameters", e);
         }
 
-        if (initControlPointName != null) {
-            controlPointName = initControlPointName;
-        } else {
-            controlPointName = "";
+        if (initControlPointName == null || initControlPointName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Control Point name must be set");
         }
+        controlPointName = initControlPointName;
+
         try {
             ApertureSDKBuilder builder = ApertureSDK.builder();
             builder.setHost(agentHost);

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "1.5.0"
+  var ver = "2.0.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added fail-open behavior configuration option for Java SDK examples and Java agent
- Introduced `FlowResult` enum and deprecated `accepted()` method in `Flow` and `TrafficFlow` classes
- Updated constructors and methods to accept `failOpen` parameter

**Documentation:**
- Updated documentation and README files with new configuration property `aperture.javaagent.enable.fail.open`

**Version Update:**
- Bumped Java SDK version from 1.5.0 to 2.0.0

> 🎉 With fail-open now configurable, we cheer,
> For better control over traffic flow is here.
> A new version emerges, two-point-oh it stands,
> Bringing flexibility to developers' hands. 🚀
<!-- end of auto-generated comment: release notes by openai -->