### PR TITLE
Add simple method for retrieving reject values to flow classes

### DIFF
--- a/sdks/aperture-java/lib/core/build.gradle.kts
+++ b/sdks/aperture-java/lib/core/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-exporter-logging:1.18.0")
     implementation("io.grpc:grpc-protobuf:1.44.0")
     implementation("io.grpc:grpc-stub:1.44.0")
+    implementation("org.apache.httpcomponents:httpcore:4.4.16")
     implementation("org.slf4j:slf4j-simple:1.7.0")
 
     runtimeOnly("io.grpc:grpc-netty-shaded:1.49.0")


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added `rejectReason()` method to `Flow` and `TrafficFlow` classes for retrieving reject reason value

**Chore:**
- Added dependency on `httpcore` library version 4.4.16

> 🎉 A new feature we bring, with grace,
> To help developers in their chase.
> Reject reasons now in sight,
> And dependencies set just right. 🚀
<!-- end of auto-generated comment: release notes by openai -->