### PR TITLE
Add headers from denied_response in actual response headers

### DIFF
--- a/docs/content/get-started/integrations/flow-control/gateway/nginx.md
+++ b/docs/content/get-started/integrations/flow-control/gateway/nginx.md
@@ -142,6 +142,7 @@ Follow these steps to configure Nginx to use the installed Aperture Lua module:
      init_by_lua_block {
        access = require "aperture-plugin.access"
        log = require "aperture-plugin.log"
+       headers = require "aperture-plugin.headers"
      }
      ...
    }
@@ -165,7 +166,21 @@ Follow these steps to configure Nginx to use the installed Aperture Lua module:
    }
    ```
 
-5. Add the `log_by_lua_block` section under the `http` block of the Nginx
+5. Add the `header_filter_by_lua_block` section under the `http` block of the
+   Nginx configuration to add the headers received from Aperture check to the
+   response being returned to the client:
+
+   ```bash
+   http {
+     ...
+     header_filter_by_lua_block {
+       headers()
+     }
+     ...
+   }
+   ```
+
+6. Add the `log_by_lua_block` section under the `http` block of the Nginx
    configuration to forward the OpenTelemetry logs to Aperture for all servers
    and locations after the response is received from upstream:
 
@@ -179,7 +194,7 @@ Follow these steps to configure Nginx to use the installed Aperture Lua module:
    }
    ```
 
-6. Aperture needs the upstream address of the server using
+7. Aperture needs the upstream address of the server using
    `destination_hostname` and `destination_port` variables and also
    `control_point` variable for referring the service in Aperture Policy, which
    need to be set from Nginx `location` block:
@@ -199,7 +214,7 @@ Follow these steps to configure Nginx to use the installed Aperture Lua module:
    }
    ```
 
-7. Below is how a complete Nginx configuration would look like:
+8. Below is how a complete Nginx configuration would look like:
 
    ```bash
    worker_processes auto;
@@ -219,6 +234,7 @@ Follow these steps to configure Nginx to use the installed Aperture Lua module:
      init_by_lua_block {
        access = require "aperture-plugin.access"
        log = require "aperture-plugin.log"
+       headers = require "aperture-plugin.headers"
      }
 
      access_by_lua_block {
@@ -231,6 +247,10 @@ Follow these steps to configure Nginx to use the installed Aperture Lua module:
 
      log_by_lua_block {
        log()
+     }
+
+     header_filter_by_lua_block {
+       headers()
      }
 
      server {

--- a/gateways/lua/aperture-kong-plugin-0.1.0-1.rockspec
+++ b/gateways/lua/aperture-kong-plugin-0.1.0-1.rockspec
@@ -21,5 +21,6 @@ build = {
       ["kong.plugins.aperture-plugin.handler"] = "kong/handler.lua",
       ["kong.plugins.aperture-plugin.schema"] = "kong/schema.lua",
       ["kong.plugins.aperture-plugin.log"] = "aperture-plugin/log.lua",
+      ["kong.plugins.aperture-plugin.headers"] = "aperture-plugin/headers.lua",
    },
 }

--- a/gateways/lua/aperture-nginx-plugin-0.1.0-1.rockspec
+++ b/gateways/lua/aperture-nginx-plugin-0.1.0-1.rockspec
@@ -19,5 +19,6 @@ build = {
    modules = {
       ["aperture-plugin.access"] = "aperture-plugin/access.lua",
       ["aperture-plugin.log"] = "aperture-plugin/log.lua",
+      ["aperture-plugin.headers"] = "aperture-plugin/headers.lua",
    },
 }

--- a/gateways/lua/aperture-plugin/access.lua
+++ b/gateways/lua/aperture-plugin/access.lua
@@ -123,6 +123,7 @@ return function(destination_hostname, destination_port, control_point)
       end
     elseif response_json.denied_response ~= nil then
       code = response_json.denied_response.status
+      ngx.ctx.denied_response_headers = response_json.denied_response.headers
     else
       code = 200
     end

--- a/gateways/lua/aperture-plugin/headers.lua
+++ b/gateways/lua/aperture-plugin/headers.lua
@@ -1,0 +1,8 @@
+return function(config)
+  local headers = ngx.ctx.denied_response_headers
+  if headers ~= nil then
+    for header_name, header_value in pairs(headers) do
+      ngx.header[header_name] = header_value
+    end
+  end
+end

--- a/gateways/lua/kong/handler.lua
+++ b/gateways/lua/kong/handler.lua
@@ -1,5 +1,6 @@
 local access = require "kong.plugins.aperture-plugin.access"
 local log = require "kong.plugins.aperture-plugin.log"
+local headers = require "kong.plugins.aperture-plugin.headers"
 local json = require "cjson"
 
 local ApertureHandler = {
@@ -15,5 +16,7 @@ function ApertureHandler:access(config)
 end
 
 ApertureHandler.log = log
+
+ApertureHandler.header_filter = headers
 
 return ApertureHandler

--- a/playground/resources/nginx/nginx_config.conf
+++ b/playground/resources/nginx/nginx_config.conf
@@ -15,6 +15,7 @@ http {
     init_by_lua_block {
         access = require "aperture-plugin.access"
         log = require "aperture-plugin.log"
+        headers = require "aperture-plugin.headers"
     }
 
     access_by_lua_block {
@@ -23,6 +24,10 @@ http {
         if authorized_status ~= ngx.HTTP_OK then
           return ngx.exit(authorized_status)
         end
+    }
+
+    header_filter_by_lua_block {
+        headers()
     }
 
     log_by_lua_block {


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added support for modifying response headers in Nginx and Kong plugins
- Introduced `aperture-plugin.headers` module to handle header modifications

> 🎉 A new feature takes the stage,
> Modifying headers, all the rage.
> Nginx and Kong now unite,
> To make responses just right. 🚀
<!-- end of auto-generated comment: release notes by openai -->