### PR TITLE
Add `extra_filters` to blueprints' dashboards

### DIFF
--- a/blueprints/blueprint-assets-generator.py
+++ b/blueprints/blueprint-assets-generator.py
@@ -301,8 +301,6 @@ MARKDOWN_DOC_TPL = """
 {%- macro render_type(param_type, is_complex_type) %}
 {%- if param_type.startswith('[]') %}
 {{- 'Array of ' + render_type(param_type[2:], is_complex_type) }}
-{%- elif param_type.startswith('map[') %}
-{{- 'Map of ' + render_type(param_type[4:-1], is_complex_type) }}
 {%- elif is_complex_type %}
 {{- 'Object (' + param_type + ')' }}
 {%- elif param_type == 'bool' %}
@@ -391,8 +389,6 @@ MARKDOWN_README_TPL = """
 {%- macro render_type(param_type, is_complex_type) %}
 {%- if param_type.startswith('[]') %}
 {{- 'Array of ' + render_type(param_type[2:], is_complex_type) }}
-{%- elif param_type.startswith('map[') %}
-{{- 'Map of ' + render_type(param_type[4:-1], is_complex_type) }}
 {%- elif is_complex_type %}
 {{- 'Object (' + param_type + ')' }}
 {%- elif param_type == 'bool' %}
@@ -472,7 +468,7 @@ items:
   {{ render_type(param_type[2:], ref_id, is_complex_type) | indent(2) }}
 {% elif param_type.startswith('map[') %}
 type: object
-additionalProperties: {{ render_type(param_type[4:-1], ref_id, is_complex_type) }}
+additionalProperties: true
 {% elif is_complex_type %}
 type: object
 $ref: "{{- ref_id }}"

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/config.libsonnet
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/config.libsonnet
@@ -38,11 +38,13 @@ autoScalingDefaults {
   * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
   * @param (dashboard.time_from: string) Time from of dashboard.
   * @param (dashboard.time_to: string) Time to of dashboard.
+  * @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
   */
   dashboard+: {
     refresh_interval: '15s',
     time_from: 'now-15m',
     time_to: 'now',
+    extra_filters: {},
     /**
     * @param (dashboard.datasource.name: string) Datasource name.
     * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/definitions.json
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/definitions.json
@@ -138,6 +138,12 @@
           "default": "now",
           "type": "string"
         },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
         "datasource": {
           "type": "object",
           "additionalProperties": false,

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values.yaml
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values.yaml
@@ -82,6 +82,9 @@ dashboard:
   # Time to of dashboard.
   # Type: string
   time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/blueprints/policies/feature-rollout/average-latency/gen/definitions.json
+++ b/blueprints/policies/feature-rollout/average-latency/gen/definitions.json
@@ -68,6 +68,7 @@
           "filter_regex": "",
           "name": "$datasource"
         },
+        "extra_filters": {},
         "refresh_interval": "5s",
         "time_from": "now-15m",
         "time_to": "now"

--- a/blueprints/policies/feature-rollout/average-latency/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/average-latency/gen/values.yaml
@@ -41,6 +41,7 @@ dashboard:
   datasource:
     filter_regex: ""
     name: "$datasource"
+  extra_filters:
   refresh_interval: "5s"
   time_from: "now-15m"
   time_to: "now"

--- a/blueprints/policies/feature-rollout/base/config.libsonnet
+++ b/blueprints/policies/feature-rollout/base/config.libsonnet
@@ -181,11 +181,13 @@ local rollout_policy_defaults = rollout_policy_base_defaults {
   * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
   * @param (dashboard.time_from: string) From time of dashboard.
   * @param (dashboard.time_to: string) To time of dashboard.
+  * @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
   */
   dashboard: {
     refresh_interval: '5s',
     time_from: 'now-15m',
     time_to: 'now',
+    extra_filters: {},
     /**
     * @param (dashboard.datasource.name: string) Datasource name.
     * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.

--- a/blueprints/policies/feature-rollout/base/gen/definitions.json
+++ b/blueprints/policies/feature-rollout/base/gen/definitions.json
@@ -58,6 +58,12 @@
           "default": "now",
           "type": "string"
         },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
         "datasource": {
           "type": "object",
           "additionalProperties": false,

--- a/blueprints/policies/feature-rollout/base/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/base/gen/values.yaml
@@ -34,6 +34,9 @@ dashboard:
   # To time of dashboard.
   # Type: string
   time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/blueprints/policies/feature-rollout/ema-latency/gen/definitions.json
+++ b/blueprints/policies/feature-rollout/ema-latency/gen/definitions.json
@@ -72,6 +72,7 @@
           "filter_regex": "",
           "name": "$datasource"
         },
+        "extra_filters": {},
         "refresh_interval": "5s",
         "time_from": "now-15m",
         "time_to": "now"

--- a/blueprints/policies/feature-rollout/ema-latency/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/ema-latency/gen/values.yaml
@@ -44,6 +44,7 @@ dashboard:
   datasource:
     filter_regex: ""
     name: "$datasource"
+  extra_filters:
   refresh_interval: "5s"
   time_from: "now-15m"
   time_to: "now"

--- a/blueprints/policies/feature-rollout/percentile-latency/gen/definitions.json
+++ b/blueprints/policies/feature-rollout/percentile-latency/gen/definitions.json
@@ -76,6 +76,7 @@
           "filter_regex": "",
           "name": "$datasource"
         },
+        "extra_filters": {},
         "refresh_interval": "5s",
         "time_from": "now-15m",
         "time_to": "now"

--- a/blueprints/policies/feature-rollout/percentile-latency/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/percentile-latency/gen/values.yaml
@@ -56,6 +56,7 @@ dashboard:
   datasource:
     filter_regex: ""
     name: "$datasource"
+  extra_filters:
   refresh_interval: "5s"
   time_from: "now-15m"
   time_to: "now"

--- a/blueprints/policies/feature-rollout/promql/gen/definitions.json
+++ b/blueprints/policies/feature-rollout/promql/gen/definitions.json
@@ -66,6 +66,7 @@
           "filter_regex": "",
           "name": "$datasource"
         },
+        "extra_filters": {},
         "refresh_interval": "5s",
         "time_from": "now-15m",
         "time_to": "now"

--- a/blueprints/policies/feature-rollout/promql/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/promql/gen/values.yaml
@@ -42,6 +42,7 @@ dashboard:
   datasource:
     filter_regex: ""
     name: "$datasource"
+  extra_filters:
   refresh_interval: "5s"
   time_from: "now-15m"
   time_to: "now"

--- a/blueprints/policies/policy-utils.libsonnet
+++ b/blueprints/policies/policy-utils.libsonnet
@@ -1,0 +1,21 @@
+{
+  // Serialize a basic value to a string, adding double quotes around string values
+  serializeValue: function(value)
+    if (std.isString(value)) then
+      '"%(value)s"' % { value: value }
+    else
+      if (std.isNumber(value) || std.isBoolean(value)) then
+        std.toString(value)
+      else
+        error 'Unsupported value type: %(value)s' % { value: std.typeOf(value) }
+  ,
+  // Convert a dict to a prometheus filter
+  dictToPrometheusFilter: function(dict)
+    std.join(
+      ',',
+      std.map(
+        function(key) '%(key)s:"%(value)s"' % { key: key, value: $.serializeValue(dict[key]) },
+        std.objectFields(dict),
+      )
+    ),
+}

--- a/blueprints/policies/policy-utils.libsonnet
+++ b/blueprints/policies/policy-utils.libsonnet
@@ -14,7 +14,7 @@
     std.join(
       ',',
       std.map(
-        function(key) '%(key)s:"%(value)s"' % { key: key, value: $.serializeValue(dict[key]) },
+        function(key) '%(key)s=%(value)s' % { key: key, value: $.serializeValue(dict[key]) },
         std.objectFields(dict),
       )
     ),

--- a/blueprints/policies/quota-scheduler/config.libsonnet
+++ b/blueprints/policies/quota-scheduler/config.libsonnet
@@ -37,11 +37,13 @@
   * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
   * @param (dashboard.time_from: string) Time from of dashboard.
   * @param (dashboard.time_to: string) Time to of dashboard.
+  * @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
   */
   dashboard: {
     refresh_interval: '10s',
     time_from: 'now-15m',
     time_to: 'now',
+    extra_filters: {},
     /**
     * @param (dashboard.datasource.name: string) Datasource name.
     * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.

--- a/blueprints/policies/quota-scheduler/dashboard.libsonnet
+++ b/blueprints/policies/quota-scheduler/dashboard.libsonnet
@@ -1,5 +1,6 @@
 local aperture = import '../../grafana/aperture.libsonnet';
 local lib = import '../../grafana/grafana.libsonnet';
+local utils = import '../policy-utils.libsonnet';
 local baseDashboardFn = import '../service-protection/base/dashboard.libsonnet';
 local config = import './config.libsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -16,6 +17,7 @@ function(cfg) {
   local policyName = params.policy.policy_name,
   local ds = params.dashboard.datasource,
   local dsName = ds.name,
+  local filters = utils.dictToPrometheusFilter(params.dashboard.extra_filters { policy_name: policyName }),
 
   local quotaSchedulerPanel =
     graphPanel.new(
@@ -26,7 +28,7 @@ function(cfg) {
     )
     .addTarget(
       prometheus.target(
-        expr='sum by(decision_type) (rate(workload_requests_total{policy_name="%(policy_name)s"}[$__rate_interval]))' % { policy_name: policyName },
+        expr='sum by(decision_type) (rate(workload_requests_total{%(filters)s}[$__rate_interval]))' % { filters: filters },
         intervalFactor=1,
       )
     ),

--- a/blueprints/policies/quota-scheduler/gen/definitions.json
+++ b/blueprints/policies/quota-scheduler/gen/definitions.json
@@ -103,6 +103,12 @@
           "default": "now",
           "type": "string"
         },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
         "datasource": {
           "type": "object",
           "additionalProperties": false,

--- a/blueprints/policies/quota-scheduler/gen/values.yaml
+++ b/blueprints/policies/quota-scheduler/gen/values.yaml
@@ -48,6 +48,9 @@ dashboard:
   # Time to of dashboard.
   # Type: string
   time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/blueprints/policies/rate-limiting/config.libsonnet
+++ b/blueprints/policies/rate-limiting/config.libsonnet
@@ -35,9 +35,11 @@
   },
   /**
   * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
+  * @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
   */
   dashboard: {
     refresh_interval: '10s',
+    extra_filters: {},
     /**
     * @param (dashboard.datasource.name: string) Datasource name.
     * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.

--- a/blueprints/policies/rate-limiting/dashboard.libsonnet
+++ b/blueprints/policies/rate-limiting/dashboard.libsonnet
@@ -1,5 +1,6 @@
 local aperture = import '../../grafana/aperture.libsonnet';
 local lib = import '../../grafana/grafana.libsonnet';
+local utils = import '../policy-utils.libsonnet';
 local config = import './config.libsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 
@@ -12,17 +13,8 @@ function(cfg) {
   local policyName = params.policy.policy_name,
   local ds = params.dashboard.datasource,
   local dsName = ds.name,
-  local baseFilters = {
-    policy_name: policyName,
-  },
-  local filters = baseFilters + params.dashboard.extra_filters,
-  local stringFilters = std.join(
-    ',',
-    std.map(
-      function(key) '%(key)s:"%(value)s"' % { key: key, value: filters[key] },
-      std.objectFields(filters),
-    )
-  ),
+
+  local stringFilters = utils.dictToPrometheusFilter(params.dashboard.extra_filters { policy_name: policyName }),
 
   local rateLimiterPanel =
     graphPanel.new(

--- a/blueprints/policies/rate-limiting/gen/definitions.json
+++ b/blueprints/policies/rate-limiting/gen/definitions.json
@@ -87,6 +87,12 @@
           "default": "10s",
           "type": "string"
         },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
         "datasource": {
           "type": "object",
           "additionalProperties": false,

--- a/blueprints/policies/rate-limiting/gen/values.yaml
+++ b/blueprints/policies/rate-limiting/gen/values.yaml
@@ -44,6 +44,9 @@ dashboard:
   # Refresh interval for dashboard panels.
   # Type: string
   refresh_interval: "10s"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/config.libsonnet
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/config.libsonnet
@@ -28,6 +28,7 @@ local averageLatencyServiceProtection = import '../../service-protection/average
 * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
 * @param (dashboard.time_from: string) From time of dashboard.
 * @param (dashboard.time_to: string) To time of dashboard.
+* @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
 * @param (dashboard.datasource.name: string) Datasource name.
 * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.
 */

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/definitions.json
@@ -218,6 +218,12 @@
           "default": "now",
           "type": "string"
         },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
         "datasource": {
           "type": "object",
           "additionalProperties": false,

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
@@ -115,6 +115,9 @@ dashboard:
   # To time of dashboard.
   # Type: string
   time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/config.libsonnet
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/config.libsonnet
@@ -27,6 +27,7 @@ local promqlServiceProtection = import '../../service-protection/promql/config.l
 * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
 * @param (dashboard.time_from: string) From time of dashboard.
 * @param (dashboard.time_to: string) To time of dashboard.
+* @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
 * @param (dashboard.datasource.name: string) Datasource name.
 * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.
 */

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/definitions.json
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/definitions.json
@@ -180,6 +180,12 @@
           "default": "now",
           "type": "string"
         },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
         "datasource": {
           "type": "object",
           "additionalProperties": false,

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
@@ -105,6 +105,9 @@ dashboard:
   # To time of dashboard.
   # Type: string
   time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/blueprints/policies/service-protection/average-latency/config.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/config.libsonnet
@@ -13,14 +13,6 @@ local serviceProtectionDefaults = import '../base/config-defaults.libsonnet';
 * @param (policy.service_protection_core.dry_run: bool) Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.
 */
 
-/**
-* @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
-* @param (dashboard.time_from: string) From time of dashboard.
-* @param (dashboard.time_to: string) To time of dashboard.
-* @param (dashboard.datasource.name: string) Datasource name.
-* @param (dashboard.datasource.filter_regex: string) Datasource filter regex.
-*/
-
 serviceProtectionDefaults {
   policy+: {
     latency_baseliner: {
@@ -49,11 +41,13 @@ serviceProtectionDefaults {
   * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
   * @param (dashboard.time_from: string) Time from of dashboard.
   * @param (dashboard.time_to: string) Time to of dashboard.
+  * @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
   */
   dashboard: {
     refresh_interval: '15s',
     time_from: 'now-15m',
     time_to: 'now',
+    extra_filters: {},
     /**
     * @param (dashboard.datasource.name: string) Datasource name.
     * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.

--- a/blueprints/policies/service-protection/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection/average-latency/gen/definitions.json
@@ -149,14 +149,20 @@
           "type": "string"
         },
         "time_from": {
-          "description": "From time of dashboard.",
+          "description": "Time from of dashboard.",
           "default": "now-15m",
           "type": "string"
         },
         "time_to": {
-          "description": "To time of dashboard.",
+          "description": "Time to of dashboard.",
           "default": "now",
           "type": "string"
+        },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
         },
         "datasource": {
           "type": "object",

--- a/blueprints/policies/service-protection/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values.yaml
@@ -69,12 +69,15 @@ dashboard:
   # Refresh interval for dashboard panels.
   # Type: string
   refresh_interval: "15s"
-  # From time of dashboard.
+  # Time from of dashboard.
   # Type: string
   time_from: "now-15m"
-  # To time of dashboard.
+  # Time to of dashboard.
   # Type: string
   time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/blueprints/policies/service-protection/promql/config.libsonnet
+++ b/blueprints/policies/service-protection/promql/config.libsonnet
@@ -14,14 +14,6 @@ local serviceProtectionDefaults = import '../base/config-defaults.libsonnet';
 * @param (policy.service_protection_core.dry_run: bool) Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.
 */
 
-/**
-* @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
-* @param (dashboard.time_from: string) From time of dashboard.
-* @param (dashboard.time_to: string) To time of dashboard.
-* @param (dashboard.datasource.name: string) Datasource name.
-* @param (dashboard.datasource.filter_regex: string) Datasource filter regex.
-*/
-
 serviceProtectionDefaults {
   policy+: {
     promql_query: '__REQUIRED_FIELD__',
@@ -35,11 +27,13 @@ serviceProtectionDefaults {
   * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
   * @param (dashboard.time_from: string) Time from of dashboard.
   * @param (dashboard.time_to: string) Time to of dashboard.
+  * @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
   */
   dashboard: {
     refresh_interval: '15s',
     time_from: 'now-15m',
     time_to: 'now',
+    extra_filters: {},
     /**
     * @param (dashboard.datasource.name: string) Datasource name.
     * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.

--- a/blueprints/policies/service-protection/promql/gen/definitions.json
+++ b/blueprints/policies/service-protection/promql/gen/definitions.json
@@ -119,14 +119,20 @@
           "type": "string"
         },
         "time_from": {
-          "description": "From time of dashboard.",
+          "description": "Time from of dashboard.",
           "default": "now-15m",
           "type": "string"
         },
         "time_to": {
-          "description": "To time of dashboard.",
+          "description": "Time to of dashboard.",
           "default": "now",
           "type": "string"
+        },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
         },
         "datasource": {
           "type": "object",

--- a/blueprints/policies/service-protection/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection/promql/gen/values.yaml
@@ -57,12 +57,15 @@ dashboard:
   # Refresh interval for dashboard panels.
   # Type: string
   refresh_interval: "15s"
-  # From time of dashboard.
+  # Time from of dashboard.
   # Type: string
   time_from: "now-15m"
-  # To time of dashboard.
+  # Time to of dashboard.
   # Type: string
   time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/docs/content/get-started/policies/assets/raw_values.yaml
+++ b/docs/content/get-started/policies/assets/raw_values.yaml
@@ -44,6 +44,9 @@ dashboard:
   # Refresh interval for dashboard panels.
   # Type: string
   refresh_interval: "10s"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters:
   datasource:
     # Datasource name.
     # Type: string

--- a/docs/content/reference/policies/bundled-blueprints/policies/auto-scaling/pod-auto-scaler.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/auto-scaling/pod-auto-scaler.md
@@ -218,6 +218,20 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/au
 
 <!-- vale off -->
 
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
 ##### dashboard.datasource {#dashboard-datasource}
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/average-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/average-latency.md
@@ -68,7 +68,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/fe
     description='Configuration for the Grafana dashboard accompanying this policy.'
     type='Object (policies/feature-rollout/base:param:dashboard)'
     reference='../../../bundled-blueprints/policies/feature-rollout/base#dashboard'
-    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
+    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "extra_filters": {}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/base.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/base.md
@@ -109,6 +109,20 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/fe
 
 <!-- vale off -->
 
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
 ##### dashboard.datasource {#dashboard-datasource}
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/ema-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/ema-latency.md
@@ -61,7 +61,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/fe
     description='Configuration for the Grafana dashboard accompanying this policy.'
     type='Object (policies/feature-rollout/base:param:dashboard)'
     reference='../../../bundled-blueprints/policies/feature-rollout/base#dashboard'
-    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
+    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "extra_filters": {}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/percentile-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/percentile-latency.md
@@ -60,7 +60,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/fe
     description='Configuration for the Grafana dashboard accompanying this policy.'
     type='Object (policies/feature-rollout/base:param:dashboard)'
     reference='../../../bundled-blueprints/policies/feature-rollout/base#dashboard'
-    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
+    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "extra_filters": {}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/promql.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/feature-rollout/promql.md
@@ -60,7 +60,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/fe
     description='Configuration for the Grafana dashboard accompanying this policy.'
     type='Object (policies/feature-rollout/base:param:dashboard)'
     reference='../../../bundled-blueprints/policies/feature-rollout/base#dashboard'
-    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
+    value='{"datasource": {"filter_regex": "", "name": "$datasource"}, "extra_filters": {}, "refresh_interval": "5s", "time_from": "now-15m", "time_to": "now"}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/quota-scheduler.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/quota-scheduler.md
@@ -207,6 +207,20 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/qu
 
 <!-- vale off -->
 
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
 ##### dashboard.datasource {#dashboard-datasource}
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/rate-limiting.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/rate-limiting.md
@@ -165,6 +165,20 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/ra
 
 <!-- vale off -->
 
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
 ##### dashboard.datasource {#dashboard-datasource}
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency.md
@@ -405,6 +405,20 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <!-- vale off -->
 
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
 ##### dashboard.datasource {#dashboard-datasource}
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql.md
@@ -291,6 +291,20 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <!-- vale off -->
 
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
 ##### dashboard.datasource {#dashboard-datasource}
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection/average-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection/average-latency.md
@@ -273,7 +273,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <ParameterDescription
     name='dashboard.time_from'
-    description='From time of dashboard.'
+    description='Time from of dashboard.'
     type='string'
     reference=''
     value='"now-15m"'
@@ -287,10 +287,24 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <ParameterDescription
     name='dashboard.time_to'
-    description='To time of dashboard.'
+    description='Time to of dashboard.'
     type='string'
     reference=''
     value='"now"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection/promql.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection/promql.md
@@ -190,7 +190,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <ParameterDescription
     name='dashboard.time_from'
-    description='From time of dashboard.'
+    description='Time from of dashboard.'
     type='string'
     reference=''
     value='"now-15m"'
@@ -204,10 +204,24 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <ParameterDescription
     name='dashboard.time_to'
-    description='To time of dashboard.'
+    description='Time to of dashboard.'
     type='string'
     reference=''
     value='"now"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
 />
 
 <!-- vale on -->


### PR DESCRIPTION
### Description of change

Add `extra_filters` to blueprints' dashboards, which allow to pass extra label filters to Prometheus in Grafana Dashboards.

Drive-by: Fix `map` handling in `blueprint-assets-generator.py`.

Ref: GH-2010

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added `extra_filters` parameter to blueprints' dashboards for passing extra label filters to Prometheus in Grafana Dashboards
- Improved handling of maps in `blueprint-assets-generator.py`
- Added support for boolean values in the `serializeValue` function

**Bug fix:**
- Set `additionalProperties` to `true` for `map` types in YAML output

**Documentation:**
- Updated documentation with a new parameter description for `dashboard.extra_filters`

> 🎉 Extra filters, oh so fine! 🌟
> Enhancing dashboards, making them shine! ✨
> Maps and booleans, now handled with care, 🗺️🔍
> Our code's more robust, beyond compare! 🚀💯
<!-- end of auto-generated comment: release notes by openai -->