### PR TITLE
Added util methods for generating CheckHTTPRequest in aperture-go

### DIFF
--- a/sdks/aperture-go/sdk/middlewares/grpc.go
+++ b/sdks/aperture-go/sdk/middlewares/grpc.go
@@ -2,19 +2,15 @@ package middlewares
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 
 	flowcontrolhttp "github.com/fluxninja/aperture-go/v2/gen/proto/flowcontrol/checkhttp/v1"
 	aperture "github.com/fluxninja/aperture-go/v2/sdk"
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -35,59 +31,7 @@ func socketAddressFromNetAddr(logger logr.Logger, addr net.Addr) *flowcontrolhtt
 // GRPCUnaryInterceptor takes a control point name and creates a UnaryInterceptor which can be used with gRPC server.
 func GRPCUnaryInterceptor(c aperture.Client, controlPoint string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		labels := aperture.LabelsFromCtx(ctx)
-
-		md, ok := metadata.FromIncomingContext(ctx)
-		authority := ""
-		scheme := ""
-		method := ""
-
-		if ok {
-			for key, value := range md {
-				labels[key] = strings.Join(value, ",")
-			}
-			getMetaValue := func(key string) string {
-				values := md.Get(key)
-				if len(values) > 0 {
-					return values[0]
-				}
-				return ""
-			}
-			authority = getMetaValue(":authority")
-			scheme = getMetaValue(":scheme")
-			method = getMetaValue(":method")
-		}
-
-		var sourceSocket *flowcontrolhttp.SocketAddress
-		if sourceAddr, ok := peer.FromContext(ctx); ok {
-			sourceSocket = socketAddressFromNetAddr(c.GetLogger(), sourceAddr.Addr)
-		}
-		destinationSocket := &flowcontrolhttp.SocketAddress{
-			Address:  getLocalIP(c.GetLogger()),
-			Protocol: flowcontrolhttp.SocketAddress_TCP,
-			Port:     0,
-		}
-
-		body, err := json.Marshal(req)
-		if err != nil {
-			c.GetLogger().V(2).Info("Unable to marshal request body")
-		}
-
-		checkreq := &flowcontrolhttp.CheckHTTPRequest{
-			Source:       sourceSocket,
-			Destination:  destinationSocket,
-			ControlPoint: controlPoint,
-			Request: &flowcontrolhttp.CheckHTTPRequest_HttpRequest{
-				Method:   method,
-				Path:     info.FullMethod,
-				Host:     authority,
-				Headers:  labels,
-				Scheme:   scheme,
-				Size:     -1,
-				Protocol: "HTTP/2",
-				Body:     string(body),
-			},
-		}
+		checkreq := PrepareCheckHTTPRequestForGRPC(req, ctx, info, c.GetLogger(), controlPoint)
 
 		flow, err := c.StartHTTPFlow(ctx, checkreq)
 		if err != nil {

--- a/sdks/aperture-go/sdk/middlewares/utils.go
+++ b/sdks/aperture-go/sdk/middlewares/utils.go
@@ -2,12 +2,20 @@ package middlewares
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
+	flowcontrolhttp "github.com/fluxninja/aperture-go/v2/gen/proto/flowcontrol/checkhttp/v1"
+	aperture "github.com/fluxninja/aperture-go/v2/sdk"
 	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 // splits address into host and port
@@ -54,4 +62,111 @@ func getLocalIP(logger logr.Logger) string {
 	}
 	logger.V(2).Info("Failed to get local IP address")
 	return ""
+}
+
+// PrepareCheckHTTPRequestForHTTP takes a http.Request, logger and Control Point to use in Aperture policy for preparing the flowcontrolhttp.CheckHTTPRequest and returns it.
+func PrepareCheckHTTPRequestForHTTP(httpRequest *http.Request, logger logr.Logger, controlPoint string) *flowcontrolhttp.CheckHTTPRequest {
+	labels := aperture.LabelsFromCtx(httpRequest.Context())
+
+	for key, value := range httpRequest.Header {
+		if strings.HasPrefix(key, ":") {
+			continue
+		}
+		labels[key] = strings.Join(value, ",")
+	}
+
+	// We know that the protocol is TCP because Golang's http package doesn't support UDP
+	// TODO: Should we support `httpu`?
+	protocol := flowcontrolhttp.SocketAddress_TCP
+
+	sourceHost, sourcePort := splitAddress(logger, httpRequest.RemoteAddr)
+	// TODO: Figure out if we can narrow down the port or figure out the host in a better way
+	destinationPort := uint32(0)
+	destinationHost := getLocalIP(logger)
+
+	bodyBytes, err := readClonedBody(httpRequest)
+	if err != nil {
+		logger.V(2).Info("Error reading body", "error", err)
+	}
+
+	return &flowcontrolhttp.CheckHTTPRequest{
+		Source: &flowcontrolhttp.SocketAddress{
+			Address:  sourceHost,
+			Protocol: protocol,
+			Port:     sourcePort,
+		},
+		Destination: &flowcontrolhttp.SocketAddress{
+			Address:  destinationHost,
+			Protocol: protocol,
+			Port:     destinationPort,
+		},
+		ControlPoint: controlPoint,
+		Request: &flowcontrolhttp.CheckHTTPRequest_HttpRequest{
+			Method:   httpRequest.Method,
+			Path:     httpRequest.URL.Path,
+			Host:     httpRequest.Host,
+			Headers:  labels,
+			Scheme:   httpRequest.URL.Scheme,
+			Size:     httpRequest.ContentLength,
+			Protocol: httpRequest.Proto,
+			Body:     string(bodyBytes),
+		},
+	}
+}
+
+// PrepareCheckHTTPRequestForGRPC takes a gRPC request, context, unary server-info, logger and Control Point to use in Aperture policy for preparing the flowcontrolhttp.CheckHTTPRequest and returns it.
+func PrepareCheckHTTPRequestForGRPC(req interface{}, ctx context.Context, info *grpc.UnaryServerInfo, logger logr.Logger, controlPoint string) *flowcontrolhttp.CheckHTTPRequest {
+	labels := aperture.LabelsFromCtx(ctx)
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	authority := ""
+	scheme := ""
+	method := ""
+
+	if ok {
+		for key, value := range md {
+			labels[key] = strings.Join(value, ",")
+		}
+		getMetaValue := func(key string) string {
+			values := md.Get(key)
+			if len(values) > 0 {
+				return values[0]
+			}
+			return ""
+		}
+		authority = getMetaValue(":authority")
+		scheme = getMetaValue(":scheme")
+		method = getMetaValue(":method")
+	}
+
+	var sourceSocket *flowcontrolhttp.SocketAddress
+	if sourceAddr, ok := peer.FromContext(ctx); ok {
+		sourceSocket = socketAddressFromNetAddr(logger, sourceAddr.Addr)
+	}
+	destinationSocket := &flowcontrolhttp.SocketAddress{
+		Address:  getLocalIP(logger),
+		Protocol: flowcontrolhttp.SocketAddress_TCP,
+		Port:     0,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		logger.V(2).Info("Unable to marshal request body")
+	}
+
+	return &flowcontrolhttp.CheckHTTPRequest{
+		Source:       sourceSocket,
+		Destination:  destinationSocket,
+		ControlPoint: controlPoint,
+		Request: &flowcontrolhttp.CheckHTTPRequest_HttpRequest{
+			Method:   method,
+			Path:     info.FullMethod,
+			Host:     authority,
+			Headers:  labels,
+			Scheme:   scheme,
+			Size:     -1,
+			Protocol: "HTTP/2",
+			Body:     string(body),
+		},
+	}
 }


### PR DESCRIPTION
### Description of change

Added util methods for generating the CheckHTTPRequest as we also need it in the Traefik integration
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Extracted `PrepareCheckHTTPRequestForGRPC` and `PrepareCheckHTTPRequestForHTTP` functions for generating `CheckHTTPRequest` objects in gRPC and HTTP requests
- Added utility methods for creating `CheckHTTPRequest` in aperture-go, improving modularity and maintainability

> 🎉 A refactor so grand, we stand in awe,
> Modular code, a sight to adore.
> With gRPC and HTTP aligned,
> Maintainability, we shall find. 🚀
<!-- end of auto-generated comment: release notes by openai -->