### PR TITLE
circleci: move cache paths around

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -304,9 +304,9 @@ jobs:
             tanka
             yq
       - restore_cache:
-          name: Restore go cache
+          name: Restore daily cache
           keys:
-            - aperture-v7-go-cache-{{ checksum "~/day" }}
+            - aperture-v7-daily-cache-{{ checksum "~/day" }}
       - run: &install_opsninja
           name: Install opsninja and its dependencies
           command: |
@@ -344,6 +344,7 @@ jobs:
             cp .pre-commit-config.yaml /tmp/pre-commit-cache-key.txt
             python --version --version >> /tmp/pre-commit-cache-key.txt
             pre-commit --version >> /tmp/pre-commit-cache-key.txt
+            cat requirements.txt >> /tmp/pre-commit-cache-key.txt
       - restore_cache:
           name: Restore pre-commit cache
           keys:
@@ -385,12 +386,11 @@ jobs:
               asdf reshim nodejs
             fi
       - save_cache:
-          name: Save go cache
-          key: aperture-v7-go-cache-{{ checksum "~/day" }}
+          name: Save daily cache
+          key: aperture-v7-daily-cache-{{ checksum "~/day" }}
           paths:
-            - ../.cache
-            - ../.local
-            - ../.pyenv
+            - ../.cache/go-build
+            - ../.cache/golangci-lint
             - ../.aperturectl
             - ./blueprints/vendor
           when: on_success
@@ -399,7 +399,11 @@ jobs:
           key:
             aperture-v1-pc-cache-{{ checksum "/tmp/pre-commit-cache-key.txt" }}
           paths:
-            - ~/.cache/pre-commit
+            - ../.cache/pre-commit
+            - ../.cache/pre-commit-zipapp
+            - ../.cache/pip
+            - ../.pyenv
+            - ../.local
       - asdf_save_cache:
           cache_name: pre-commit
       - run:
@@ -1415,6 +1419,7 @@ commands:
             "tools/go/go.mod" }}
           paths:
             - ~/.asdf
+            - ../.cache/helm
 
   aperture_docker_build:
     description: |

--- a/scripts/install_asdf_tools.sh
+++ b/scripts/install_asdf_tools.sh
@@ -71,6 +71,7 @@ install_helm_plugins() {
 		# Which spams the screen
 		helm plugin install "${url}" --version "${version}" >/dev/null
 	done
+	asdf reshim helm
 }
 
 install_plugins() {

--- a/scripts/install_go_tools.sh
+++ b/scripts/install_go_tools.sh
@@ -6,7 +6,9 @@ gitroot=$(git rev-parse --show-toplevel)
 
 pushd "${gitroot}" >/dev/null
 
-./scripts/build_aperturectl.sh --force-build >/dev/null
+aperturectl="$("$gitroot"/scripts/build_aperturectl.sh --force-build)"
+# download jsonnet dependencies as well
+"$aperturectl" blueprints list --uri="$gitroot"/blueprints >/dev/null
 
 if ! command -v go &>/dev/null; then
 	printf 'Installing Go\n'

--- a/scripts/invalidate_asdf_ci_cache.sh
+++ b/scripts/invalidate_asdf_ci_cache.sh
@@ -13,8 +13,8 @@ fi
 	"$AWK" -i inplace '/aperture-asdf-cache-v[0-9]+-/ {match($0, /aperture-asdf-cache-v([0-9]+)(.*)/, a); $0 = gensub(/aperture-asdf-cache-v[0-9]+-/, "aperture-asdf-cache-v" a[1]+1 "-", "g", $0)} {print}' "$file"
 done
 
-# invalidate aperture-v<version>-go-cache-* as well
+# invalidate aperture-v<version>-daily-cache-* as well
 # shellcheck disable=SC2016
 "$FIND" .circleci -type f \( -name "*.yml" -o -name "*.yaml" \) -print0 | while read -r -d $'\0' file; do
-	"$AWK" -i inplace '/aperture-v[0-9]+-go-cache-/ {match($0, /aperture-v([0-9]+)(.*)/, a); $0 = gensub(/aperture-v[0-9]+-go-cache-/, "aperture-v" a[1]+1 "-go-cache-", "g", $0)} {print}' "$file"
+	"$AWK" -i inplace '/aperture-v[0-9]+-daily-cache-/ {match($0, /aperture-v([0-9]+)(.*)/, a); $0 = gensub(/aperture-v[0-9]+-daily-cache-/, "aperture-v" a[1]+1 "-daily-cache-", "g", $0)} {print}' "$file"
 done


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Update CircleCI cache paths and keys for better organization
- Add `asdf reshim helm` command to `install_helm_plugins` function in `install_asdf_tools.sh`
- Modify `install_go_tools.sh` to download jsonnet dependencies using `aperturectl`

> 🎉 Cache paths renamed, daily now they're called,
> Helm plugins reshimmed, with asdf enthralled.
> Jsonnet deps fetched, aperturectl stands tall,
> A PR full of changes, we celebrate them all! 🚀
<!-- end of auto-generated comment: release notes by openai -->