### PR TITLE
Add gradle clean to dockerfiles to prevent cache errors

### DIFF
--- a/sdks/aperture-java/dockerfiles/aperture-java-all/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/aperture-java-all/Dockerfile
@@ -6,14 +6,14 @@ WORKDIR /
 
 COPY --link . .
 
-RUN ./gradlew javaagent:agent:shadowJar
-RUN ./gradlew javaagent:test-services:armeria-test-service:shadowJar
-RUN ./gradlew javaagent:test-services:netty-test-service:shadowJar
-
-RUN ./gradlew examples:armeria-example:shadowJar
-RUN ./gradlew examples:netty-example:shadowJar
-RUN ./gradlew examples:standalone-example:shadowJar
-RUN ./gradlew examples:spring-example:assemble
+RUN ./gradlew clean \
+    javaagent:agent:shadowJar \
+    javaagent:test-services:armeria-test-service:shadowJar \
+    javaagent:test-services:netty-test-service:shadowJar \
+    examples:armeria-example:shadowJar \
+    examples:netty-example:shadowJar \
+    examples:standalone-example:shadowJar \
+    examples:spring-example:assemble
 # TODO: also add tomcat here
 
 FROM --platform=linux/amd64 openjdk:18-jdk-alpine

--- a/sdks/aperture-java/dockerfiles/example/Dockerfile
+++ b/sdks/aperture-java/dockerfiles/example/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /
 
 COPY --link . .
 
-RUN ./gradlew examples:armeria-example:shadowJar
+RUN ./gradlew clean examples:armeria-example:shadowJar
 
 FROM --platform=linux/amd64 openjdk:18-jdk-alpine
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Chore:
- Added `clean` command to Gradle build process in sdks/aperture-java/dockerfiles/aperture-java-all/Dockerfile and sdks/aperture-java/dockerfiles/example/Dockerfile
```

> 🎉 A clean slate, a fresh start,
> With Gradle builds, we play our part.
> Cache errors, now at bay,
> Our Dockerfiles lead the way. 🚀
<!-- end of auto-generated comment: release notes by openai -->