### PR TITLE
Re-add FAQ with expanded answers

### DIFF
--- a/.github/styles/Vocab/FluxNinja/accept.txt
+++ b/.github/styles/Vocab/FluxNinja/accept.txt
@@ -79,3 +79,4 @@ EnvoyFilter
 [Ll]aunch
 write_http
 Kubelet
+colocating

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -1,0 +1,61 @@
+---
+title: FAQ
+slug: faq
+sidebar_position: 7
+description: Frequently asked questions about FluxNinja Aperture.
+image: /assets/img/aperture_logo.png
+keywords:
+  - reliability
+  - overload
+  - concurrency
+  - aperture
+  - fluxninja
+  - microservices
+  - cloud
+  - auto-scale
+  - load management
+  - flow control
+  - faq
+---
+
+### Does the usage of Aperture entail extra overhead on requests?
+
+Aperture does not add any extra overhead. Aperture keeps the latency of the
+request as low as possible.
+
+### If we already have circuit breakers and rate limiting in EnvoyProxy, what are the benefits of using Aperture?
+
+Yes, EnvoyProxy does have, but Aperture does it better by having a global view
+of the system. Aperture can be used in conjunction with Envoy to provide a
+better experience.
+
+### Does Aperture reject requests immediately?
+
+No, Aperture does not reject requests immediately. Aperture queues the requests
+or rejects them based on the configuration.
+
+### If Aperture is rejecting or queuing requests, how will it impact the user experience?
+
+Aperture queues the requests or rejects them based on the configuration. The
+user experience is decided based on the configuration. If you want to prioritize
+the user experience, you can configure Aperture to queue the requests. If you
+want to prioritize the system health, you can configure Aperture to reject the
+requests.
+
+### How can we ensure the uniqueness of requests for the flow label when using Aperture?
+
+Aperture uses the flow label to identify the requests.
+
+### How does Aperture address the issue of delays in servers becoming available and reaching a healthy state, particularly in the context of auto-scaling?
+
+As Aperture observes the system, it can detect early sign of overload and can
+take necessary actions to prevent the system from becoming unhealthy. Therefore,
+server gets enough time to reach a healthy state.
+
+### Can the Aperture controller run in a non-containerized environment?
+
+No, the Aperture controller runs in a containerized environment only.
+
+### Is a Kubernetes cluster necessary for working with the Aperture Controller?
+
+Yes, the Aperture controller runs on a Kubernetes cluster.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -29,7 +29,7 @@ While Envoy does have some local and non-local rate-limiting capabilities, there
 are still benefits of using Aperture:
 
 - Aperture [Rate Limiter][] allows dynamically configuring Rate Limiter
-  parameters via signals from Policy.
+  parameters through signals from Policy.
 - The ability to configure global rate limiting without configuring any external
   components
   – [mesh of Agents is providing distributed counters](/concepts/flow-control/components/rate-limiter.md#distributed-counters).
@@ -40,12 +40,12 @@ are still benefits of using Aperture:
 
 ### Does Aperture reject requests immediately?
 
-- Rate Limiter always accepts/rejects immediately.
+- Rate Limiter always accepts or rejects immediately.
 - [Load Scheduler][] can hold a request within some time period (derived from
   gRPC request timeout).
 - Load Scheduler can also be configured in a way which effectively disables the
-  holding/scheduling part. If such configuration is desired, it will accept or
-  reject request immediately based on workload priorities and other factors.
+  holding/scheduling part. If such a configuration is desired, it will accept or
+  reject the request immediately based on workload priorities and other factors.
 
 ### If Aperture is rejecting or queuing requests, how will it impact the user experience?
 
@@ -56,8 +56,8 @@ or 503 Service Unavailable response and react accordingly.
 
 Remember that while receiving 503 by some of the users might seem like a thing
 to avoid, if such a case occurs an overload is already happening and Aperture is
-protecting your service from an unhealthy state (e.g. crashing) and therefore
-affecting even more users.
+protecting your service from an unhealthy state (for example crashing) and
+therefore affecting even more users.
 
 ### How can we define Flow Labels for workload prioritization or rate limiting?
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -25,15 +25,15 @@ colocating agents with services, it's a single RPC call within a single node.
 
 ### If we already have circuit breakers and rate limiting in EnvoyProxy, what are the benefits of using Aperture? {#envoy-rate-limit}
 
-While Envoy does have some local and non-local rate limiting capabilities, there
+While Envoy does have some local and non-local rate-limiting capabilities, there
 are still benefits of using Aperture:
 
 - Aperture [Rate Limiter][] allows dynamically configuring Rate Limiter
   parameters via signals from Policy.
-- Ability to configure global rate limiting without configuring any external
+- The ability to configure global rate limiting without configuring any external
   components
   – [mesh of Agents is providing distributed counters](/concepts/flow-control/components/rate-limiter.md#distributed-counters).
-- Rate-limiting decisions can be made locally on agent, if lazy sync is enabled.
+- Rate-limiting decisions can be made locally on agent if lazy sync is enabled.
 - In addition to Rate Limiter, Aperture also offers Load Scheduler, which Envoy
   doesn't have an equivalent of.
 
@@ -42,21 +42,21 @@ are still benefits of using Aperture:
 - Rate Limiter always accepts/rejects immediately.
 - [Load Scheduler][] can hold a request within some time period (derived from
   request's grpc-timeout).
-- Load Scheduler can also be configured in a way which effectively disables
+- Load Scheduler can also be configured in a way which effectively disables the
   holding/scheduling part. If such configuration is desired, it will
   accept/reject request immediately based on workload priorities and other
   factors.
 
 ### If Aperture is rejecting or queuing requests, how will it impact the user experience?
 
-Queuing requests should not affect user experience (apart of increased latency).
-When it comes to rejecting requests, clients (whether it's frontend code or some
-other service) should be prepared to receive 429 Too Many Requests or 503
-Service Unavailable response and react accordingly.
+Queuing requests should not affect user experience (apart from increased
+latency). When it comes to rejecting requests, clients (whether it's frontend
+code or some other service) should be prepared to receive 429 Too Many Requests
+or 503 Service Unavailable response and react accordingly.
 
-Remember that while receiving 503 by some of users may seem like a thing to
-avoid, if such case occurs overload is already happening and Aperture is
-protecting your service from unhealthy state (eg. crashing) and thus affecting
+Remember that while receiving 503 by some of the users may seem like a thing to
+avoid, if such a case occurs an overload is already happening and Aperture is
+protecting your service from unhealthy state (e.g. crashing) and thus affecting
 even more users.
 
 ### How can we define Flow Labels for workload prioritization or ratelimiting?
@@ -73,15 +73,15 @@ See the [Flow Label][] page for more details.
 
 As Aperture observes the system, it can detect early sign of overload and can
 take necessary actions to prevent the system from becoming unhealthy. Therefore,
-server gets enough time to reach a healthy state.
+the server gets enough time to reach a healthy state.
 
 It may happen that overload is happening too quickly for auto-scale to happen.
-In such case, load scheduler will queue or drop excessive load to protect
+In such case, Load Scheduler will queue or drop excessive load to protect
 existing services.
 
 ### Can the Aperture Controller run in a non-containerized environment?
 
-No, right now we only support deploying [Aperture Controller][] on a Kubernetes
+No, right now, we only support deploying [Aperture Controller][] on a Kubernetes
 cluster.
 
 [Rate Limiter]: /concepts/flow-control/components/rate-limiter.md

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -18,39 +18,63 @@ keywords:
   - faq
 ---
 
-### Does the usage of Aperture entail extra overhead on requests?
+### Does the usage of Aperture entail extra overhead on requests? {#request-overhead}
 
-Aperture does not add any extra overhead. Aperture keeps the latency of the
-request as low as possible.
+While Aperture does add some latency overhead, it's a minimal one. Thanks to
+colocating agents with services, it's a single RPC call within a single node.
 
-### If we already have circuit breakers and rate limiting in EnvoyProxy, what are the benefits of using Aperture?
+### If we already have circuit breakers and rate limiting in EnvoyProxy, what are the benefits of using Aperture? {#envoy-rate-limit}
 
-Yes, EnvoyProxy does have, but Aperture does it better by having a global view
-of the system. Aperture can be used in conjunction with Envoy to provide a
-better experience.
+While Envoy does have some local and non-local rate limiting capabilities, there
+are still benefits of using Aperture:
+
+- Aperture Rate limiter allows dynamically configuring Rate Limiter parameters
+  via signals from Policy.
+- Ability to configure global rate limiting without configuring any external
+  components
+  – [mesh of Agents is providing distributed counters](/concepts/flow-control/components/rate-limiter.md#distributed-counters).
+- Rate-limiting decisions can be made locally on agent, if lazy sync is enabled.
+- In addition to Rate Limiter, Aperture also offers Load Scheduler, which Envoy
+  doesn't have an equivalent of.
 
 ### Does Aperture reject requests immediately?
 
-No, Aperture does not reject requests immediately. Aperture queues the requests
-or rejects them based on the configuration.
+- Rate Limiter always accepts/rejects immediately.
+- Load Scheduler can hold a request within some time period (derived from
+  request's grpc-timeout)
+- Load Scheduler can also be configured which effectively disables
+  holding/scheduling part. If such configuration is desired, it will
+  accept/reject request immediately based on workload priorities and other
+  factors.
 
 ### If Aperture is rejecting or queuing requests, how will it impact the user experience?
 
-Aperture queues the requests or rejects them based on the configuration. The
-user experience is decided based on the configuration. If you want to prioritize
-the user experience, you can configure Aperture to queue the requests. If you
-want to prioritize the system health, you can configure Aperture to reject the
-requests.
+Queuing requests should not affect user experience (apart of increased latency).
+When it comes to rejecting requests, clients (whether it's frontend code or some
+other service) should be prepared to receive 429 Too Many Requests or 503
+Service Unavailable response and react accordingly. We're working on a library
+to make it easy to handle these scenarios and provide nice UX for end users.
+
+Remember that while receiving 503 by some of users may seem like a thing to
+avoid, if such case occurs overload is already happening Aperture is protecting
+your service from unhealthy state (eg. crashing) and thus affecting even more
+users.
 
 ### How can we ensure the uniqueness of requests for the flow label when using Aperture?
 
 Aperture uses the flow label to identify the requests.
+
+TODO (I don't get the question tbh)
 
 ### How does Aperture address the issue of delays in servers becoming available and reaching a healthy state, particularly in the context of auto-scaling?
 
 As Aperture observes the system, it can detect early sign of overload and can
 take necessary actions to prevent the system from becoming unhealthy. Therefore,
 server gets enough time to reach a healthy state.
+
+It may happen that overload is happening too quickly for auto-scale to happen.
+In such case, load scheduler will queue or drop excessive load to protect
+existing services.
 
 ### Can the Aperture controller run in a non-containerized environment?
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -42,11 +42,10 @@ are still benefits of using Aperture:
 
 - Rate Limiter always accepts/rejects immediately.
 - [Load Scheduler][] can hold a request within some time period (derived from
-  request's grpc-timeout).
+  gRPC request timeout).
 - Load Scheduler can also be configured in a way which effectively disables the
-  holding/scheduling part. If such configuration is desired, it will
-  accept/reject request immediately based on workload priorities and other
-  factors.
+  holding/scheduling part. If such configuration is desired, it will accept or
+  reject request immediately based on workload priorities and other factors.
 
 ### If Aperture is rejecting or queuing requests, how will it impact the user experience?
 
@@ -55,15 +54,16 @@ latency). When it comes to rejecting requests, clients (whether it's frontend
 code or some other service) should be prepared to receive 429 Too Many Requests
 or 503 Service Unavailable response and react accordingly.
 
-Remember that while receiving 503 by some of the users may seem like a thing to
-avoid, if such a case occurs an overload is already happening and Aperture is
-protecting your service from an unhealthy state (e.g. crashing) and thus
+Remember that while receiving 503 by some of the users might seem like a thing
+to avoid, if such a case occurs an overload is already happening and Aperture is
+protecting your service from an unhealthy state (e.g. crashing) and therefore
 affecting even more users.
 
-### How can we define Flow Labels for workload prioritization or ratelimiting?
+### How can we define Flow Labels for workload prioritization or rate limiting?
 
 - In proxy- or web-framework-based Control Point insertion, most request
-  metadata is already available as Flow Labels, e.g. `http.request.header.foo`.
+  metadata is already available as Flow Labels, for example
+  `http.request.header.foo`.
 - Already existing baggage is also available as Flow Labels.
 - With SDKs, it's possible to explicitly pass Flow Labels to the Check call.
 - Proxy-based integrations can use a [Classifier][] to define new Flow Labels.
@@ -76,14 +76,14 @@ As Aperture observes the system, it can detect early sign of overload and can
 take necessary actions to prevent the system from becoming unhealthy. Therefore,
 the server gets enough time to reach a healthy state.
 
-It may happen that overload is happening too quickly for auto-scale to happen.
+It might happen that overload is happening too quickly for auto-scale to happen.
 In such case, the Load Scheduler will queue or drop excessive load to protect
 existing services.
 
 ### Can the Aperture Controller run in a non-containerized environment?
 
-No, right now, we only support deploying [Aperture Controller][] on a Kubernetes
-cluster.
+No, as for now, we only support deploying [Aperture Controller][] on a
+Kubernetes cluster.
 
 [Rate Limiter]: /concepts/flow-control/components/rate-limiter.md
 [Load Scheduler]: /concepts/flow-control/components/load-scheduler.md

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -28,8 +28,8 @@ colocating agents with services, it's a single RPC call within a single node.
 While Envoy does have some local and non-local rate limiting capabilities, there
 are still benefits of using Aperture:
 
-- Aperture Rate limiter allows dynamically configuring Rate Limiter parameters
-  via signals from Policy.
+- Aperture [Rate Limiter][] allows dynamically configuring Rate Limiter
+  parameters via signals from Policy.
 - Ability to configure global rate limiting without configuring any external
   components
   – [mesh of Agents is providing distributed counters](/concepts/flow-control/components/rate-limiter.md#distributed-counters).
@@ -40,9 +40,9 @@ are still benefits of using Aperture:
 ### Does Aperture reject requests immediately?
 
 - Rate Limiter always accepts/rejects immediately.
-- Load Scheduler can hold a request within some time period (derived from
-  request's grpc-timeout)
-- Load Scheduler can also be configured which effectively disables
+- [Load Scheduler][] can hold a request within some time period (derived from
+  request's grpc-timeout).
+- Load Scheduler can also be configured in a way which effectively disables
   holding/scheduling part. If such configuration is desired, it will
   accept/reject request immediately based on workload priorities and other
   factors.
@@ -55,23 +55,19 @@ other service) should be prepared to receive 429 Too Many Requests or 503
 Service Unavailable response and react accordingly.
 
 Remember that while receiving 503 by some of users may seem like a thing to
-avoid, if such case occurs overload is already happening Aperture is protecting
-your service from unhealthy state (eg. crashing) and thus affecting even more
-users.
+avoid, if such case occurs overload is already happening and Aperture is
+protecting your service from unhealthy state (eg. crashing) and thus affecting
+even more users.
 
 ### How can we define Flow Labels for workload prioritization or ratelimiting?
 
 - In proxy- or web-framework-based Control Point insertion, most request
   metadata is already available as Flow Labels, e.g. `http.request.header.foo`.
 - Already existing baggage is also available as Flow Labels.
-- SDKs can explicitly pass Flow Labels to the Check call.
-- Proxy-based integrations can use a
-  [Classifier](https://docs.fluxninja.com/development/concepts/flow-control/resources/classifier)
-  to define new Flow Labels.
+- With SDKs, it's possible to explicitly pass Flow Labels to the Check call.
+- Proxy-based integrations can use a [Classifier][] to define new Flow Labels.
 
-See the
-[Flow Label sources](https://docs.fluxninja.com/development/concepts/flow-control/flow-label#sources)
-section for more details.
+See the [Flow Label][] page for more details.
 
 ### How does Aperture address the issue of delays in servers becoming available and reaching a healthy state, particularly in the context of auto-scaling?
 
@@ -85,5 +81,11 @@ existing services.
 
 ### Can the Aperture Controller run in a non-containerized environment?
 
-No, right now we only support deploying Aperture Controller on a Kubernetes
+No, right now we only support deploying [Aperture Controller][] on a Kubernetes
 cluster.
+
+[Rate Limiter]: /concepts/flow-control/components/rate-limiter.md
+[Load Scheduler]: /concepts/flow-control/components/load-scheduler.md
+[Classifier]: /concepts/flow-control/resources/classifier.md
+[Flow Label]: /concepts/flow-control/flow-label.md
+[Aperture Controller]: /get-started/installation/controller/controller.md

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -44,8 +44,9 @@ are still benefits of using Aperture:
 - [Load Scheduler][] can hold a request within some time period (derived from
   gRPC request timeout).
 - Load Scheduler can also be configured in a way which effectively disables the
-  holding/scheduling part. If such a configuration is desired, it will accept or
-  reject the request immediately based on workload priorities and other factors.
+  holding/scheduling part. If such a configuration is desired, it will either
+  accept or reject the request immediately based on workload priorities and
+  other factors.
 
 ### If Aperture is rejecting or queuing requests, how will it impact the user experience?
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -33,7 +33,8 @@ are still benefits of using Aperture:
 - The ability to configure global rate limiting without configuring any external
   components
   – [mesh of Agents is providing distributed counters](/concepts/flow-control/components/rate-limiter.md#distributed-counters).
-- Rate-limiting decisions can be made locally on agent if lazy sync is enabled.
+- Rate-limiting decisions can be made locally on the agent if lazy sync is
+  enabled.
 - In addition to Rate Limiter, Aperture also offers Load Scheduler, which Envoy
   doesn't have an equivalent of.
 
@@ -56,8 +57,8 @@ or 503 Service Unavailable response and react accordingly.
 
 Remember that while receiving 503 by some of the users may seem like a thing to
 avoid, if such a case occurs an overload is already happening and Aperture is
-protecting your service from unhealthy state (e.g. crashing) and thus affecting
-even more users.
+protecting your service from an unhealthy state (e.g. crashing) and thus
+affecting even more users.
 
 ### How can we define Flow Labels for workload prioritization or ratelimiting?
 
@@ -76,7 +77,7 @@ take necessary actions to prevent the system from becoming unhealthy. Therefore,
 the server gets enough time to reach a healthy state.
 
 It may happen that overload is happening too quickly for auto-scale to happen.
-In such case, Load Scheduler will queue or drop excessive load to protect
+In such case, the Load Scheduler will queue or drop excessive load to protect
 existing services.
 
 ### Can the Aperture Controller run in a non-containerized environment?

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -52,19 +52,26 @@ are still benefits of using Aperture:
 Queuing requests should not affect user experience (apart of increased latency).
 When it comes to rejecting requests, clients (whether it's frontend code or some
 other service) should be prepared to receive 429 Too Many Requests or 503
-Service Unavailable response and react accordingly. We're working on a library
-to make it easy to handle these scenarios and provide nice UX for end users.
+Service Unavailable response and react accordingly.
 
 Remember that while receiving 503 by some of users may seem like a thing to
 avoid, if such case occurs overload is already happening Aperture is protecting
 your service from unhealthy state (eg. crashing) and thus affecting even more
 users.
 
-### How can we ensure the uniqueness of requests for the flow label when using Aperture?
+### How can we define Flow Labels for workload prioritization or ratelimiting?
 
-Aperture uses the flow label to identify the requests.
+- In proxy- or web-framework-based Control Point insertion, most request
+  metadata is already available as Flow Labels, e.g. `http.request.header.foo`.
+- Already existing baggage is also available as Flow Labels.
+- SDKs can explicitly pass Flow Labels to the Check call.
+- Proxy-based integrations can use a
+  [Classifier](https://docs.fluxninja.com/development/concepts/flow-control/resources/classifier)
+  to define new Flow Labels.
 
-TODO (I don't get the question tbh)
+See the
+[Flow Label sources](https://docs.fluxninja.com/development/concepts/flow-control/flow-label#sources)
+section for more details.
 
 ### How does Aperture address the issue of delays in servers becoming available and reaching a healthy state, particularly in the context of auto-scaling?
 
@@ -76,10 +83,7 @@ It may happen that overload is happening too quickly for auto-scale to happen.
 In such case, load scheduler will queue or drop excessive load to protect
 existing services.
 
-### Can the Aperture controller run in a non-containerized environment?
+### Can the Aperture Controller run in a non-containerized environment?
 
-No, the Aperture controller runs in a containerized environment only.
-
-### Is a Kubernetes cluster necessary for working with the Aperture Controller?
-
-Yes, the Aperture controller runs on a Kubernetes cluster.
+No, right now we only support deploying Aperture Controller on a Kubernetes
+cluster.


### PR DESCRIPTION
Readded the FAQ skeleton (https://github.com/fluxninja/aperture/issues/1951)
and expanded some answers.

~~Some things I'm unsure about, added comments/TODOs.~~

[:framed_picture: Preview](https://github.com/fluxninja/aperture/blob/faq-reborn/docs/content/faq.md)

Resolves #1951 
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Expanded FAQ section in `docs/content/faq.md` with new questions and answers related to Aperture's usage, rate limiting, request rejection, flow label uniqueness, delays in server availability, and Kubernetes cluster requirements.

**Style:**
- Updated `.github/styles/Vocab/FluxNinja/accept.txt` with additional vocabulary.

> 🎉 A wealth of knowledge we now share,
> In our FAQ, answers everywhere! 📚
> Rate limits, requests, and more,
> FluxNinja's wisdom, we adore! 💡🥳
<!-- end of auto-generated comment: release notes by openai -->