### PR TITLE
Fix Aperture Controller heading

### DIFF
--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -34,6 +34,7 @@ reliability.
 ```
 
 </Zoom>
+
 ### Aperture Controller
 
 The Aperture Controller is the central component of the platform. The controller


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [X ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Added a new section heading for the "Aperture Controller" in architecture.md

> 🎉 A new section takes its place,
> In architecture.md, it finds its space.
> Aperture Controller, shining bright,
> Our docs now guide with clearer light. 📚✨
<!-- end of auto-generated comment: release notes by openai -->