### PR TITLE
Fixed aperturectl apply when controller address is provided

### DIFF
--- a/cmd/aperturectl/cmd/agents.go
+++ b/cmd/aperturectl/cmd/agents.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 var agentsCmd = &cobra.Command{
-	Use:               "agents {--kube | --controller ADDRESS}",
+	Use:               "agents",
 	Short:             "List connected agents",
 	Long:              `List connected agents`,
 	SilenceErrors:     true,

--- a/cmd/aperturectl/cmd/apply/dynamic-config.go
+++ b/cmd/aperturectl/cmd/apply/dynamic-config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/structpb"
+	appsv1 "k8s.io/api/apps/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,61 +61,82 @@ var ApplyDynamicConfigCmd = &cobra.Command{
 			return fmt.Errorf("failed to connect to Kubernetes: %w", err)
 		}
 
-		c, err := k8sclient.New(kubeRestConfig, k8sclient.Options{
-			Scheme: scheme.Scheme,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create Kubernetes client: %w", err)
-		}
-
-		deployment, err := utils.GetControllerDeployment(kubeRestConfig, controllerNs)
-		if err != nil {
-			return err
-		}
-
 		dynamicConfigYAML := make(map[string]interface{})
 		err = yaml.Unmarshal(dynamicConfigBytes, &dynamicConfigYAML)
 		if err != nil {
 			return fmt.Errorf("failed to parse DynamicConfig YAML: %w", err)
 		}
-		dynamicConfigBytes, err := json.Marshal(dynamicConfigYAML)
-		if err != nil {
-			return fmt.Errorf("failed to parse DynamicConfig JSON: %w", err)
-		}
 
-		policy := &policyv1alpha1.Policy{}
-		err = c.Get(context.Background(), k8sclient.ObjectKey{
-			Namespace: deployment.Namespace,
-			Name:      policyName,
-		}, policy)
-		if err != nil {
-			if apimeta.IsNoMatchError(err) {
-				var dynamicConfigStruct *structpb.Struct
-				dynamicConfigStruct, err = structpb.NewStruct(dynamicConfigYAML)
-				if err != nil {
-					return fmt.Errorf("failed to parse DynamicConfig Struct: %w", err)
-				}
-				request := languagev1.PostDynamicConfigRequest{
-					PolicyName:    policyName,
-					DynamicConfig: dynamicConfigStruct,
-				}
-				_, err = client.PostDynamicConfig(context.Background(), &request)
-				if err != nil {
-					return fmt.Errorf("failed to update DynamicConfig: %w", err)
+		if isKube {
+			var kubeClient k8sclient.Client
+			kubeClient, err = k8sclient.New(kubeRestConfig, k8sclient.Options{
+				Scheme: scheme.Scheme,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create Kubernetes client: %w", err)
+			}
+
+			var deployment *appsv1.Deployment
+			deployment, err = utils.GetControllerDeployment(kubeRestConfig, controllerNs)
+			if err != nil {
+				return err
+			}
+
+			dynamicConfigBytes, err = json.Marshal(dynamicConfigYAML)
+			if err != nil {
+				return fmt.Errorf("failed to parse DynamicConfig JSON: %w", err)
+			}
+
+			policy := &policyv1alpha1.Policy{}
+			err = kubeClient.Get(context.Background(), k8sclient.ObjectKey{
+				Namespace: deployment.Namespace,
+				Name:      policyName,
+			}, policy)
+			if err != nil {
+				if apimeta.IsNoMatchError(err) {
+					err = applyDynamicConfigUsingAPI(dynamicConfigYAML)
+					if err != nil {
+						return err
+					}
+				} else {
+					return fmt.Errorf("failed to get Policy '%s': %w", policyName, err)
 				}
 			} else {
-				return fmt.Errorf("failed to get Policy '%s': %w", policyName, err)
+				policy.DynamicConfig.Raw = dynamicConfigBytes
+				err = kubeClient.Update(context.Background(), policy)
+				if err != nil {
+					return fmt.Errorf("failed to update DynamicConfig for policy '%s': %w", policyName, err)
+				}
 			}
 		} else {
-			policy.DynamicConfig.Raw = dynamicConfigBytes
-			err = c.Update(context.Background(), policy)
+			err = applyDynamicConfigUsingAPI(dynamicConfigYAML)
 			if err != nil {
-				return fmt.Errorf("failed to update DynamicConfig for policy '%s': %w", policyName, err)
+				return err
 			}
 		}
 
-		log.Info().Str("policy", policyName).Str("namespace", deployment.Namespace).Msg("Updated DynamicConfig successfully")
+		log.Info().Str("policy", policyName).Msg("Updated DynamicConfig successfully")
 
 		return nil
 	},
+}
+
+// applyDynamicConfig applies the DynamicConfig to the Policy using API.
+func applyDynamicConfigUsingAPI(dynamicConfigYAML map[string]interface{}) error {
+	var dynamicConfigStruct *structpb.Struct
+	var err error
+	dynamicConfigStruct, err = structpb.NewStruct(dynamicConfigYAML)
+	if err != nil {
+		return fmt.Errorf("failed to parse DynamicConfig Struct: %w", err)
+	}
+	request := languagev1.PostDynamicConfigRequest{
+		PolicyName:    policyName,
+		DynamicConfig: dynamicConfigStruct,
+	}
+	_, err = client.PostDynamicConfig(context.Background(), &request)
+	if err != nil {
+		return fmt.Errorf("failed to update DynamicConfig: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/aperturectl/cmd/apply/dynamic-config.go
+++ b/cmd/aperturectl/cmd/apply/dynamic-config.go
@@ -69,7 +69,7 @@ var ApplyDynamicConfigCmd = &cobra.Command{
 
 		if Controller.IsKube() {
 			var kubeClient k8sclient.Client
-			kubeClient, err = k8sclient.New(kubeRestConfig, k8sclient.Options{
+			kubeClient, err = k8sclient.New(Controller.GetKubeRestConfig(), k8sclient.Options{
 				Scheme: scheme.Scheme,
 			})
 			if err != nil {
@@ -77,7 +77,7 @@ var ApplyDynamicConfigCmd = &cobra.Command{
 			}
 
 			var deployment *appsv1.Deployment
-			deployment, err = utils.GetControllerDeployment(kubeRestConfig, controllerNs)
+			deployment, err = utils.GetControllerDeployment(Controller.GetKubeRestConfig(), controllerNs)
 			if err != nil {
 				return err
 			}

--- a/cmd/aperturectl/cmd/apply/dynamic-config.go
+++ b/cmd/aperturectl/cmd/apply/dynamic-config.go
@@ -67,7 +67,7 @@ var ApplyDynamicConfigCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse DynamicConfig YAML: %w", err)
 		}
 
-		if isKube {
+		if Controller.IsKube() {
 			var kubeClient k8sclient.Client
 			kubeClient, err = k8sclient.New(kubeRestConfig, k8sclient.Options{
 				Scheme: scheme.Scheme,

--- a/cmd/aperturectl/cmd/apply/policy.go
+++ b/cmd/aperturectl/cmd/apply/policy.go
@@ -62,7 +62,7 @@ aperturectl apply policy --dir=policies`,
 			for policyIndex := range model.Selected {
 				fileName := policies[policyIndex]
 				if err := applyPolicy(fileName); err != nil {
-					log.Error().Err(err).Msgf("failed to apply policy '%s' on Kubernetes.", fileName)
+					log.Error().Err(err).Msgf("failed to apply policy '%s'.", fileName)
 				}
 			}
 			return nil
@@ -119,60 +119,68 @@ func createAndApplyPolicy(policy *languagev1.Policy, name string) error {
 		return err
 	}
 
-	policyCR := &policyv1alpha1.Policy{}
-	policyCR.Spec.Raw = policyBytes
-	policyCR.Name = name
+	if isKube {
+		policyCR := &policyv1alpha1.Policy{}
+		policyCR.Spec.Raw = policyBytes
+		policyCR.Name = name
 
-	deployment, err := utils.GetControllerDeployment(kubeRestConfig, controllerNs)
-	if err != nil {
-		return err
-	}
-	controllerNs = deployment.GetNamespace()
+		deployment, err := utils.GetControllerDeployment(kubeRestConfig, controllerNs)
+		if err != nil {
+			return err
+		}
+		controllerNs = deployment.GetNamespace()
 
-	err = api.AddToScheme(scheme.Scheme)
-	if err != nil {
-		return fmt.Errorf("failed to connect to Kubernetes: %w", err)
-	}
+		err = api.AddToScheme(scheme.Scheme)
+		if err != nil {
+			return fmt.Errorf("failed to connect to Kubernetes: %w", err)
+		}
 
-	kubeClient, err := k8sclient.New(kubeRestConfig, k8sclient.Options{
-		Scheme: scheme.Scheme,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
+		kubeClient, err := k8sclient.New(kubeRestConfig, k8sclient.Options{
+			Scheme: scheme.Scheme,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create Kubernetes client: %w", err)
+		}
 
-	policyCR.Namespace = deployment.GetNamespace()
-	policyCR.Annotations = map[string]string{
-		"fluxninja.com/validate": "true",
-	}
-	err = kubeClient.Create(context.Background(), policyCR)
-	if err != nil {
-		if apimeta.IsNoMatchError(err) {
-			var isUpdated bool
-			isUpdated, updatePolicyUsingAPIErr := updatePolicyUsingAPI(name, policy)
-			if !isUpdated {
-				return updatePolicyUsingAPIErr
+		policyCR.Namespace = deployment.GetNamespace()
+		policyCR.Annotations = map[string]string{
+			"fluxninja.com/validate": "true",
+		}
+		err = kubeClient.Create(context.Background(), policyCR)
+		if err != nil {
+			if apimeta.IsNoMatchError(err) {
+				var isUpdated bool
+				isUpdated, updatePolicyUsingAPIErr := updatePolicyUsingAPI(name, policy)
+				if !isUpdated {
+					return updatePolicyUsingAPIErr
+				}
+			} else if apierrors.IsAlreadyExists(err) {
+				var update bool
+				update, checkForUpdateErr := checkForUpdate(name)
+				if checkForUpdateErr != nil {
+					return fmt.Errorf("failed to check for update: %w", checkForUpdateErr)
+				}
+				if !update {
+					log.Info().Str("policy", name).Str("namespace", deployment.GetNamespace()).Msg("Skipping update of Policy")
+					return nil
+				}
+				updatePolicyCRErr := updatePolicyCR(name, policyCR, kubeClient)
+				if updatePolicyCRErr != nil {
+					return updatePolicyCRErr
+				}
+			} else {
+				return fmt.Errorf("failed to apply policy in Kubernetes: %w", err)
 			}
-		} else if apierrors.IsAlreadyExists(err) {
-			var update bool
-			update, checkForUpdateErr := checkForUpdate(name)
-			if checkForUpdateErr != nil {
-				return fmt.Errorf("failed to check for update: %w", checkForUpdateErr)
-			}
-			if !update {
-				log.Info().Str("policy", name).Str("namespace", deployment.GetNamespace()).Msg("Skipping update of Policy")
-				return nil
-			}
-			updatePolicyCRErr := updatePolicyCR(name, policyCR, kubeClient)
-			if updatePolicyCRErr != nil {
-				return updatePolicyCRErr
-			}
-		} else {
-			return fmt.Errorf("failed to apply policy in Kubernetes: %w", err)
+		}
+
+	} else {
+		isUpdated, updatePolicyUsingAPIErr := updatePolicyUsingAPI(name, policy)
+		if !isUpdated {
+			return updatePolicyUsingAPIErr
 		}
 	}
 
-	log.Info().Str("policy", name).Str("namespace", deployment.GetNamespace()).Msg("Applied Policy successfully")
+	log.Info().Str("policy", name).Msg("Applied Policy successfully")
 	return nil
 }
 

--- a/cmd/aperturectl/cmd/apply/policy.go
+++ b/cmd/aperturectl/cmd/apply/policy.go
@@ -119,7 +119,7 @@ func createAndApplyPolicy(policy *languagev1.Policy, name string) error {
 		return err
 	}
 
-	if isKube {
+	if Controller.IsKube() {
 		policyCR := &policyv1alpha1.Policy{}
 		policyCR.Spec.Raw = policyBytes
 		policyCR.Name = name

--- a/cmd/aperturectl/cmd/apply/policy.go
+++ b/cmd/aperturectl/cmd/apply/policy.go
@@ -124,7 +124,7 @@ func createAndApplyPolicy(policy *languagev1.Policy, name string) error {
 		policyCR.Spec.Raw = policyBytes
 		policyCR.Name = name
 
-		deployment, err := utils.GetControllerDeployment(kubeRestConfig, controllerNs)
+		deployment, err := utils.GetControllerDeployment(Controller.GetKubeRestConfig(), controllerNs)
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func createAndApplyPolicy(policy *languagev1.Policy, name string) error {
 			return fmt.Errorf("failed to connect to Kubernetes: %w", err)
 		}
 
-		kubeClient, err := k8sclient.New(kubeRestConfig, k8sclient.Options{
+		kubeClient, err := k8sclient.New(Controller.GetKubeRestConfig(), k8sclient.Options{
 			Scheme: scheme.Scheme,
 		})
 		if err != nil {

--- a/cmd/aperturectl/cmd/apply/root.go
+++ b/cmd/aperturectl/cmd/apply/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
 
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
@@ -14,10 +13,8 @@ var (
 	// Controller is the controller connection object.
 	Controller utils.ControllerConn
 
-	kubeConfig     string
-	kubeRestConfig *rest.Config
-	client         cmdv1.ControllerClient
-	controllerNs   string
+	client       cmdv1.ControllerClient
+	controllerNs string
 )
 
 func init() {
@@ -41,17 +38,7 @@ Use this command to apply the Aperture Policies.`,
 			return fmt.Errorf("failed to run controller pre-run: %w", err)
 		}
 
-		if Controller.IsKube() {
-			kubeRestConfig, err = utils.GetKubeConfig(kubeConfig)
-			if err != nil {
-				return fmt.Errorf("failed to get kube config: %w", err)
-			}
-
-			controllerNs, err = cmd.Flags().GetString("controller-ns")
-			if err != nil {
-				return fmt.Errorf("failed to get controller namespace flag: %w", err)
-			}
-		}
+		controllerNs = utils.GetControllerNs()
 
 		client, err = Controller.Client()
 		if err != nil {

--- a/cmd/aperturectl/cmd/apply/root.go
+++ b/cmd/aperturectl/cmd/apply/root.go
@@ -8,18 +8,23 @@ import (
 
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
+	"github.com/fluxninja/aperture/v2/pkg/log"
 )
 
 var (
+	// Controller is the controller connection object.
+	Controller utils.ControllerConn
+
 	kubeConfig     string
 	kubeRestConfig *rest.Config
-	controller     utils.ControllerConn
 	client         cmdv1.ControllerClient
 	controllerNs   string
+	isKube         bool
+	controllerAddr string
 )
 
 func init() {
-	controller.InitFlags(ApplyCmd.PersistentFlags())
+	Controller.InitFlags(ApplyCmd.PersistentFlags())
 
 	ApplyCmd.AddCommand(ApplyPolicyCmd)
 	ApplyCmd.AddCommand(ApplyDynamicConfigCmd)
@@ -34,44 +39,49 @@ Use this command to apply the Aperture Policies.`,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		kubeRestConfig, err = utils.GetKubeConfig(kubeConfig)
-		if err != nil {
-			return fmt.Errorf("failed to get kube config: %w", err)
-		}
-
-		controllerNs, err = cmd.Flags().GetString("controller-ns")
-		if err != nil {
-			return fmt.Errorf("failed to get controller namespace flag: %w", err)
-		}
-
-		controllerAddr, err := cmd.Flags().GetString("controller")
+		controllerAddr, err = cmd.Flags().GetString("controller")
 		if err != nil {
 			return fmt.Errorf("failed to get controller address flag: %w", err)
 		}
 
-		kube, err := cmd.Flags().GetBool("kube")
+		isKube, err = cmd.Flags().GetBool("kube")
 		if err != nil {
 			return fmt.Errorf("failed to get kube flag: %w", err)
 		}
 
-		if controllerAddr == "" && !kube {
+		if controllerAddr == "" && !isKube {
+			log.Info().Msg("Both --controller and --kube flags are not set. Assuming --kube=true.")
 			err = cmd.Flags().Set("kube", "true")
 			if err != nil {
 				return fmt.Errorf("failed to set kube flag: %w", err)
 			}
+
+			Controller.IsKube = true
 		}
 
-		err = controller.PreRunE(cmd, args)
+		if isKube {
+			kubeRestConfig, err = utils.GetKubeConfig(kubeConfig)
+			if err != nil {
+				return fmt.Errorf("failed to get kube config: %w", err)
+			}
+
+			controllerNs, err = cmd.Flags().GetString("controller-ns")
+			if err != nil {
+				return fmt.Errorf("failed to get controller namespace flag: %w", err)
+			}
+		}
+
+		err = Controller.PreRunE(cmd, args)
 		if err != nil {
 			return fmt.Errorf("failed to run controller pre-run: %w", err)
 		}
 
-		client, err = controller.Client()
+		client, err = Controller.Client()
 		if err != nil {
 			return fmt.Errorf("failed to get controller client: %w", err)
 		}
 
 		return nil
 	},
-	PersistentPostRun: controller.PostRun,
+	PersistentPostRun: Controller.PostRun,
 }

--- a/cmd/aperturectl/cmd/apply/root.go
+++ b/cmd/aperturectl/cmd/apply/root.go
@@ -57,6 +57,7 @@ Use this command to apply the Aperture Policies.`,
 			}
 
 			Controller.IsKube = true
+			isKube = true
 		}
 
 		if isKube {

--- a/cmd/aperturectl/cmd/autoscale/control-points.go
+++ b/cmd/aperturectl/cmd/autoscale/control-points.go
@@ -18,7 +18,7 @@ var ControlPointsCmd = &cobra.Command{
 	Short:         "List AutoScale control points",
 	Long:          `List AutoScale control points`,
 	SilenceErrors: true,
-	Example:       `aperturectl auto-scale control-points --kube`,
+	Example:       `aperturectl auto-scale control-points`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		client, err := controller.Client()
 		if err != nil {

--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -149,12 +149,8 @@ aperturectl blueprints generate --name=policies/static-rate-limiting --values-fi
 		log.Info().Msgf("Generated manifests at %s", updatedOutputDir)
 
 		if applyPolicy {
+			apply.Controller = controllerConn
 			err = apply.ApplyPolicyCmd.Flag("dir").Value.Set(updatedOutputDir)
-			if err != nil {
-				return err
-			}
-
-			err = apply.ApplyPolicyCmd.Flag("kube").Value.Set("true")
 			if err != nil {
 				return err
 			}

--- a/cmd/aperturectl/cmd/delete/root.go
+++ b/cmd/aperturectl/cmd/delete/root.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
@@ -11,7 +12,6 @@ import (
 )
 
 var (
-	kubeConfig     string
 	kubeRestConfig *rest.Config
 	controller     utils.ControllerConn
 	client         cmdv1.ControllerClient
@@ -39,41 +39,16 @@ Use this command to delete the Aperture Policies.`,
 		}
 
 		var err error
-		kubeRestConfig, err = utils.GetKubeConfig(kubeConfig)
-		if err != nil {
-			return err
-		}
-
-		controllerNs, err = cmd.Flags().GetString("controller-ns")
-		if err != nil {
-			return err
-		}
-
-		controllerAddr, err := cmd.Flags().GetString("controller")
-		if err != nil {
-			return err
-		}
-
-		kube, err := cmd.Flags().GetBool("kube")
-		if err != nil {
-			return err
-		}
-
-		if controllerAddr == "" && !kube {
-			err = cmd.Flags().Set("kube", "true")
-			if err != nil {
-				return err
-			}
-		}
-
 		err = controller.PreRunE(cmd, args)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to run controller pre-run: %w", err)
 		}
+
+		controllerNs = utils.GetControllerNs()
 
 		client, err = controller.Client()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get controller client: %w", err)
 		}
 		return nil
 	},

--- a/cmd/aperturectl/cmd/discovery/entities.go
+++ b/cmd/aperturectl/cmd/discovery/entities.go
@@ -24,11 +24,11 @@ var EntitiesCmd = &cobra.Command{
 	Short:         "List AutoScale control points",
 	Long:          `List AutoScale control points`,
 	SilenceErrors: true,
-	Example: `aperturectl discovery entities --kube
+	Example: `aperturectl discovery entities
 
-aperturectl discovery entities --kube --find-by="name=service1-demo-app-7dfdf9c698-4wmlt"
+aperturectl discovery entities --find-by="name=service1-demo-app-7dfdf9c698-4wmlt"
 
-aperturectl discovery entities --kube --find-by=“ip=10.244.1.24”`,
+aperturectl discovery entities --find-by=“ip=10.244.1.24”`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		client, err := controller.Client()
 		if err != nil {

--- a/cmd/aperturectl/cmd/flowcontrol/control-points.go
+++ b/cmd/aperturectl/cmd/flowcontrol/control-points.go
@@ -18,7 +18,7 @@ var ControlPointsCmd = &cobra.Command{
 	Short:         "List Flow Control control points",
 	Long:          `List Flow Control control points`,
 	SilenceErrors: true,
-	Example:       `aperturectl flow-control control-points --kube`,
+	Example:       `aperturectl flow-control control-points`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		client, err := controller.Client()
 		if err != nil {

--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -15,6 +15,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -31,9 +32,12 @@ var controllerNs string
 // ControllerConn manages flags for connecting to controller – either via
 // address or kubeconfig.
 type ControllerConn struct {
+	// IsKube is true if controller should be found in Kubernetes cluster.
+	IsKube bool
+
 	controllerAddr string
 	allowInsecure  bool
-	isKube         bool
+	skipVerify     bool
 	kubeConfigPath string
 	kubeConfig     *rest.Config
 
@@ -53,10 +57,16 @@ func (c *ControllerConn) InitFlags(flags *flag.FlagSet) {
 		&c.allowInsecure,
 		"insecure",
 		false,
-		"Allow insecure connection to controller",
+		"Allow connection to controller running without TLS",
 	)
 	flags.BoolVar(
-		&c.isKube,
+		&c.skipVerify,
+		"skip-verify",
+		false,
+		"Skip TLS certificate verification while connecting to controller",
+	)
+	flags.BoolVar(
+		&c.IsKube,
 		"kube",
 		false,
 		"Find controller in Kubernetes cluster, instead of connecting directly",
@@ -77,19 +87,19 @@ func (c *ControllerConn) InitFlags(flags *flag.FlagSet) {
 
 // PreRunE verifies flags (optionally loading kubeconfig) and should be run at PreRunE stage.
 func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
-	if c.controllerAddr == "" && !c.isKube {
+	if c.controllerAddr == "" && !c.IsKube {
 		return errors.New("either --controller or --kube should be set")
 	}
 
-	if c.controllerAddr != "" && c.isKube {
+	if c.controllerAddr != "" && c.IsKube {
 		return errors.New("--controller cannot be used with --kube")
 	}
 
-	if c.kubeConfigPath != "" && !c.isKube {
+	if c.kubeConfigPath != "" && !c.IsKube {
 		return errors.New("--kube-config can only be used with --kube")
 	}
 
-	if c.isKube {
+	if c.IsKube {
 		var err error
 		c.kubeConfig, err = GetKubeConfig(c.kubeConfigPath)
 		if err != nil {
@@ -109,12 +119,14 @@ func (c *ControllerConn) Client() (cmdv1.ControllerClient, error) {
 	var addr string
 	var cred credentials.TransportCredentials
 	if c.allowInsecure {
+		cred = insecure.NewCredentials()
+	} else if c.skipVerify {
 		cred = credentials.NewTLS(&tls.Config{
 			InsecureSkipVerify: true, //nolint:gosec // Requires enabling CLI option
 		})
 	}
 
-	if !c.isKube {
+	if !c.IsKube {
 		addr = c.controllerAddr
 
 		if cred == nil {

--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -275,3 +275,13 @@ func (c *ControllerConn) startPortForward() (localPort uint16, cert []byte, err 
 func (c *ControllerConn) IsKube() bool {
 	return c.kube
 }
+
+// GetKubeRestConfig returns kubeRestConfig.
+func (c *ControllerConn) GetKubeRestConfig() *rest.Config {
+	return c.kubeConfig
+}
+
+// GetControllerNs returns namespace in which the Aperture Controller is running.
+func GetControllerNs() string {
+	return controllerNs
+}

--- a/docs/content/reference/aperturectl/agents/agents.md
+++ b/docs/content/reference/aperturectl/agents/agents.md
@@ -26,9 +26,10 @@ aperturectl agents {--kube | --controller ADDRESS} [flags]
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for agents
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/agents/agents.md
+++ b/docs/content/reference/aperturectl/agents/agents.md
@@ -17,7 +17,7 @@ List connected agents
 List connected agents
 
 ```
-aperturectl agents {--kube | --controller ADDRESS} [flags]
+aperturectl agents [flags]
 ```
 
 ### Options

--- a/docs/content/reference/aperturectl/apply/apply.md
+++ b/docs/content/reference/aperturectl/apply/apply.md
@@ -22,9 +22,10 @@ Use this command to apply the Aperture Policies.
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for apply
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
+++ b/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
@@ -39,9 +39,10 @@ aperturectl apply dynamic-config --policy=static-rate-limiting --file=dynamic-co
 ```
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/apply/policy/policy.md
+++ b/docs/content/reference/aperturectl/apply/policy/policy.md
@@ -41,9 +41,10 @@ aperturectl apply policy --dir=policies
 ```
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/auto-scale/auto-scale.md
+++ b/docs/content/reference/aperturectl/auto-scale/auto-scale.md
@@ -22,9 +22,10 @@ Use this command to query information about active AutoScale integrations
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for auto-scale
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
@@ -23,7 +23,7 @@ aperturectl auto-scale control-points [flags]
 ### Examples
 
 ```
-aperturectl auto-scale control-points --kube
+aperturectl auto-scale control-points
 ```
 
 ### Options

--- a/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
@@ -37,9 +37,10 @@ aperturectl auto-scale control-points --kube
 ```
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/blueprints/generate/generate.md
+++ b/docs/content/reference/aperturectl/blueprints/generate/generate.md
@@ -36,7 +36,7 @@ aperturectl blueprints generate --name=policies/static-rate-limiting --values-fi
       --controller-ns string   Namespace in which the Aperture Controller is running
       --graph-depth int        Max depth of the graph when generating DOT and Mermaid files (default 1)
   -h, --help                   help for generate
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
       --name string            Name of the Aperture Blueprint to generate Aperture Policy resources for
@@ -44,6 +44,7 @@ aperturectl blueprints generate --name=policies/static-rate-limiting --values-fi
       --no-yaml-modeline       Do not add YAML language server modeline to generated YAML files
       --output-dir string      Directory path where the generated Policy resources will be stored. If not provided, will use current directory
       --overwrite              Overwrite existing output directory
+      --skip-verify            Skip TLS certificate verification while connecting to controller
       --values-file string     Path to the values file for Blueprint's input
 ```
 

--- a/docs/content/reference/aperturectl/delete/delete.md
+++ b/docs/content/reference/aperturectl/delete/delete.md
@@ -22,10 +22,11 @@ Use this command to delete the Aperture Policies.
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for delete
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
       --policy string          Name of the Policy to delete
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/delete/policy/policy.md
+++ b/docs/content/reference/aperturectl/delete/policy/policy.md
@@ -37,10 +37,11 @@ aperturectl delete policy --policy=static-rate-limiting
 ```
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
       --policy string          Name of the Policy to delete
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/discovery/discovery.md
+++ b/docs/content/reference/aperturectl/discovery/discovery.md
@@ -22,9 +22,10 @@ Use this command to query information about active Discovery integrations
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for discovery
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/discovery/entities/entities.md
+++ b/docs/content/reference/aperturectl/discovery/entities/entities.md
@@ -42,9 +42,10 @@ aperturectl discovery entities --kube --find-by=“ip=10.244.1.24”
 ```
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/discovery/entities/entities.md
+++ b/docs/content/reference/aperturectl/discovery/entities/entities.md
@@ -23,11 +23,11 @@ aperturectl discovery entities [flags]
 ### Examples
 
 ```
-aperturectl discovery entities --kube
+aperturectl discovery entities
 
-aperturectl discovery entities --kube --find-by="name=service1-demo-app-7dfdf9c698-4wmlt"
+aperturectl discovery entities --find-by="name=service1-demo-app-7dfdf9c698-4wmlt"
 
-aperturectl discovery entities --kube --find-by=“ip=10.244.1.24”
+aperturectl discovery entities --find-by=“ip=10.244.1.24”
 ```
 
 ### Options

--- a/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
@@ -23,7 +23,7 @@ aperturectl flow-control control-points [flags]
 ### Examples
 
 ```
-aperturectl flow-control control-points --kube
+aperturectl flow-control control-points
 ```
 
 ### Options

--- a/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
@@ -37,9 +37,10 @@ aperturectl flow-control control-points --kube
 ```
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/flow-control/flow-control.md
+++ b/docs/content/reference/aperturectl/flow-control/flow-control.md
@@ -22,9 +22,10 @@ Use this command to query information about active Flow Control integrations
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for flow-control
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/flow-control/preview/preview.md
+++ b/docs/content/reference/aperturectl/flow-control/preview/preview.md
@@ -34,9 +34,10 @@ aperturectl flow-control preview [--http] SERVICE CONTROL_POINT [flags]
 ```
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
-      --insecure               Allow insecure connection to controller
+      --insecure               Allow connection to controller running without TLS
       --kube                   Find controller in Kubernetes cluster, instead of connecting directly
       --kube-config string     Path to the Kubernetes cluster config. Defaults to '~/.kube/config' or $KUBECONFIG
+      --skip-verify            Skip TLS certificate verification while connecting to controller
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
### Description of change

There was an issue where even if we provide `--controller` flag, it was trying to connect to kubernetes.
Also, added support for insecure controller communication.
Also, --kube flag is now default for all subcommands and can be omitted.

##### Checklist

- [x] Tested in playground or other setup
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added support for insecure controller communication and skipping TLS certificate verification

**Bug fix:**
- Fixed issue where `--controller` flag was not being used to connect to the controller
- Made `--kube` flag default for all subcommands, allowing it to be omitted

**Documentation:**
- Updated documentation to reflect changes in code and new features

> 🎉 A flag once lost, now found and secure,
> Insecure connections, we can endure.
> With kube as default, our commands are free,
> Documentation updated, a joyous decree! 🥳
<!-- end of auto-generated comment: release notes by openai -->