### PR TITLE
Added steps for using workloadSelector in istioconfig chart

### DIFF
--- a/docs/content/integrations/flow-control/envoy/istio.md
+++ b/docs/content/integrations/flow-control/envoy/istio.md
@@ -289,7 +289,7 @@ Install the tool of your choice using the following links:
 
    :::info Refer
 
-   [aperturectl install controller](/reference/aperturectl/install/controller/controller.md)
+   [aperturectl install istioconfig](/reference/aperturectl/install/istioconfig/istioconfig.md)
    to see all the available command line arguments.
 
    :::
@@ -366,7 +366,33 @@ into your cluster.
    </TabItem>
    </Tabs>
 
-2. If you want to modify the default parameters of the chart, for example
+2. If you want to apply the Istio EnvoyFilter to specific workloads, you can use
+   the `workloadSelector` parameter. For example, if you want to apply the Istio
+   EnvoyFilter to the pods having the label `app.kubernetes.io/name=service1`,
+   you can create or update the `values.yaml` file and pass it with the
+   `install` command:
+
+   ```yaml
+   envoyFilter:
+     workloadSelector:
+       labels:
+         app.kubernetes.io/name: service1
+   ```
+
+   <Tabs groupId="setup" queryString>
+   <TabItem value="aperturectl" label="aperturectl">
+   <CodeBlock language="bash">
+   {`aperturectl install istioconfig --version ${apertureVersion} --namespace ISTIOD_NAMESPACE_HERE --values-file values.yaml`}
+   </CodeBlock>
+   </TabItem>
+   <TabItem value="Helm" label="Helm">
+   <CodeBlock language="bash">
+   {`helm upgrade --install aperture-envoy-filter aperture/istioconfig --namespace ISTIOD_NAMESPACE_HERE -f values.yaml`}
+   </CodeBlock>
+   </TabItem>
+   </Tabs>
+
+3. If you want to modify the default parameters of the chart, for example
    `sidecarMode`, you can create or update the `values.yaml` file and pass it
    with `install` command:
 

--- a/docs/content/integrations/flow-control/envoy/istio.md
+++ b/docs/content/integrations/flow-control/envoy/istio.md
@@ -366,11 +366,11 @@ into your cluster.
    </TabItem>
    </Tabs>
 
-2. If you would like to apply the Istio EnvoyFilter to specific workloads, you
-   can use the `workloadSelector` parameter. For example, if you would like to
-   apply the Istio EnvoyFilter to the pods having the label
-   `app.kubernetes.io/name=service1`, you can create or update the `values.yaml`
-   file and pass it with the `install` command:
+2. If you want to apply the Istio EnvoyFilter to specific workloads, you can use
+   the `workloadSelector` parameter. For example, if you want to apply the Istio
+   EnvoyFilter to the pods having the label `app.kubernetes.io/name=service1`,
+   you can create or update the `values.yaml` file and pass it with the
+   `install` command:
 
    ```yaml
    envoyFilter:
@@ -392,7 +392,7 @@ into your cluster.
    </TabItem>
    </Tabs>
 
-3. If you would like to modify the default parameters of the chart, for example
+3. If you want to modify the default parameters of the chart, for example
    `sidecarMode`, you can create or update the `values.yaml` file and pass it
    with `install` command:
 

--- a/docs/content/integrations/flow-control/envoy/istio.md
+++ b/docs/content/integrations/flow-control/envoy/istio.md
@@ -366,11 +366,11 @@ into your cluster.
    </TabItem>
    </Tabs>
 
-2. If you want to apply the Istio EnvoyFilter to specific workloads, you can use
-   the `workloadSelector` parameter. For example, if you want to apply the Istio
-   EnvoyFilter to the pods having the label `app.kubernetes.io/name=service1`,
-   you can create or update the `values.yaml` file and pass it with the
-   `install` command:
+2. If you would like to apply the Istio EnvoyFilter to specific workloads, you
+   can use the `workloadSelector` parameter. For example, if you would like to
+   apply the Istio EnvoyFilter to the pods having the label
+   `app.kubernetes.io/name=service1`, you can create or update the `values.yaml`
+   file and pass it with the `install` command:
 
    ```yaml
    envoyFilter:
@@ -392,7 +392,7 @@ into your cluster.
    </TabItem>
    </Tabs>
 
-3. If you want to modify the default parameters of the chart, for example
+3. If you would like to modify the default parameters of the chart, for example
    `sidecarMode`, you can create or update the `values.yaml` file and pass it
    with `install` command:
 

--- a/manifests/charts/istioconfig/README.md
+++ b/manifests/charts/istioconfig/README.md
@@ -6,16 +6,16 @@ This Chart inserts Envoy filters that integrate with Aperture Agent.
 
 ### Envoy Filter Parameters
 
-| Name                                          | Description                                                                                                                            | Value            |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `envoyFilter.name`                            | Name of service running `aperture-agent`                                                                                               | `aperture-agent` |
-| `envoyFilter.namespace`                       | Namespace where `aperture-agent` is running                                                                                            | `aperture-agent` |
-| `envoyFilter.port`                            | Port serving external authorization API and for streaming access logs                                                                  | `8080`           |
-| `envoyFilter.authzGrpcTimeout`                | Timeout in seconds to authorization requests made to `aperture-agent`.                                                                 | `0.25s`          |
-| `envoyFilter.enableAuthzRequestBodyBuffering` | Enable buffering request body that is sent over external authorization API. Note: This might break some streaming APIs.                | `true`           |
-| `envoyFilter.maxRequestBytes`                 | Maximum size of request that is sent over external authorization API                                                                   | `8192`           |
-| `envoyFilter.packAsBytes`                     | If true, the body sent to the external authorization service is set with raw bytes.                                                    | `false`          |
-| `envoyFilter.sidecarMode`                     | Aperture Agent installed using the Sidecar mode                                                                                        | `false`          |
-| `envoyFilter.workloadSelector`                | Workload selector for Istio EnvoyFilter. Refer https://istio.io/latest/docs/reference/config/type/workload-selector/ for more details. | `{}`             |
-| `envoyFilter.inboundRequestControlPoint`      | Specifies the control point for inbound requests, used to refer the service in Aperture Policy.                                        | `nil`            |
-| `envoyFilter.outboundRequestControlPoint`     | Specifies the control point for outbound requests, used to refer the service in Aperture Policy.                                       | `nil`            |
+| Name                                          | Description                                                                                                                                         | Value            |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `envoyFilter.name`                            | Name of service running `aperture-agent`                                                                                                            | `aperture-agent` |
+| `envoyFilter.namespace`                       | Namespace where `aperture-agent` is running                                                                                                         | `aperture-agent` |
+| `envoyFilter.port`                            | Port serving external authorization API and for streaming access logs                                                                               | `8080`           |
+| `envoyFilter.authzGrpcTimeout`                | Timeout in seconds to authorization requests made to `aperture-agent`.                                                                              | `0.25s`          |
+| `envoyFilter.enableAuthzRequestBodyBuffering` | Enable buffering request body that is sent over external authorization API. Note: This might break some streaming APIs.                             | `true`           |
+| `envoyFilter.maxRequestBytes`                 | Maximum size of request that is sent over external authorization API                                                                                | `8192`           |
+| `envoyFilter.packAsBytes`                     | If true, the body sent to the external authorization service is set with raw bytes.                                                                 | `false`          |
+| `envoyFilter.sidecarMode`                     | Aperture Agent installed using the Sidecar mode                                                                                                     | `false`          |
+| `envoyFilter.workloadSelector`                | Workload selector for Istio EnvoyFilter. Refer https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector for more details. | `{}`             |
+| `envoyFilter.inboundRequestControlPoint`      | Specifies the control point for inbound requests, used to refer the service in Aperture Policy.                                                     | `nil`            |
+| `envoyFilter.outboundRequestControlPoint`     | Specifies the control point for outbound requests, used to refer the service in Aperture Policy.                                                    | `nil`            |

--- a/manifests/charts/istioconfig/README.md
+++ b/manifests/charts/istioconfig/README.md
@@ -6,16 +6,16 @@ This Chart inserts Envoy filters that integrate with Aperture Agent.
 
 ### Envoy Filter Parameters
 
-| Name                                          | Description                                                                                                                                         | Value            |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `envoyFilter.name`                            | Name of service running `aperture-agent`                                                                                                            | `aperture-agent` |
-| `envoyFilter.namespace`                       | Namespace where `aperture-agent` is running                                                                                                         | `aperture-agent` |
-| `envoyFilter.port`                            | Port serving external authorization API and for streaming access logs                                                                               | `8080`           |
-| `envoyFilter.authzGrpcTimeout`                | Timeout in seconds to authorization requests made to `aperture-agent`.                                                                              | `0.25s`          |
-| `envoyFilter.enableAuthzRequestBodyBuffering` | Enable buffering request body that is sent over external authorization API. Note: This might break some streaming APIs.                             | `true`           |
-| `envoyFilter.maxRequestBytes`                 | Maximum size of request that is sent over external authorization API                                                                                | `8192`           |
-| `envoyFilter.packAsBytes`                     | If true, the body sent to the external authorization service is set with raw bytes.                                                                 | `false`          |
-| `envoyFilter.sidecarMode`                     | Aperture Agent installed using the Sidecar mode                                                                                                     | `false`          |
-| `envoyFilter.workloadSelector`                | Workload selector for Istio EnvoyFilter. Refer https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector for more details. | `{}`             |
-| `envoyFilter.inboundRequestControlPoint`      | Specifies the control point for inbound requests, used to refer the service in Aperture Policy.                                                     | `nil`            |
-| `envoyFilter.outboundRequestControlPoint`     | Specifies the control point for outbound requests, used to refer the service in Aperture Policy.                                                    | `nil`            |
+| Name                                          | Description                                                                                                                                            | Value            |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `envoyFilter.name`                            | Name of service running `aperture-agent`                                                                                                               | `aperture-agent` |
+| `envoyFilter.namespace`                       | Namespace where `aperture-agent` is running                                                                                                            | `aperture-agent` |
+| `envoyFilter.port`                            | Port serving external authorization API and for streaming access logs                                                                                  | `8080`           |
+| `envoyFilter.authzGrpcTimeout`                | Timeout in seconds to authorization requests made to `aperture-agent`.                                                                                 | `0.25s`          |
+| `envoyFilter.enableAuthzRequestBodyBuffering` | Enable buffering request body that is sent over external authorization API. Note: This might break some streaming APIs.                                | `true`           |
+| `envoyFilter.maxRequestBytes`                 | Maximum size of request that is sent over external authorization API                                                                                   | `8192`           |
+| `envoyFilter.packAsBytes`                     | If true, the body sent to the external authorization service is set with raw bytes.                                                                    | `false`          |
+| `envoyFilter.sidecarMode`                     | Aperture Agent installed using the Sidecar mode                                                                                                        | `false`          |
+| `envoyFilter.workloadSelector`                | Workload selector for Istio EnvoyFilter. Refer to https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector for more details. | `{}`             |
+| `envoyFilter.inboundRequestControlPoint`      | Specifies the control point for inbound requests, used to refer the service in Aperture Policy.                                                        | `nil`            |
+| `envoyFilter.outboundRequestControlPoint`     | Specifies the control point for outbound requests, used to refer the service in Aperture Policy.                                                       | `nil`            |

--- a/manifests/charts/istioconfig/values.yaml
+++ b/manifests/charts/istioconfig/values.yaml
@@ -20,7 +20,7 @@ envoyFilter:
   packAsBytes: false
   ## @param envoyFilter.sidecarMode Aperture Agent installed using the Sidecar mode
   sidecarMode: false
-  ## @param envoyFilter.workloadSelector Workload selector for Istio EnvoyFilter. Refer https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector for more details.
+  ## @param envoyFilter.workloadSelector Workload selector for Istio EnvoyFilter. Refer to https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector for more details.
   ## Example:
   ## workloadSelector:
   ##   labels:

--- a/manifests/charts/istioconfig/values.yaml
+++ b/manifests/charts/istioconfig/values.yaml
@@ -20,7 +20,7 @@ envoyFilter:
   packAsBytes: false
   ## @param envoyFilter.sidecarMode Aperture Agent installed using the Sidecar mode
   sidecarMode: false
-  ## @param envoyFilter.workloadSelector Workload selector for Istio EnvoyFilter. Refer https://istio.io/latest/docs/reference/config/type/workload-selector/ for more details.
+  ## @param envoyFilter.workloadSelector Workload selector for Istio EnvoyFilter. Refer https://istio.io/latest/docs/reference/config/networking/sidecar/#WorkloadSelector for more details.
   ## Example:
   ## workloadSelector:
   ##   labels:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Added `workloadSelector` parameter to Istioconfig chart for applying EnvoyFilter to specific workloads
- Updated documentation with steps and examples for using `workloadSelector` in Istioconfig chart
```

> 🎉 With selectors now in place, we steer,
> To workloads that need us most near.
> A filter applied, with precision and grace,
> Our Istioconfig finds its rightful space. 🚀
<!-- end of auto-generated comment: release notes by openai -->