### PR TITLE
Added nil check for omitempty fields in AdaptiveLoadScheduler

### DIFF
--- a/pkg/policies/controlplane/components/flowcontrol/loadscheduler/adaptive-load-scheduler.go
+++ b/pkg/policies/controlplane/components/flowcontrol/loadscheduler/adaptive-load-scheduler.go
@@ -58,8 +58,14 @@ func ParseAdaptiveLoadScheduler(
 
 	isOverloadDeciderOperator := "gt"
 	// if slope is greater than 0 then we want to use less than operator
-	if adaptiveLoadScheduler.Parameters.Gradient.Slope > 0 {
+	if adaptiveLoadScheduler.Parameters.Gradient != nil && adaptiveLoadScheduler.Parameters.Gradient.Slope > 0 {
 		isOverloadDeciderOperator = "lt"
+	}
+
+	if adaptiveLoadScheduler.Parameters.Alerter == nil {
+		adaptiveLoadScheduler.Parameters.Alerter = &policylangv1.Alerter_Parameters{
+			AlertName: "Load Throttling Event",
+		}
 	}
 
 	alerterLabels := adaptiveLoadScheduler.Parameters.Alerter.Labels


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Added nil checks for omitempty fields in AdaptiveLoadScheduler and set default values
- Ensured safe access to Gradient field properties
```

> 🎉 In this PR we find delight,
> As nil checks make our code right.
> With safety ensured, we forge ahead,
> On a path where no errors are bred. 🚀
<!-- end of auto-generated comment: release notes by openai -->