### PR TITLE
Add inframeter for collecting jmx metrics from prometheus

### DIFF
--- a/playground/resources/java-demo-app/build.gradle.kts
+++ b/playground/resources/java-demo-app/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
             exclude(group = "org.slf4j", module = "slf4j-api")
     }
 
+	implementation("org.springframework.boot:spring-boot-starter-actuator:2.7.9")
+	implementation("io.micrometer:micrometer-registry-prometheus:1.9.0")
 	implementation("org.springframework.boot:spring-boot-starter-web:2.7.9")
 	implementation("com.fluxninja.aperture:aperture-java-core:1.5.0")
 

--- a/playground/resources/java-demo-app/src/main/resources/application.properties
+++ b/playground/resources/java-demo-app/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 logging.level.com=error
 logging.level.org.springframework.web=error
+management.endpoints.web.exposure.include=health,metrics,prometheus
+management.metrics.web.server.auto-time-requests=true

--- a/playground/resources/wavepool-generator/apps-v1.Deployment-wavepool-graphql-generator.yaml
+++ b/playground/resources/wavepool-generator/apps-v1.Deployment-wavepool-graphql-generator.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app.kubernetes.io/component: wavepool-generator
         sidecar.istio.io/inject: "false"
+      annotations:
+        prometheus.io/scrape: "false"
     spec:
       containers:
         - args:

--- a/playground/scenarios/java-service-protection/metadata.json
+++ b/playground/scenarios/java-service-protection/metadata.json
@@ -17,9 +17,7 @@
     }
   ],
   "port_forwards": {
-    "service1-demo-app": "8087:8087",
-    "service2-demo-app": "8087:8087",
-    "service3-demo-app": "8087:8087"
+    "service1-demo-app": "8087:8087"
   },
   "child_resources": [
     {

--- a/playground/scenarios/java-service-protection/metadata.json
+++ b/playground/scenarios/java-service-protection/metadata.json
@@ -16,9 +16,6 @@
       "ssh": "default"
     }
   ],
-  "port_forwards": {
-    "service1-demo-app": "8087:8087"
-  },
   "child_resources": [
     {
       "workload": "service1-demo-app",

--- a/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
@@ -18,12 +18,23 @@ metadata:
       "service3-demo-app.demoapp.svc.cluster.local"}]}}, "policy_name": "service-protection",
       "resources": {"flow_control": {"classifiers": [{"rules": {"user_type": {"extractor":
       {"from": "request.http.headers.user-type"}}}, "selectors": [{"control_point":
-      "awesomeFeature", "service": "service1-demo-app.demoapp.svc.cluster.local"}]}]}},
-      "service_protection_core": {"adaptive_load_scheduler": {"load_multiplier_linear_increment":
-      0.0025000000000000001, "load_scheduler": {"scheduler": {"workloads": [{"label_matcher":
-      {"match_labels": {"user_type": "guest"}}, "parameters": {"priority": 50}}, {"label_matcher":
-      {"match_labels": {"user_type": "subscriber"}}, "parameters": {"priority": 200}}]},
-      "selectors": [{"control_point": "awesomeFeature", "service": "service1-demo-app.demoapp.svc.cluster.local"}]}}}}}'
+      "awesomeFeature", "service": "service1-demo-app.demoapp.svc.cluster.local"}]}]},
+      "telemetry_collectors": [{"agent_group": "default", "infra_meters": {"prometheus":
+      {"per_agent_group": true, "pipeline": {"receivers": ["prometheus"]}, "receivers":
+      {"prometheus": {"config": {"scrape_configs": [{"job_name": "java-demo-app-jmx",
+      "kubernetes_sd_configs": [{"namespaces": {"names": ["demoapp"]}, "role": "pod"}],
+      "relabel_configs": [{"action": "keep", "regex": true, "source_labels": ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]},
+      {"action": "keep", "regex": "(.*?:8087)", "source_labels": ["__address__"]}],
+      "scrape_interval": "10s"}, {"job_name": "java-demo-app-micrometer", "kubernetes_sd_configs":
+      [{"namespaces": {"names": ["demoapp"]}, "role": "pod"}], "metrics_path": "/actuator/prometheus",
+      "relabel_configs": [{"action": "keep", "regex": true, "source_labels": ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]},
+      {"action": "keep", "regex": "(.*?:8099)", "source_labels": ["__address__"]}],
+      "scrape_interval": "10s"}]}}}}}}]}, "service_protection_core": {"adaptive_load_scheduler":
+      {"load_multiplier_linear_increment": 0.0025000000000000001, "load_scheduler":
+      {"scheduler": {"workloads": [{"label_matcher": {"match_labels": {"user_type":
+      "guest"}}, "parameters": {"priority": 50}}, {"label_matcher": {"match_labels":
+      {"user_type": "subscriber"}}, "parameters": {"priority": 200}}]}, "selectors":
+      [{"control_point": "awesomeFeature", "service": "service1-demo-app.demoapp.svc.cluster.local"}]}}}}}'
   labels:
     fluxninja.com/validate: "true"
   name: service-protection
@@ -197,6 +208,23 @@ spec:
                     - __meta_kubernetes_pod_annotation_prometheus_io_scrape
                   - action: keep
                     regex: (.*?:8087)
+                    source_labels:
+                    - __address__
+                  scrape_interval: 10s
+                - job_name: java-demo-app-micrometer
+                  kubernetes_sd_configs:
+                  - namespaces:
+                      names:
+                      - demoapp
+                    role: pod
+                  metrics_path: /actuator/prometheus
+                  relabel_configs:
+                  - action: keep
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                  - action: keep
+                    regex: (.*?:8099)
                     source_labels:
                     - __address__
                   scrape_interval: 10s

--- a/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
@@ -172,3 +172,31 @@ spec:
           selectors:
           - control_point: awesomeFeature
             service: service3-demo-app.demoapp.svc.cluster.local
+    telemetry_collectors:
+    - agent_group: default
+      infra_meters:
+        prometheus:
+          per_agent_group: true
+          pipeline:
+            receivers:
+            - prometheus
+          receivers:
+            prometheus:
+              config:
+                scrape_configs:
+                - job_name: java-demo-app-jmx
+                  kubernetes_sd_configs:
+                  - namespaces:
+                      names:
+                      - demoapp
+                    role: pod
+                  relabel_configs:
+                  - action: keep
+                    regex: true
+                    source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                  - action: keep
+                    regex: (.*?:8087)
+                    source_labels:
+                    - __address__
+                  scrape_interval: 10s

--- a/playground/scenarios/java-service-protection/policies/service-protection.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection.yaml
@@ -63,6 +63,32 @@ policy:
             user_type:
               extractor:
                 from: request.http.headers.user-type
+    telemetry_collectors:
+      - agent_group: default
+        infra_meters:
+          prometheus:
+            per_agent_group: true
+            pipeline:
+              receivers:
+                - prometheus
+            receivers:
+              prometheus:
+                config:
+                  scrape_configs:
+                    - job_name: 'java-demo-app-jmx'
+                      scrape_interval: 10s
+                      kubernetes_sd_configs:
+                        - role: pod
+                          namespaces:
+                            names:
+                              - demoapp
+                      relabel_configs:
+                        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                          action: keep
+                          regex: true
+                        - source_labels: [__address__]
+                          action: keep
+                          regex: (.*?:8087)
 
   service_protection_core:
     adaptive_load_scheduler:

--- a/playground/scenarios/java-service-protection/policies/service-protection.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection.yaml
@@ -89,6 +89,21 @@ policy:
                         - source_labels: [__address__]
                           action: keep
                           regex: (.*?:8087)
+                    - job_name: 'java-demo-app-micrometer'
+                      scrape_interval: 10s
+                      metrics_path: '/actuator/prometheus'
+                      kubernetes_sd_configs:
+                        - role: pod
+                          namespaces:
+                            names:
+                              - demoapp
+                      relabel_configs:
+                        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                          action: keep
+                          regex: true
+                        - source_labels: [__address__]
+                          action: keep
+                          regex: (.*?:8099)
 
   service_protection_core:
     adaptive_load_scheduler:

--- a/playground/tanka/apps/java-demo-app/mixins.libsonnet
+++ b/playground/tanka/apps/java-demo-app/mixins.libsonnet
@@ -10,6 +10,10 @@ local application = {
   },
   values:: {
     replicaCount: 2,
+    podAnnotations: {
+      'prometheus.io/scrape': 'true',
+      'prometheus.io/port': '8087',
+    },
   },
   service1:
     helm.template('service1', 'charts/java-demo-app', {


### PR DESCRIPTION
### Description of change
Ref: GH-2009

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added JMX metrics collection for Prometheus
- Enabled automatic timing of requests for the metrics endpoint

> 🎉 Oh, what a glorious day! 🌟
> Metrics now pave our way. 📊
> With JMX in hand, 🤲
> Our app's performance we'll understand. 💡
> Rejoice, for Prometheus is here to stay! 🚀
<!-- end of auto-generated comment: release notes by openai -->