### PR TITLE
Disable building Kubernetes Discovery when outside the cluster

### DIFF
--- a/pkg/policies/autoscale/kubernetes/actuators/podscaler/pod-scaler.go
+++ b/pkg/policies/autoscale/kubernetes/actuators/podscaler/pod-scaler.go
@@ -105,6 +105,10 @@ func setupPodScalerFactory(
 		log.Info().Msg("Kubernetes AutoScaler is disabled")
 		return nil
 	}
+	if k8sClient == nil {
+		log.Info().Msg("Not in Kubernetes cluster, omitting AutoScaler")
+		return nil
+	}
 
 	agentGroup := ai.GetAgentGroup()
 	etcdPath := path.Join(paths.PodScalerDecisionsPath)

--- a/pkg/policies/autoscale/kubernetes/discovery/provide.go
+++ b/pkg/policies/autoscale/kubernetes/discovery/provide.go
@@ -48,6 +48,10 @@ type FxIn struct {
 
 // provideAutoScaleControlPoints provides Kubernetes AutoScaler and starts Kubernetes control point discovery if enabled.
 func provideAutoScaleControlPoints(in FxIn) (AutoScaleControlPoints, error) {
+	if in.KubernetesClient == nil {
+		log.Error().Msg("Kubernetes client is not available, skipping Kubernetes AutoScaler creation and control point discovery")
+		return nil, nil
+	}
 	pn, err := newPodNotifier(in.PrometheusRegistry, in.ElectionTrackers, in.Lifecycle, in.AgentInfo.GetAgentGroup())
 	if err != nil {
 		return nil, err
@@ -59,10 +63,6 @@ func provideAutoScaleControlPoints(in FxIn) (AutoScaleControlPoints, error) {
 
 	if !in.Config.Enabled {
 		log.Info().Msg("Skipping Kubernetes Control Point Discovery since AutoScale is disabled")
-		return controlPointCache, nil
-	}
-	if in.KubernetesClient == nil {
-		log.Error().Msg("Kubernetes client is not available, skipping Kubernetes Control Point Discovery")
 		return controlPointCache, nil
 	}
 	cpd, err := newControlPointDiscovery(in.Election, in.KubernetesClient, controlPointCache)


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Support running outside Kubernetes cluster
  - Return nil client if not in a Kubernetes environment
  - Disable Kubernetes AutoScaler when not running inside a cluster
  - Skip AutoScaler creation and control point discovery if the Kubernetes client is unavailable
```

> 🎉 Outside the cluster, we now can run,
> With AutoScaler disabled, it's still fun! 🚀
> Nil clients returned, no more dismay,
> Our code adapts, come what may! 😄
<!-- end of auto-generated comment: release notes by openai -->