### PR TITLE
fix broken link

### DIFF
--- a/docs/content/applying-policies/quota-scheduler/external-rate-limiting.md
+++ b/docs/content/applying-policies/quota-scheduler/external-rate-limiting.md
@@ -29,7 +29,7 @@ based Workload Scheduler to assure prioritized access for critical workloads.
 ## Policy
 
 In this policy,
-[Quota Scheduler](reference/policies/bundled-blueprints/policies/quota-scheduler.md#policy-quota-scheduler)
+[Quota Scheduler](/reference/policies/bundled-blueprints/policies/quota-scheduler.md#policy-quota-scheduler)
 component is configured with `bucket_capacity`, and rate limiting is configured
 based on label key `api_key` extracted from the request header. While the lazy
 sync of between the agent is set to false.
@@ -77,6 +77,6 @@ for this policy.
 
 <Zoom>
 
-![Quota Scheduler With Workload Prioritization ](./assets/with-external-api-calls-prioritization/dashboard.png)
+![External Rate Limiting With Prioritization ](./assets/with-external-api-calls-prioritization/dashboard.png)
 
 </Zoom>


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Fixed a broken link in the quota-scheduler external rate limiting policy documentation

> 🎉 A broken link no more, we've mended the lore,
> In our docs now restored, users can explore! 📚
<!-- end of auto-generated comment: release notes by openai -->