### PR TITLE
telemetry resource: update etcd path to use policy name

### DIFF
--- a/pkg/policies/controlplane/policy.go
+++ b/pkg/policies/controlplane/policy.go
@@ -120,7 +120,7 @@ func compilePolicyWrapper(wrapperMessage *policysyncv1.PolicyWrapper, registry s
 			// Initialize classifiers
 			classifiers := flowControl.GetClassifiers()
 			for index, classifierProto := range classifiers {
-				classifierOption, err := classifier.NewClassifierOptions(int64(index), classifierProto, policy)
+				classifierOption, err := classifier.NewClassifierOptions(index, classifierProto, policy)
 				if err != nil {
 					return nil, nil, nil, err
 				}

--- a/pkg/policies/controlplane/resources/classifier/classifier.go
+++ b/pkg/policies/controlplane/resources/classifier/classifier.go
@@ -20,12 +20,12 @@ type classifierConfigSync struct {
 	classifierProto *policylangv1.Classifier
 	etcdPath        string
 	agentGroupName  string
-	classifierIndex int64
+	classifierIndex int
 }
 
 // NewClassifierOptions creates fx options for classifier.
 func NewClassifierOptions(
-	classifierIndex int64,
+	classifierIndex int,
 	classifierProto *policylangv1.Classifier,
 	policyBaseAPI iface.Policy,
 ) (fx.Option, error) {
@@ -60,7 +60,7 @@ func (configSync *classifierConfigSync) doSync(etcdClient *etcdclient.Client, li
 				ClassifierAttributes: &policysyncv1.ClassifierAttributes{
 					PolicyName:      configSync.policyReadAPI.GetPolicyName(),
 					PolicyHash:      configSync.policyReadAPI.GetPolicyHash(),
-					ClassifierIndex: configSync.classifierIndex,
+					ClassifierIndex: int64(configSync.classifierIndex),
 				},
 			}
 			dat, err := proto.Marshal(wrapper)

--- a/pkg/policies/controlplane/resources/telemetry-collectors/telemetry-collectors.go
+++ b/pkg/policies/controlplane/resources/telemetry-collectors/telemetry-collectors.go
@@ -30,7 +30,7 @@ func NewTelemetryCollectorsOptions(
 	for i, tcProto := range tcProtos {
 		agentGroup := tcProto.GetAgentGroup()
 		etcdPath := path.Join(paths.TelemetryCollectorConfigPath,
-			paths.TelemetryCollectorKey(agentGroup, i))
+			paths.TelemetryCollectorKey(agentGroup, policyBaseAPI.GetPolicyName(), i))
 		configSync := &tcConfigSync{
 			tcProto:        tcProto,
 			policyReadAPI:  policyBaseAPI,

--- a/pkg/policies/paths/paths.go
+++ b/pkg/policies/paths/paths.go
@@ -73,11 +73,11 @@ func FluxMeterKey(agentGroupName, fluxMeterName string) string {
 }
 
 // TelemetryCollectorKey returns the identifier for TelemetryCollector in etcd.
-func TelemetryCollectorKey(agentGroupName string, index int) string {
-	return AgentGroupPrefix(agentGroupName) + "-telemetry_collector-" + strconv.Itoa(index)
+func TelemetryCollectorKey(agentGroupName string, policyName string, index int) string {
+	return PolicyPrefix(agentGroupName, policyName) + "-telemetry_collector-" + strconv.Itoa(index)
 }
 
 // ClassifierKey returns the identifier for a Classifier in etcd.
-func ClassifierKey(agentGroupName, policyName string, classifierIndex int64) string {
-	return PolicyPrefix(agentGroupName, policyName) + "-classifier_index-" + strconv.FormatInt(classifierIndex, 10)
+func ClassifierKey(agentGroupName, policyName string, classifierIndex int) string {
+	return PolicyPrefix(agentGroupName, policyName) + "-classifier_index-" + strconv.Itoa(classifierIndex)
 }


### PR DESCRIPTION
### Description of change

Prevent clash in telemetry collector etcd paths across policies

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Bug fix:**
- Prevent clashes in telemetry collector etcd paths across policies by updating the path and key functions
- Update `NewClassifierOptions` function call to use an integer index instead of int64

> 🎉 No more clashes, our paths are clear,
> With updated keys, we have nothing to fear.
> A small change in type, but a big win,
> Our code is now stronger, let the celebration begin! 🥳
<!-- end of auto-generated comment: release notes by openai -->