### PR TITLE
Stop crashing agent on implicit infra meter pipeline

### DIFF
--- a/pkg/otelcollector/infra-meter/infra-meter.go
+++ b/pkg/otelcollector/infra-meter/infra-meter.go
@@ -70,6 +70,12 @@ func addInfraMeter(
 		config.AddProcessor(id, cfg)
 	}
 
+	if infraMeter.Pipeline == nil {
+		// We treat empty pipeline the same way as not-set pipeline, normalize.
+		// This also allows to avoid nil checks below.
+		infraMeter.Pipeline = &policylangv1.InfraMeter_MetricsPipeline{}
+	}
+
 	if len(infraMeter.Pipeline.Receivers) == 0 && len(infraMeter.Pipeline.Processors) == 0 {
 		if len(infraMeter.Processors) >= 1 {
 			return fmt.Errorf("empty pipeline, inferring pipeline is supported only with 0 or 1 processors")


### PR DESCRIPTION
### Description of change

Fixes #1925

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Tests and/or benchmarks are included

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Ensure infraMeter.Pipeline is not nil and set to an empty InfraMeter_MetricsPipeline if needed
```

> 🎉 No more nil, we've had our fill,
> A safer check, in code we'll inject,
> With this PR, we pave the way,
> For cleaner code, hip hip hooray! 🚀
<!-- end of auto-generated comment: release notes by openai -->