### PR TITLE
Fixed default alert parameters in auto-scaler blueprint

### DIFF
--- a/blueprints/policies/auto-scaling/base/config-defaults.libsonnet
+++ b/blueprints/policies/auto-scaling/base/config-defaults.libsonnet
@@ -31,6 +31,12 @@ local promql_scale_in_controller_defaults = {
 local scaling_parameters_defaults = {
   scale_in_cooldown: '40s',
   scale_out_cooldown: '30s',
+  scale_in_alerter: {
+    alert_name: 'Auto-scaler is scaling in',
+  },
+  scale_out_alerter: {
+    alert_name: 'Auto-scaler is scaling out',
+  },
 };
 
 local auto_scaling_defaults = auto_scaling_base_defaults {

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/definitions.json
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/definitions.json
@@ -58,7 +58,13 @@
         "scaling_parameters": {
           "description": "Parameters that define the scaling behavior.",
           "default": {
+            "scale_in_alerter": {
+              "alert_name": "Auto-scaler is scaling in"
+            },
             "scale_in_cooldown": "40s",
+            "scale_out_alerter": {
+              "alert_name": "Auto-scaler is scaling out"
+            },
             "scale_out_cooldown": "30s"
           },
           "type": "object",

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values-required.yaml
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values-required.yaml
@@ -27,7 +27,11 @@ policy:
   # Type: aperture.spec.v1.AutoScalerScalingParameters
   # Required: True
   scaling_parameters:
+    scale_in_alerter:
+      alert_name: "Auto-scaler is scaling in"
     scale_in_cooldown: "40s"
+    scale_out_alerter:
+      alert_name: "Auto-scaler is scaling out"
     scale_out_cooldown: "30s"
   # Scaling backend for the policy.
   # Type: aperture.spec.v1.AutoScalerScalingBackend

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values.yaml
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values.yaml
@@ -27,7 +27,11 @@ policy:
   # Type: aperture.spec.v1.AutoScalerScalingParameters
   # Required: True
   scaling_parameters:
+    scale_in_alerter:
+      alert_name: "Auto-scaler is scaling in"
     scale_in_cooldown: "40s"
+    scale_out_alerter:
+      alert_name: "Auto-scaler is scaling out"
     scale_out_cooldown: "30s"
   # Scaling backend for the policy.
   # Type: aperture.spec.v1.AutoScalerScalingBackend

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/definitions.json
@@ -182,7 +182,13 @@
             "scaling_parameters": {
               "description": "Parameters that define the scaling behavior.",
               "default": {
+                "scale_in_alerter": {
+                  "alert_name": "Auto-scaler is scaling in"
+                },
                 "scale_in_cooldown": "40s",
+                "scale_out_alerter": {
+                  "alert_name": "Auto-scaler is scaling out"
+                },
                 "scale_out_cooldown": "30s"
               },
               "type": "object",

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values-required.yaml
@@ -96,5 +96,9 @@ policy:
     # Type: aperture.spec.v1.AutoScalerScalingParameters
     # Required: True
     scaling_parameters:
+      scale_in_alerter:
+        alert_name: "Auto-scaler is scaling in"
       scale_in_cooldown: "40s"
+      scale_out_alerter:
+        alert_name: "Auto-scaler is scaling out"
       scale_out_cooldown: "30s"

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
@@ -96,7 +96,11 @@ policy:
     # Type: aperture.spec.v1.AutoScalerScalingParameters
     # Required: True
     scaling_parameters:
+      scale_in_alerter:
+        alert_name: "Auto-scaler is scaling in"
       scale_in_cooldown: "40s"
+      scale_out_alerter:
+        alert_name: "Auto-scaler is scaling out"
       scale_out_cooldown: "30s"
 
 dashboard:

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/definitions.json
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/definitions.json
@@ -157,7 +157,13 @@
             "scaling_parameters": {
               "description": "Parameters that define the scaling behavior.",
               "default": {
+                "scale_in_alerter": {
+                  "alert_name": "Auto-scaler is scaling in"
+                },
                 "scale_in_cooldown": "40s",
+                "scale_out_alerter": {
+                  "alert_name": "Auto-scaler is scaling out"
+                },
                 "scale_out_cooldown": "30s"
               },
               "type": "object",

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values-required.yaml
@@ -87,5 +87,9 @@ policy:
     # Type: aperture.spec.v1.AutoScalerScalingParameters
     # Required: True
     scaling_parameters:
+      scale_in_alerter:
+        alert_name: "Auto-scaler is scaling in"
       scale_in_cooldown: "40s"
+      scale_out_alerter:
+        alert_name: "Auto-scaler is scaling out"
       scale_out_cooldown: "30s"

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
@@ -87,7 +87,11 @@ policy:
     # Type: aperture.spec.v1.AutoScalerScalingParameters
     # Required: True
     scaling_parameters:
+      scale_in_alerter:
+        alert_name: "Auto-scaler is scaling in"
       scale_in_cooldown: "40s"
+      scale_out_alerter:
+        alert_name: "Auto-scaler is scaling out"
       scale_out_cooldown: "30s"
 
 dashboard:

--- a/docs/content/applying-policies/auto-scale/load-based-auto-scaling/assets/policy.yaml
+++ b/docs/content/applying-policies/auto-scale/load-based-auto-scaling/assets/policy.yaml
@@ -122,7 +122,11 @@ spec:
               max_replicas: "10"
               min_replicas: "1"
           scaling_parameters:
+            scale_in_alerter:
+              alert_name: Auto-scaler is scaling in
             scale_in_cooldown: 40s
+            scale_out_alerter:
+              alert_name: Auto-scaler is scaling out
             scale_out_cooldown: 30s
     - query:
         promql:

--- a/docs/content/reference/policies/bundled-blueprints/policies/auto-scaling/pod-auto-scaler.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/auto-scaling/pod-auto-scaler.md
@@ -91,7 +91,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/au
     description='Parameters that define the scaling behavior.'
     type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
     reference='../../../spec#auto-scaler-scaling-parameters'
-    value='{"scale_in_cooldown": "40s", "scale_out_cooldown": "30s"}'
+    value='{"scale_in_alerter": {"alert_name": "Auto-scaler is scaling in"}, "scale_in_cooldown": "40s", "scale_out_alerter": {"alert_name": "Auto-scaler is scaling out"}, "scale_out_cooldown": "30s"}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency.md
@@ -328,7 +328,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Parameters that define the scaling behavior.'
     type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
     reference='../../../spec#auto-scaler-scaling-parameters'
-    value='{"scale_in_cooldown": "40s", "scale_out_cooldown": "30s"}'
+    value='{"scale_in_alerter": {"alert_name": "Auto-scaler is scaling in"}, "scale_in_cooldown": "40s", "scale_out_alerter": {"alert_name": "Auto-scaler is scaling out"}, "scale_out_cooldown": "30s"}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql.md
@@ -234,7 +234,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Parameters that define the scaling behavior.'
     type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
     reference='../../../spec#auto-scaler-scaling-parameters'
-    value='{"scale_in_cooldown": "40s", "scale_out_cooldown": "30s"}'
+    value='{"scale_in_alerter": {"alert_name": "Auto-scaler is scaling in"}, "scale_in_cooldown": "40s", "scale_out_alerter": {"alert_name": "Auto-scaler is scaling out"}, "scale_out_cooldown": "30s"}'
 />
 
 <!-- vale on -->


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added default alert parameters to auto-scaler blueprint
- Updated `AutoScalerScalingParameters` object with `scale_in_alerter` and `scale_out_alerter`

**Documentation:**
- Fixed default alert parameters in auto-scaler blueprint documentation

> 🎉 Scaling up and down, we've got it right,
> With new alert parameters, our code takes flight.
> Auto-scaler blueprint, now more complete,
> A better experience, we're proud to meet! 🚀
<!-- end of auto-generated comment: release notes by openai -->