### PR TITLE
Add `sub_circuit_id` variable to singals dashboard

### DIFF
--- a/blueprints/dashboards/signals/dashboard.libsonnet
+++ b/blueprints/dashboards/signals/dashboard.libsonnet
@@ -22,9 +22,9 @@ function(cfg) {
     .addTarget(
       prometheus.target(
         expr=(
-          'increase(signal_reading_sum{policy_name="' + policyName + '",signal_name="${signal_name}"}[$__rate_interval])' +
+          'increase(signal_reading_sum{policy_name="' + policyName + '",signal_name="${signal_name}",sub_circuit_id="${sub_circuit_id}"}[$__rate_interval])' +
           '/' +
-          'increase(signal_reading_count{policy_name="' + policyName + '",signal_name="${signal_name}"}[$__rate_interval])'
+          'increase(signal_reading_count{policy_name="' + policyName + '",signal_name="${signal_name}",sub_circuit_id="${sub_circuit_id}"}[$__rate_interval])'
         ),
         intervalFactor=1,
       ),
@@ -39,14 +39,14 @@ function(cfg) {
     )
     .addTarget(
       prometheus.target(
-        expr='avg(rate(signal_reading_count{policy_name="%(policy_name)s",signal_name="${signal_name}"}[$__rate_interval]))' % { policy_name: policyName },
+        expr='avg(rate(signal_reading_count{policy_name="%(policy_name)s",signal_name="${signal_name}",sub_circuit_id="${sub_circuit_id}"}[$__rate_interval]))' % { policy_name: policyName },
         intervalFactor=1,
         legendFormat='Valid',
       ),
     )
     .addTarget(
       prometheus.target(
-        expr='sum(rate(invalid_signal_readings_total{policy_name="%(policy_name)s",signal_name="${signal_name}"}[$__rate_interval]))' % { policy_name: policyName },
+        expr='sum(rate(invalid_signal_readings_total{policy_name="%(policy_name)s",signal_name="${signal_name}",sub_circuit_id="${sub_circuit_id}"}[$__rate_interval]))' % { policy_name: policyName },
         intervalFactor=1,
         legendFormat='Invalid',
       ),
@@ -76,11 +76,28 @@ function(cfg) {
         type: 'prometheus',
         uid: '${datasource}',
       },
-      query: 'label_values(signal_reading{policy_name="%(policy_name)s"}, signal_name)' % { policy_name: policyName },
+      query: 'label_values(signal_reading{policy_name="%(policy_name)s",sub_circuit_id="${sub_circuit_id}"}, signal_name)' % { policy_name: policyName },
       hide: 0,
       includeAll: false,
       multi: false,
       name: 'signal_name',
+      options: [],
+      refresh: 1,
+      regex: '',
+      skipUrlSync: false,
+      sort: 0,
+      type: 'query',
+    })
+    .addTemplate({
+      datasource: {
+        type: 'prometheus',
+        uid: '${datasource}',
+      },
+      query: 'label_values(signal_reading{policy_name="%(policy_name)s",signal_name="${signal_name}"}, sub_circuit_id)' % { policy_name: policyName },
+      hide: 0,
+      includeAll: false,
+      multi: false,
+      name: 'sub_circuit_id',
       options: [],
       refresh: 1,
       regex: '',

--- a/blueprints/dashboards/signals/dashboard.libsonnet
+++ b/blueprints/dashboards/signals/dashboard.libsonnet
@@ -76,7 +76,7 @@ function(cfg) {
         type: 'prometheus',
         uid: '${datasource}',
       },
-      query: 'label_values(signal_reading{policy_name="%(policy_name)s",sub_circuit_id="${sub_circuit_id}"}, signal_name)' % { policy_name: policyName },
+      query: 'label_values(signal_reading{policy_name="%(policy_name)s"}, signal_name)' % { policy_name: policyName },
       hide: 0,
       includeAll: false,
       multi: false,

--- a/docs/content/reference/policies/assets/monitoring/signals-dashboard.json
+++ b/docs/content/reference/policies/assets/monitoring/signals-dashboard.json
@@ -53,7 +53,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(signal_reading_sum{policy_name=\"signal-processing\",signal_name=\"${signal_name}\"}[$__rate_interval])/increase(signal_reading_count{policy_name=\"signal-processing\",signal_name=\"${signal_name}\"}[$__rate_interval])",
+          "expr": "increase(signal_reading_sum{policy_name=\"signal-processing\",signal_name=\"${signal_name}\",sub_circuit_id=\"${sub_circuit_id}\"}[$__rate_interval])/increase(signal_reading_count{policy_name=\"signal-processing\",signal_name=\"${signal_name}\",sub_circuit_id=\"${sub_circuit_id}\"}[$__rate_interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -138,14 +138,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(signal_reading_count{policy_name=\"signal-processing\",signal_name=\"${signal_name}\"}[$__rate_interval]))",
+          "expr": "avg(rate(signal_reading_count{policy_name=\"signal-processing\",signal_name=\"${signal_name}\",sub_circuit_id=\"${sub_circuit_id}\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Valid",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(invalid_signal_readings_total{policy_name=\"signal-processing\",signal_name=\"${signal_name}\"}[$__rate_interval]))",
+          "expr": "sum(rate(invalid_signal_readings_total{policy_name=\"signal-processing\",signal_name=\"${signal_name}\",sub_circuit_id=\"${sub_circuit_id}\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Invalid",
@@ -220,7 +220,24 @@
         "multi": false,
         "name": "signal_name",
         "options": [],
-        "query": "label_values(signal_reading{policy_name=\"signal-processing\"}, signal_name)",
+        "query": "label_values(signal_reading{policy_name=\"signal-processing\",sub_circuit_id=\"${sub_circuit_id}\"}, signal_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "sub_circuit_id",
+        "options": [],
+        "query": "label_values(signal_reading{policy_name=\"signal-processing\",signal_name=\"${signal_name}\"}, sub_circuit_id)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/docs/content/reference/policies/assets/monitoring/signals-dashboard.json
+++ b/docs/content/reference/policies/assets/monitoring/signals-dashboard.json
@@ -220,7 +220,7 @@
         "multi": false,
         "name": "signal_name",
         "options": [],
-        "query": "label_values(signal_reading{policy_name=\"signal-processing\",sub_circuit_id=\"${sub_circuit_id}\"}, signal_name)",
+        "query": "label_values(signal_reading{policy_name=\"signal-processing\"}, signal_name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
### Description of change
![Screenshot from 2023-05-10 11-19-58](https://github.com/fluxninja/aperture/assets/1553055/66e6d7d1-8c63-43c3-9a69-d8280ecbf642)
![Screenshot from 2023-05-10 11-19-50](https://github.com/fluxninja/aperture/assets/1553055/1c2d5e77-c9bb-4387-9abe-bde77568beb2)


##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### New Feature:
- Added `sub_circuit_id` variable to Prometheus queries in signals dashboard
- Introduced new template for querying available sub-circuit IDs

> 🎉 A new feature takes the stage,
> With `sub_circuit_id`, we engage.
> Queries refined, templates combined,
> In our signals dashboard, they're now aligned. 🚀
<!-- end of auto-generated comment: release notes by openai -->