### PR TITLE
do not panic on shutdown errors

### DIFF
--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -62,6 +62,6 @@ func Mod(a, b int) int {
 // Shutdown invokes fx.Shutdowner and logs error if any.
 func Shutdown(shutdowner fx.Shutdowner) {
 	if err := shutdowner.Shutdown(); err != nil {
-		log.Panic().Err(err).Msg("Unable to shutdown!")
+		log.Error().Err(err).Msg("Unable to shutdown!")
 	}
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Changed log level from `Panic` to `Error` in the `Shutdown` function of pkg/utils/helpers.go
```

> 🎉 Hooray for this change, so small and neat,
> No more panic, just errors we'll meet.
> A smoother shutdown, that's what we cheer,
> With every release, progress is near! 🚀
<!-- end of auto-generated comment: release notes by openai -->