### PR TITLE
Aperture py changes

### DIFF
--- a/docs/content/get-started/integrations/flow-control/sdk/python/manual.md
+++ b/docs/content/get-started/integrations/flow-control/sdk/python/manual.md
@@ -43,7 +43,7 @@ The created instance can then be used to start a flow:
         logger.info("Flow check failed - will fail-open")
 
     # See whether flow was accepted by Aperture Agent.
-    if flow.accepted:
+    if flow.result != FlowResult.Rejected:
         # do actual work
         flow.end(FlowStatus.OK)
     else:
@@ -58,7 +58,7 @@ You can also use the flow as a context manager:
     control_point="AwesomeFeature",
     explicit_labels=labels,
   ) as flow:
-    if flow.accepted:
+    if flow.result != FlowResult.Rejected:
       # do actual work
       # if you do not call flow.end() explicitly, it will be called automatically
       # when the context manager exits - with the status of the flow

--- a/sdks/aperture-py/aperture_sdk/client.py
+++ b/sdks/aperture-py/aperture_sdk/client.py
@@ -19,7 +19,7 @@ from aperture_sdk.const import (
     source_label,
     workload_start_timestamp_label,
 )
-from aperture_sdk.flow import Flow
+from aperture_sdk.flow import Flow, FlowResult
 from aperture_sdk.utils import TWrappedReturn, run_fn
 from opentelemetry import baggage, trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
@@ -106,7 +106,11 @@ class ApertureClient:
         try:
             # stub.Check is typed to accept an int, but it actually accepts a float
             timeout = typing.cast(int, self.timeout.total_seconds())
-            response = stub.Check(request) if timeout == 0 else stub.Check(request, timeout=timeout)
+            response = (
+                stub.Check(request)
+                if timeout == 0
+                else stub.Check(request, timeout=timeout)
+            )
         except grpc.RpcError as e:
             self.logger.debug(f"Aperture gRPC call failed: {e.details()}")
             response = None
@@ -118,12 +122,15 @@ class ApertureClient:
         control_point: str,
         explicit_labels: Optional[Dict[str, str]] = None,
         on_reject: Optional[Callable] = None,
+        fail_open: bool = True,
     ) -> Callable[[TWrappedFunction], TWrappedFunction]:
         def decorator(fn: TWrappedFunction) -> TWrappedFunction:
             @functools.wraps(fn)
             async def wrapper(*args, **kwargs):
                 with self.start_flow(control_point, explicit_labels) as flow:
-                    if flow.accepted:
+                    if flow.result == FlowResult.Accepted or (
+                        fail_open and flow.result == FlowResult.Unreachable
+                    ):
                         return await run_fn(fn, *args, **kwargs)
                     else:
                         if on_reject:

--- a/sdks/aperture-py/aperture_sdk/client.py
+++ b/sdks/aperture-py/aperture_sdk/client.py
@@ -106,7 +106,7 @@ class ApertureClient:
         try:
             # stub.Check is typed to accept an int, but it actually accepts a float
             timeout = typing.cast(int, self.timeout.total_seconds())
-            response = stub.Check(request, timeout=timeout)
+            response = stub.Check(request) if timeout == 0 else stub.Check(request, timeout=timeout)
         except grpc.RpcError as e:
             self.logger.debug(f"Aperture gRPC call failed: {e.details()}")
             response = None

--- a/sdks/aperture-py/aperture_sdk/const.py
+++ b/sdks/aperture-py/aperture_sdk/const.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 # Library name and version can be used by the user to create a resource that connects to telemetry exporter.
 library_name = "aperture-py"
-library_version = "v0.1.0"
+library_version = "v2.1.0"
 
 # Config defaults.
 default_rpc_timeout = timedelta(milliseconds=200)

--- a/sdks/aperture-py/pyproject.toml
+++ b/sdks/aperture-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aperture-sdk"
-version = "0.1.0"
+version = "2.1.0"
 description = "SDK to interact with the Aperture Agent"
 authors = ["FluxNinja <support@fluxninja.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added `FlowResult` enum with `Accepted`, `Rejected`, and `Unreachable` values
- Updated `result()` method to return `FlowResult` value based on decision type
- Modified `success()` method to check for `Unreachable` result

**Bug fix:**
- Updated default RPC timeout to 200 milliseconds
- Added `fail_open` parameter to `decorate` function
- Handled case where `timeout` is 0 in `start_flow` function

**Documentation:**
- Updated Python SDK manual to reflect changes in flow control logic

> 🎉 A new dawn for flow control, we see,
> With `FlowResult` enum, as easy as one, two, three.
> Unreachable or not, we now can tell,
> And celebrate this PR, where improvements dwell. 🚀
<!-- end of auto-generated comment: release notes by openai -->