### PR TITLE
Add prometheus-jmx javaagent to java demo app, expose port

### DIFF
--- a/playground/resources/java-demo-app/Dockerfile
+++ b/playground/resources/java-demo-app/Dockerfile
@@ -10,8 +10,10 @@ RUN gradle clean build
 FROM openjdk:18-jdk-alpine
 
 COPY --link --from=builder /app/build/libs/JavaDemoApp-0.0.1-SNAPSHOT.war demo.war
+COPY --link ./config.yaml config.yaml
+RUN wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.18.0/jmx_prometheus_javaagent-0.18.0.jar
 
 HEALTHCHECK --interval=5s --timeout=60s --retries=3 --start-period=20s \
    CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8080/health || exit 1
 
-CMD java -jar demo.war --server.port=${SIMPLE_SERVICE_PORT}
+CMD java -javaagent:./jmx_prometheus_javaagent-0.18.0.jar=8087:config.yaml -jar demo.war --server.port=${SIMPLE_SERVICE_PORT}

--- a/playground/resources/java-demo-app/config.yaml
+++ b/playground/resources/java-demo-app/config.yaml
@@ -1,0 +1,2 @@
+rules:
+- pattern: ".*"

--- a/playground/scenarios/java-service-protection/metadata.json
+++ b/playground/scenarios/java-service-protection/metadata.json
@@ -16,6 +16,11 @@
       "ssh": "default"
     }
   ],
+  "port_forwards": {
+    "service1-demo-app": "8087:8087",
+    "service2-demo-app": "8087:8087",
+    "service3-demo-app": "8087:8087"
+  },
   "child_resources": [
     {
       "workload": "service1-demo-app",

--- a/playground/tanka/charts/java-demo-app/templates/deployment.yaml
+++ b/playground/tanka/charts/java-demo-app/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             - name: srvhttp
               containerPort: 8099
               protocol: TCP
+            - name: metrics
+              containerPort: 8087
+              protocol: TCP
           env:
             - name: SIMPLE_SERVICE_PORT
               value: "8099"

--- a/playground/tanka/charts/java-demo-app/templates/service.yaml
+++ b/playground/tanka/charts/java-demo-app/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: srvhttp
       protocol: TCP
       name: http
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: http-metrics
   selector:
     {{- include "demo-app.selectorLabels" . | nindent 4 }}

--- a/playground/tanka/charts/java-demo-app/values.yaml
+++ b/playground/tanka/charts/java-demo-app/values.yaml
@@ -49,6 +49,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  metricsPort: 8087
 
 
 resources: {}


### PR DESCRIPTION
### Description of change
Closes: GH-1950
##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Added JMX Prometheus Java agent for monitoring
- Included `config.yaml` file for JMX exporter configuration
```

> 🎉 A new dawn rises, metrics in sight,
> With JMX Prometheus, our app takes flight.
> Monitoring enabled, insights we'll gain,
> For better performance, and less growing pain. 🚀
<!-- end of auto-generated comment: release notes by openai -->