### PR TITLE
Fixed nil pointer error on aperturectl delete

### DIFF
--- a/cmd/aperturectl/cmd/delete/root.go
+++ b/cmd/aperturectl/cmd/delete/root.go
@@ -5,18 +5,16 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
 
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
 )
 
 var (
-	kubeRestConfig *rest.Config
-	controller     utils.ControllerConn
-	client         cmdv1.ControllerClient
-	controllerNs   string
-	policyName     string
+	controller   utils.ControllerConn
+	client       cmdv1.ControllerClient
+	controllerNs string
+	policyName   string
 )
 
 func init() {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Fixed a nil pointer error in `aperturectl delete` command by updating the way kubeRestConfig is obtained
- Added a check for "Policy not found" error and logged it as an info message
- Removed unnecessary import and modified variable declarations for better maintainability
```

> 🎉 Hooray for the fix, no more crash we'll see,
> With pointers tamed, our code roams free.
> A policy check, logs now clear,
> Embrace the change, release notes cheer! 🥳
<!-- end of auto-generated comment: release notes by openai -->