### PR TITLE
Use new flow rejection reason retrieval in libs and examples

### DIFF
--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -110,7 +110,7 @@ public class App {
         } else {
             // Flow has been rejected by Aperture Agent.
             try {
-                res.status(403);
+                res.status(flow.rejectReason());
                 flow.end(FlowStatus.Error);
             } catch (ApertureSDKException e) {
                 e.printStackTrace();

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
@@ -22,10 +22,8 @@ class HttpUtils {
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }
-        if (flow.checkResponse() != null
-                && flow.checkResponse().hasDeniedResponse()
-                && flow.checkResponse().getDeniedResponse().getStatus() != 0) {
-            int httpStatusCode = flow.checkResponse().getDeniedResponse().getStatus();
+        if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
+            int httpStatusCode = flow.rejectReason();
             HttpResponseBuilder resBuilder = HttpResponse.builder();
             resBuilder.status(httpStatusCode);
             for (Map.Entry<String, String> entry :

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
@@ -3,7 +3,6 @@ package com.fluxninja.aperture.armeria;
 import com.fluxninja.aperture.sdk.ApertureSDKException;
 import com.fluxninja.aperture.sdk.Flow;
 import com.fluxninja.aperture.sdk.FlowStatus;
-import com.fluxninja.generated.aperture.flowcontrol.check.v1.CheckResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RpcRequest;
 import java.util.HashMap;
@@ -16,20 +15,7 @@ class RpcUtils {
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }
-        if (flow.checkResponse() != null) {
-            CheckResponse.RejectReason reason = flow.checkResponse().getRejectReason();
-            switch (reason) {
-                case REJECT_REASON_RATE_LIMITED:
-                    return HttpStatus.TOO_MANY_REQUESTS;
-                case REJECT_REASON_NO_TOKENS:
-                    return HttpStatus.SERVICE_UNAVAILABLE;
-                case REJECT_REASON_REGULATED:
-                    return HttpStatus.FORBIDDEN;
-                case REJECT_REASON_NONE:
-                case UNRECOGNIZED:
-            }
-        }
-        return HttpStatus.FORBIDDEN;
+        return HttpStatus.valueOf(flow.rejectReason());
     }
 
     protected static Map<String, String> labelsFromRequest(RpcRequest req) {

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "2.1.0";
+    public static final String LIBRARY_VERSION = "2.2.0";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -94,12 +94,8 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
             }
             HttpResponseStatus status;
             Map<String, String> headers;
-            if (flow.checkResponse() != null
-                    && flow.checkResponse().hasDeniedResponse()
-                    && flow.checkResponse().getDeniedResponse().getStatus() != 0) {
-                status =
-                        HttpResponseStatus.valueOf(
-                                flow.checkResponse().getDeniedResponse().getStatus());
+            if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
+                status = HttpResponseStatus.valueOf(flow.rejectReason());
                 headers = flow.checkResponse().getDeniedResponse().getHeadersMap();
 
             } else {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
@@ -26,10 +26,8 @@ public class ServletUtils {
         }
 
         int code = 403;
-        if (flow.checkResponse() != null
-                && flow.checkResponse().hasDeniedResponse()
-                && flow.checkResponse().getDeniedResponse().getStatus() != 0) {
-            code = flow.checkResponse().getDeniedResponse().getStatus();
+        if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
+            code = flow.rejectReason();
             Map<String, String> headers = flow.checkResponse().getDeniedResponse().getHeadersMap();
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 response.setHeader(entry.getKey(), entry.getValue());

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
@@ -26,10 +26,8 @@ public class ServletUtils {
         }
 
         int code = 403;
-        if (flow.checkResponse() != null
-                && flow.checkResponse().hasDeniedResponse()
-                && flow.checkResponse().getDeniedResponse().getStatus() != 0) {
-            code = flow.checkResponse().getDeniedResponse().getStatus();
+        if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
+            code = flow.rejectReason();
             Map<String, String> headers = flow.checkResponse().getDeniedResponse().getHeadersMap();
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 response.setHeader(entry.getKey(), entry.getValue());

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "2.1.0"
+  var ver = "2.2.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Updated method for retrieving rejection reason in libs and examples

**Chore:**
- Updated library version in `Constants.java` and `version.gradle.kts`

> 🎉 A new method we embrace,
> For rejection reasons, we now trace.
> With updated libs, our code takes flight,
> Enhancing our project, shining bright! ✨
<!-- end of auto-generated comment: release notes by openai -->