### PR TITLE
docs: fix link

### DIFF
--- a/docs/content/get-started/setting-up-application/manual-control-points.md
+++ b/docs/content/get-started/setting-up-application/manual-control-points.md
@@ -11,7 +11,7 @@ import { Cards } from '@site/src/components/Cards';
 ```
 
 Control points are used to define where you want to act in code or at service
-level. It's important to understand what control points are, because you will be
+level. It's important to understand what control points are because you will be
 using them many times in your code.
 
 <!-- vale off -->
@@ -35,7 +35,7 @@ response to an issue or error.
 <!-- vale on -->
 
 Let's create a feature control point manually in java code. To begin with, you
-need to configure Aperture Java SDK for your application. You can configure
+need to configure the Aperture Java SDK for your application. You can configure
 Aperture SDK as follows:
 
 ```java

--- a/docs/content/integrations/flow-control/sdk/java/armeria.md
+++ b/docs/content/integrations/flow-control/sdk/java/armeria.md
@@ -68,5 +68,4 @@ refer to the [example app][armeria-example] available in the repository.
 
 [armeria-example]:
   https://github.com/fluxninja/aperture-java/tree/releases/aperture-java/v1.0.0/examples/armeria-example
-[javaagent]:
-  /integrations/flow-control/sdk/java/using-instrumentation-agent-to-automatically-set-control-points-using-java-sdk
+[javaagent]: /integrations/flow-control/sdk/java/auto-instrumentation.md

--- a/docs/content/integrations/flow-control/sdk/java/auto-instrumentation.md
+++ b/docs/content/integrations/flow-control/sdk/java/auto-instrumentation.md
@@ -1,7 +1,6 @@
 ---
 title: Using instrumentation agent to automatically set control points
 sidebar_position: 2
-slug: using-instrumentation-agent-to-automatically-set-control-points-using-java-sdk
 keywords:
   - java
   - sdk

--- a/docs/content/integrations/flow-control/sdk/java/netty.md
+++ b/docs/content/integrations/flow-control/sdk/java/netty.md
@@ -83,5 +83,4 @@ the [example app][netty-example] available in the repository.
 
 [netty-example]:
   https://github.com/fluxninja/aperture-java/tree/releases/aperture-java/v1.0.0/examples/netty-example
-[javaagent]:
-  /integrations/flow-control/sdk/java/using-instrumentation-agent-to-automatically-set-control-points-using-java-sdk
+[javaagent]: /integrations/flow-control/sdk/java/auto-instrumentation.md


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Fixed broken links in Armeria and Netty integration documentation
- Updated front matter in auto-instrumentation documentation

> 📚 Docs are shining bright,
> 🛠️ Broken links now right,
> 🎉 Celebrate the change,
> 🌟 Our knowledge, rearrange!
<!-- end of auto-generated comment: release notes by openai -->