### PR TITLE
docs: Stop recommending to add batch processor for custom metrics

### DIFF
--- a/docs/content/get-started/integrations/metrics/active-directory-ds.md
+++ b/docs/content/get-started/integrations/metrics/active-directory-ds.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           active_directory_ds:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - active_directory_ds
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               active_directory_ds:
                 [activedirectorydsreceiver configuration here]

--- a/docs/content/get-started/integrations/metrics/aerospike.md
+++ b/docs/content/get-started/integrations/metrics/aerospike.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           aerospike:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - aerospike
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               aerospike: [aerospikereceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/apache-web-server.md
+++ b/docs/content/get-started/integrations/metrics/apache-web-server.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           apache:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - apache
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               apache: [apachereceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/aws-container-insight.md
+++ b/docs/content/get-started/integrations/metrics/aws-container-insight.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           awscontainerinsightreceiver:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - awscontainerinsightreceiver
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               awscontainerinsightreceiver:
                 [awscontainerinsightreceiver configuration here]

--- a/docs/content/get-started/integrations/metrics/aws-ecs-container-metrics.md
+++ b/docs/content/get-started/integrations/metrics/aws-ecs-container-metrics.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           awsecscontainermetrics:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - awsecscontainermetrics
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               awsecscontainermetrics:
                 [awsecscontainermetricsreceiver configuration here]

--- a/docs/content/get-started/integrations/metrics/aws-kinesis-data-firehose.md
+++ b/docs/content/get-started/integrations/metrics/aws-kinesis-data-firehose.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           awsfirehose:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - awsfirehose
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               awsfirehose: [awsfirehosereceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/azure-event-hub.md
+++ b/docs/content/get-started/integrations/metrics/azure-event-hub.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           azureeventhub:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - azureeventhub
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               azureeventhub: [azureeventhubreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/chrony.md
+++ b/docs/content/get-started/integrations/metrics/chrony.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           chrony:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - chrony
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               chrony: [chronyreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/cloud-foundry.md
+++ b/docs/content/get-started/integrations/metrics/cloud-foundry.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           cloudfoundry:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - cloudfoundry
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               cloudfoundry: [cloudfoundryreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/collectd.md
+++ b/docs/content/get-started/integrations/metrics/collectd.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           collectd:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - collectd
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               collectd: [collectdreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/couchdb.md
+++ b/docs/content/get-started/integrations/metrics/couchdb.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           couchdb:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - couchdb
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               couchdb: [couchdbreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/docker.md
+++ b/docs/content/get-started/integrations/metrics/docker.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           docker_stats:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - docker_stats
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               docker_stats: [dockerstatsreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/elasticsearch.md
+++ b/docs/content/get-started/integrations/metrics/elasticsearch.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           elasticsearch:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - elasticsearch
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               elasticsearch: [elasticsearchreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/expvar.md
+++ b/docs/content/get-started/integrations/metrics/expvar.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           expvar:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - expvar
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               expvar: [expvarreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/f5-bigip.md
+++ b/docs/content/get-started/integrations/metrics/f5-bigip.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           bigip:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - bigip
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               bigip: [bigipreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/flinkmetrics.md
+++ b/docs/content/get-started/integrations/metrics/flinkmetrics.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           flinkmetrics:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - flinkmetrics
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               flinkmetrics: [flinkmetricsreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/google-cloud-spanner.md
+++ b/docs/content/get-started/integrations/metrics/google-cloud-spanner.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           googlecloudspanner:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - googlecloudspanner
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               googlecloudspanner:
                 [googlecloudspannerreceiver configuration here]

--- a/docs/content/get-started/integrations/metrics/google-pubsub.md
+++ b/docs/content/get-started/integrations/metrics/google-pubsub.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           googlecloudpubsub:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - googlecloudpubsub
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               googlecloudpubsub: [googlecloudpubsubreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/haproxy.md
+++ b/docs/content/get-started/integrations/metrics/haproxy.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           haproxy:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - haproxy
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               haproxy: [haproxyreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/httpcheck.md
+++ b/docs/content/get-started/integrations/metrics/httpcheck.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           httpcheck:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - httpcheck
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               httpcheck: [httpcheckreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/influxdb.md
+++ b/docs/content/get-started/integrations/metrics/influxdb.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           influxdb:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - influxdb
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               influxdb: [influxdbreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/jmx.md
+++ b/docs/content/get-started/integrations/metrics/jmx.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           jmx:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - jmx
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               jmx: [jmxreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/kafka.md
+++ b/docs/content/get-started/integrations/metrics/kafka.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           kafkametrics:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - kafkametrics
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               kafkametrics: [kafkametricsreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/kubelet-stats.md
+++ b/docs/content/get-started/integrations/metrics/kubelet-stats.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           kubeletstats:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - kubeletstats
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               kubeletstats: [kubeletstatsreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/kubernetes-cluster.md
+++ b/docs/content/get-started/integrations/metrics/kubernetes-cluster.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           k8s_cluster:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - k8s_cluster
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               k8s_cluster: [k8sclusterreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/memcached.md
+++ b/docs/content/get-started/integrations/metrics/memcached.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           memcached:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - memcached
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               memcached: [memcachedreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/metrics.md
+++ b/docs/content/get-started/integrations/metrics/metrics.md
@@ -29,15 +29,6 @@ policy:
         infra_meters:
           rabbitmq:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - rabbitmq
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               rabbitmq:
                 endpoint: ${RABBITMQ_ENDPOINT}

--- a/docs/content/get-started/integrations/metrics/microsoft-sql-server.md
+++ b/docs/content/get-started/integrations/metrics/microsoft-sql-server.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           sqlserver:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - sqlserver
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               sqlserver: [sqlserverreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/mongodb-atlas.md
+++ b/docs/content/get-started/integrations/metrics/mongodb-atlas.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           mongodbatlas:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - mongodbatlas
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               mongodbatlas: [mongodbatlasreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/mongodb.md
+++ b/docs/content/get-started/integrations/metrics/mongodb.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           mongodb:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - mongodb
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               mongodb: [mongodbreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/mysql.md
+++ b/docs/content/get-started/integrations/metrics/mysql.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           mysql:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - mysql
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               mysql: [mysqlreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/nginx.md
+++ b/docs/content/get-started/integrations/metrics/nginx.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           nginx:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - nginx
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               nginx: [nginxreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/nsxt.md
+++ b/docs/content/get-started/integrations/metrics/nsxt.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           nsxt:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - nsxt
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               nsxt: [nsxtreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/opencensus.md
+++ b/docs/content/get-started/integrations/metrics/opencensus.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           opencensus:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - opencensus
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               opencensus: [opencensusreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/oracledb.md
+++ b/docs/content/get-started/integrations/metrics/oracledb.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           oracledb:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - oracledb
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               oracledb: [oracledbreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/otlp-json-file.md
+++ b/docs/content/get-started/integrations/metrics/otlp-json-file.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           otlpjsonfile:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - otlpjsonfile
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               otlpjsonfile: [otlpjsonfilereceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/podman.md
+++ b/docs/content/get-started/integrations/metrics/podman.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           podman_stats:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - podman_stats
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               podman_stats: [podmanreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/postgresql.md
+++ b/docs/content/get-started/integrations/metrics/postgresql.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           postgresql:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - postgresql
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               postgresql: [postgresqlreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/prometheus-simple.md
+++ b/docs/content/get-started/integrations/metrics/prometheus-simple.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           prometheus_simple:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - prometheus_simple
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               prometheus_simple: [simpleprometheusreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/prometheus.md
+++ b/docs/content/get-started/integrations/metrics/prometheus.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           prometheus:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - prometheus
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               prometheus: [prometheusreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/pulsar.md
+++ b/docs/content/get-started/integrations/metrics/pulsar.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           pulsar:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - pulsar
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               pulsar: [pulsarreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/pure-storage-flasharray.md
+++ b/docs/content/get-started/integrations/metrics/pure-storage-flasharray.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           purefa:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - purefa
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               purefa: [purefareceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/pure-storage-flashblade.md
+++ b/docs/content/get-started/integrations/metrics/pure-storage-flashblade.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           purefb:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - purefb
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               purefb: [purefbreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/rabbitmq.md
+++ b/docs/content/get-started/integrations/metrics/rabbitmq.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           rabbitmq:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - rabbitmq
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               rabbitmq: [rabbitmqreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/redis.md
+++ b/docs/content/get-started/integrations/metrics/redis.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           redis:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - redis
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               redis: [redisreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/riak.md
+++ b/docs/content/get-started/integrations/metrics/riak.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           riak:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - riak
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               riak: [riakreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/sap-hana.md
+++ b/docs/content/get-started/integrations/metrics/sap-hana.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           saphana:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - saphana
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               saphana: [saphanareceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/signalfx.md
+++ b/docs/content/get-started/integrations/metrics/signalfx.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           signalfx:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - signalfx
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               signalfx: [signalfxreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/snmp.md
+++ b/docs/content/get-started/integrations/metrics/snmp.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           snmp:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - snmp
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               snmp: [snmpreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/snowflake.md
+++ b/docs/content/get-started/integrations/metrics/snowflake.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           snowflake:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - snowflake
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               snowflake: [snowflakereceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/splunk-hec.md
+++ b/docs/content/get-started/integrations/metrics/splunk-hec.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           splunk_hec:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - splunk_hec
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               splunk_hec: [splunkhecreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/sql-query.md
+++ b/docs/content/get-started/integrations/metrics/sql-query.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           sqlquery:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - sqlquery
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               sqlquery: [sqlqueryreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/sshcheck.md
+++ b/docs/content/get-started/integrations/metrics/sshcheck.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           sshcheck:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - sshcheck
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               sshcheck: [sshcheckreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/statsd.md
+++ b/docs/content/get-started/integrations/metrics/statsd.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           statsd:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - statsd
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               statsd: [statsdreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/vcenter.md
+++ b/docs/content/get-started/integrations/metrics/vcenter.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           vcenter:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - vcenter
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               vcenter: [vcenterreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/wavefront.md
+++ b/docs/content/get-started/integrations/metrics/wavefront.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           wavefront:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - wavefront
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               wavefront: [wavefrontreceiver configuration here]
 ```

--- a/docs/content/get-started/integrations/metrics/zookeeper.md
+++ b/docs/content/get-started/integrations/metrics/zookeeper.md
@@ -37,15 +37,6 @@ policy:
         infra_meters:
           zookeeper:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - zookeeper
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               zookeeper: [zookeeperreceiver configuration here]
 ```

--- a/docs/tools/otel_collectors/template.md
+++ b/docs/tools/otel_collectors/template.md
@@ -36,15 +36,6 @@ policy:
         infra_meters:
           METRIC_NAME:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - METRIC_NAME
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               METRIC_NAME: [RECEIVER_NAME configuration here]
 ```

--- a/playground/scenarios/rabbitmq-queue-buildup/policies/rabbitmq-queue-buildup.yaml
+++ b/playground/scenarios/rabbitmq-queue-buildup/policies/rabbitmq-queue-buildup.yaml
@@ -19,15 +19,6 @@ policy:
         infra_meters:
           rabbitmq:
             per_agent_group: true
-            pipeline:
-              processors:
-                - batch
-              receivers:
-                - rabbitmq
-            processors:
-              batch:
-                send_batch_size: 10
-                timeout: 10s
             receivers:
               rabbitmq:
                 endpoint: http://rabbitmq.rabbitmq.svc.cluster.local:15672

--- a/playground/scenarios/rabbitmq-queue-buildup/policies/service1-demoapp-rabbitmq-queue-buildup-cr.yaml
+++ b/playground/scenarios/rabbitmq-queue-buildup/policies/service1-demoapp-rabbitmq-queue-buildup-cr.yaml
@@ -60,15 +60,6 @@ spec:
       infra_meters:
         rabbitmq:
           per_agent_group: true
-          pipeline:
-            processors:
-            - batch
-            receivers:
-            - rabbitmq
-          processors:
-            batch:
-              send_batch_size: 10
-              timeout: 10s
           receivers:
             rabbitmq:
               collection_interval: 1s


### PR DESCRIPTION
### Description of change

Rationale:
* We append our processors and exporters anyway, we should handle any
  batching there.
* Batching could introduce unnecessary delay in the local prometheus.

Also:
* Removed explicit pipeline definition, receiver will be added to the
  pipeline automatically.
* Update rabbitmq playground scenarios with the same change.

Resolves #1953

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Removed batch processor for custom metrics in various integrations
- Updated RabbitMQ playground scenarios
- Automatically added receiver to the pipeline, removing explicit pipeline definition

> 🎉 Oh rejoice, for changes are here,
> No more batching, we're in the clear! 🚀
> RabbitMQ scenarios refined,
> And pipelines now auto-assigned. 🌟
<!-- end of auto-generated comment: release notes by openai -->