### PR TITLE
make parameters and alerter required fields in AdaptiveLoadScheduler

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -739,7 +739,7 @@ message AdaptiveLoadScheduler {
     LoadScheduler.Parameters load_scheduler = 1; // @gotags: validate:"required"
 
     // Parameters for the _Gradient Controller_.
-    GradientController.Parameters gradient = 2;
+    GradientController.Parameters gradient = 2; // @gotags: validate:"required"
 
     // The accepted token rate is multiplied by this value to dynamically calculate the upper concurrency limit of a Service during normal (non-overload) states, helping to protect the Service from sudden spikes in incoming token rate.
     double max_load_multiplier = 3; // @gotags: default:"2.0"
@@ -748,7 +748,7 @@ message AdaptiveLoadScheduler {
     double load_multiplier_linear_increment = 4; // @gotags: default:"0.0025"
 
     // Configuration parameters for the embedded Alerter.
-    Alerter.Parameters alerter = 5;
+    Alerter.Parameters alerter = 5; // @gotags: validate:"required"
   }
 
   // Input ports for the _Adaptive Load Scheduler_ component.

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -2883,13 +2883,13 @@ type AdaptiveLoadScheduler_Parameters struct {
 	// Parameters for the _Load Scheduler_.
 	LoadScheduler *LoadScheduler_Parameters `protobuf:"bytes,1,opt,name=load_scheduler,json=loadScheduler,proto3" json:"load_scheduler,omitempty" validate:"required"` // @gotags: validate:"required"
 	// Parameters for the _Gradient Controller_.
-	Gradient *GradientController_Parameters `protobuf:"bytes,2,opt,name=gradient,proto3" json:"gradient,omitempty"`
+	Gradient *GradientController_Parameters `protobuf:"bytes,2,opt,name=gradient,proto3" json:"gradient,omitempty" validate:"required"` // @gotags: validate:"required"
 	// The accepted token rate is multiplied by this value to dynamically calculate the upper concurrency limit of a Service during normal (non-overload) states, helping to protect the Service from sudden spikes in incoming token rate.
 	MaxLoadMultiplier float64 `protobuf:"fixed64,3,opt,name=max_load_multiplier,json=maxLoadMultiplier,proto3" json:"max_load_multiplier,omitempty" default:"2.0"` // @gotags: default:"2.0"
 	// Linear increment to load multiplier in each execution tick when the system is not in overloaded state.
 	LoadMultiplierLinearIncrement float64 `protobuf:"fixed64,4,opt,name=load_multiplier_linear_increment,json=loadMultiplierLinearIncrement,proto3" json:"load_multiplier_linear_increment,omitempty" default:"0.0025"` // @gotags: default:"0.0025"
 	// Configuration parameters for the embedded Alerter.
-	Alerter *Alerter_Parameters `protobuf:"bytes,5,opt,name=alerter,proto3" json:"alerter,omitempty"`
+	Alerter *Alerter_Parameters `protobuf:"bytes,5,opt,name=alerter,proto3" json:"alerter,omitempty" validate:"required"` // @gotags: validate:"required"
 }
 
 func (x *AdaptiveLoadScheduler_Parameters) Reset() {

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -85,12 +85,14 @@
       "properties": {
         "alerter": {
           "$ref": "#/definitions/AlerterParameters",
-          "description": "Configuration parameters for the embedded Alerter.",
+          "description": "Configuration parameters for the embedded Alerter.\n\n",
+          "x-go-tag-validate": "required",
           "x-order": 0
         },
         "gradient": {
           "$ref": "#/definitions/GradientControllerParameters",
-          "description": "Parameters for the _Gradient Controller_.",
+          "description": "Parameters for the _Gradient Controller_.\n\n",
+          "x-go-tag-validate": "required",
           "x-order": 1
         },
         "load_multiplier_linear_increment": {

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -300,10 +300,16 @@ definitions:
     type: object
     properties:
       alerter:
-        description: Configuration parameters for the embedded Alerter.
+        description: |+
+          Configuration parameters for the embedded Alerter.
+
+        x-go-tag-validate: required
         $ref: '#/definitions/AlerterParameters'
       gradient:
-        description: Parameters for the _Gradient Controller_.
+        description: |+
+          Parameters for the _Gradient Controller_.
+
+        x-go-tag-validate: required
         $ref: '#/definitions/GradientControllerParameters'
       load_multiplier_linear_increment:
         description: |+

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -65,10 +65,16 @@ definitions:
         properties:
             alerter:
                 $ref: '#/definitions/AlerterParameters'
-                description: Configuration parameters for the embedded Alerter.
+                description: |+
+                    Configuration parameters for the embedded Alerter.
+
+                x-go-tag-validate: required
             gradient:
                 $ref: '#/definitions/GradientControllerParameters'
-                description: Parameters for the _Gradient Controller_.
+                description: |+
+                    Parameters for the _Gradient Controller_.
+
+                x-go-tag-validate: required
             load_multiplier_linear_increment:
                 default: 0.0025
                 description: |+

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -103,11 +103,17 @@ definitions:
     type: object
     properties:
       alerter:
-        description: Configuration parameters for the embedded Alerter.
+        description: |+
+          Configuration parameters for the embedded Alerter.
+
+        x-go-tag-validate: required
         x-order: 0
         $ref: '#/definitions/AlerterParameters'
       gradient:
-        description: Parameters for the _Gradient Controller_.
+        description: |+
+          Parameters for the _Gradient Controller_.
+
+        x-go-tag-validate: required
         x-order: 1
         $ref: '#/definitions/GradientControllerParameters'
       load_multiplier_linear_increment:

--- a/pkg/policies/controlplane/components/flowcontrol/loadscheduler/adaptive-load-scheduler.go
+++ b/pkg/policies/controlplane/components/flowcontrol/loadscheduler/adaptive-load-scheduler.go
@@ -58,14 +58,12 @@ func ParseAdaptiveLoadScheduler(
 
 	isOverloadDeciderOperator := "gt"
 	// if slope is greater than 0 then we want to use less than operator
-	if adaptiveLoadScheduler.Parameters.Gradient != nil && adaptiveLoadScheduler.Parameters.Gradient.Slope > 0 {
+	if adaptiveLoadScheduler.Parameters.Gradient.Slope > 0 {
 		isOverloadDeciderOperator = "lt"
 	}
 
-	if adaptiveLoadScheduler.Parameters.Alerter == nil {
-		adaptiveLoadScheduler.Parameters.Alerter = &policylangv1.Alerter_Parameters{
-			AlertName: "Load Throttling Event",
-		}
+	adaptiveLoadScheduler.Parameters.Alerter = &policylangv1.Alerter_Parameters{
+		AlertName: "Load Throttling Event",
 	}
 
 	alerterLabels := adaptiveLoadScheduler.Parameters.Alerter.Labels

--- a/pkg/policies/controlplane/components/flowcontrol/loadscheduler/adaptive-load-scheduler.go
+++ b/pkg/policies/controlplane/components/flowcontrol/loadscheduler/adaptive-load-scheduler.go
@@ -62,10 +62,6 @@ func ParseAdaptiveLoadScheduler(
 		isOverloadDeciderOperator = "lt"
 	}
 
-	adaptiveLoadScheduler.Parameters.Alerter = &policylangv1.Alerter_Parameters{
-		AlertName: "Load Throttling Event",
-	}
-
 	alerterLabels := adaptiveLoadScheduler.Parameters.Alerter.Labels
 	if alerterLabels == nil {
 		alerterLabels = make(map[string]string)


### PR DESCRIPTION
### Description of change

Make the fields required instead of relying on nil pointer checks and setting default behavior manually.

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Make `gradient`, `alerter`, `Parameters`, and `Alerter` fields required in `AdaptiveLoadScheduler`
- Set default value for `AlertName` if not provided

> 🎉 With fields required, we stand tall,
> No more nil checks, we've fixed them all.
> A default alert name, now in place,
> Our scheduler's stronger, keeping pace. 🚀
<!-- end of auto-generated comment: release notes by openai -->