### PR TITLE
Corrected metrics name in feature_rollout scenario dashboard

### DIFF
--- a/blueprints/policies/feature-rollout/base/dashboard.libsonnet
+++ b/blueprints/policies/feature-rollout/base/dashboard.libsonnet
@@ -21,7 +21,7 @@ function(cfg) {
     )
     .addTarget(
       prometheus.target(
-        expr='rate(flow_regulator_counter{policy_name="%(policy_name)s"}[$__rate_interval])' % {
+        expr='rate(regulator_counter{policy_name="%(policy_name)s"}[$__rate_interval])' % {
           policy_name: policyName,
         },
         intervalFactor=1,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Updated Prometheus metric name in dashboard.libsonnet

```

> 🎉 A metric's name has changed, we've fixed it with no strain! 📊
> In dashboard.libsonnet, the update was made,
> Now our monitoring will not fade. 🌟
<!-- end of auto-generated comment: release notes by openai -->