### PR TITLE
Java SDK: Rename methods to be more descriptive

### DIFF
--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
@@ -54,7 +54,7 @@ public class ArmeriaClient {
                     ApertureSDK.builder()
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
-                            .setDuration(Duration.ofMillis(1000))
+                            .setFlowTimeout(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
                             .setRootCertificateFile(rootCertFile)
                             .build();

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
@@ -86,7 +86,7 @@ public class ArmeriaServer {
                     ApertureSDK.builder()
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
-                            .setDuration(Duration.ofMillis(1000))
+                            .setFlowTimeout(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
                             .setRootCertificateFile(rootCertFile)
                             .build();

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -31,10 +31,10 @@ public class ApertureFeatureFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) res;
 
         // Check whether flow was accepted by Aperture Agent
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             try {
@@ -74,7 +74,7 @@ public class ApertureFeatureFilter implements Filter {
                     ApertureSDK.builder()
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
-                            .setDuration(Duration.ofMillis(1000))
+                            .setFlowTimeout(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
                             .setRootCertificateFile(rootCertificateFile)
                             .build();

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -56,7 +56,7 @@ public class App {
                     ApertureSDK.builder()
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
-                            .setDuration(Duration.ofMillis(1000))
+                            .setFlowTimeout(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
                             .setRootCertificateFile(rootCertFile)
                             .build();
@@ -91,9 +91,9 @@ public class App {
         // Flow.
         Flow flow = this.apertureSDK.startFlow(this.featureName, labels);
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         // See whether flow was accepted by Aperture Agent.
-        if (flowResult != FlowResult.Rejected) {
+        if (flowDecision != FlowDecision.Rejected) {
             // Simulate work being done
             try {
                 res.status(202);
@@ -110,7 +110,7 @@ public class App {
         } else {
             // Flow has been rejected by Aperture Agent.
             try {
-                res.status(flow.rejectReason());
+                res.status(flow.getRejectionHttpStatusCode());
                 flow.end(FlowStatus.Error);
             } catch (ApertureSDKException e) {
                 e.printStackTrace();

--- a/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -29,9 +29,9 @@ public class ApertureFeatureFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         // See whether flow was accepted by Aperture Agent.
-        if (flowResult != FlowResult.Rejected) {
+        if (flowDecision != FlowDecision.Rejected) {
             try {
                 chain.doFilter(request, response);
                 flow.end(FlowStatus.OK);
@@ -68,7 +68,7 @@ public class ApertureFeatureFilter implements Filter {
                     ApertureSDK.builder()
                             .setHost(agentHost)
                             .setPort(Integer.parseInt(agentPort))
-                            .setDuration(Duration.ofMillis(1000))
+                            .setFlowTimeout(Duration.ofMillis(1000))
                             .useInsecureGrpc(insecureGrpc)
                             .setRootCertificateFile(rootCertificateFile)
                             .build();

--- a/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
+++ b/sdks/aperture-java/javaagent/agent/src/main/java/com/fluxninja/aperture/instrumentation/Config.java
@@ -106,7 +106,7 @@ public class Config {
                                     Integer.parseInt(
                                             config.getProperty(
                                                     AGENT_PORT_PROPERTY, AGENT_PORT_DEFAULT_VALUE)))
-                            .setDuration(
+                            .setFlowTimeout(
                                     Duration.ofMillis(
                                             Integer.parseInt(
                                                     config.getProperty(

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
@@ -55,10 +55,10 @@ public class ApertureHTTPClient extends SimpleDecoratingHttpClient {
             return unwrap().execute(ctx, req);
         }
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             HttpResponse res;

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
@@ -54,10 +54,10 @@ public class ApertureHTTPService extends SimpleDecoratingHttpService {
             return unwrap().serve(ctx, req);
         }
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             HttpResponse res;

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClient.java
@@ -48,10 +48,10 @@ public class ApertureRPCClient extends SimpleDecoratingRpcClient {
         Map<String, String> labels = RpcUtils.labelsFromRequest(req);
         Flow flow = this.apertureSDK.startFlow(this.controlPointName, labels);
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             RpcResponse res;

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCService.java
@@ -48,10 +48,10 @@ public class ApertureRPCService extends SimpleDecoratingRpcService {
         Map<String, String> labels = RpcUtils.labelsFromRequest(req);
         Flow flow = this.apertureSDK.startFlow(this.controlPointName, labels);
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             RpcResponse res;

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
@@ -23,7 +23,7 @@ class HttpUtils {
             e.printStackTrace();
         }
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
-            int httpStatusCode = flow.rejectReason();
+            int httpStatusCode = flow.getRejectionHttpStatusCode();
             HttpResponseBuilder resBuilder = HttpResponse.builder();
             resBuilder.status(httpStatusCode);
             for (Map.Entry<String, String> entry :

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
@@ -15,7 +15,7 @@ class RpcUtils {
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }
-        return HttpStatus.valueOf(flow.rejectReason());
+        return HttpStatus.valueOf(flow.getRejectionHttpStatusCode());
     }
 
     protected static Map<String, String> labelsFromRequest(RpcRequest req) {

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
@@ -27,7 +27,7 @@ public final class ApertureSDK {
     private final FlowControlServiceHTTPGrpc.FlowControlServiceHTTPBlockingStub
             httpFlowControlClient;
     private final Tracer tracer;
-    private final Duration timeout;
+    private final Duration flowTimeout;
     private final List<String> ignoredPaths;
     private final boolean ignoredPathsMatchRegex;
 
@@ -35,12 +35,12 @@ public final class ApertureSDK {
             FlowControlServiceGrpc.FlowControlServiceBlockingStub flowControlClient,
             FlowControlServiceHTTPGrpc.FlowControlServiceHTTPBlockingStub httpFlowControlClient,
             Tracer tracer,
-            Duration timeout,
+            Duration flowTimeout,
             List<String> ignoredPaths,
             boolean ignoredPathsMatchRegex) {
         this.flowControlClient = flowControlClient;
         this.tracer = tracer;
-        this.timeout = timeout;
+        this.flowTimeout = flowTimeout;
         this.httpFlowControlClient = httpFlowControlClient;
         this.ignoredPaths = ignoredPaths;
         this.ignoredPathsMatchRegex = ignoredPathsMatchRegex;
@@ -90,12 +90,12 @@ public final class ApertureSDK {
 
         CheckResponse res = null;
         try {
-            if (timeout.isZero()) {
+            if (flowTimeout.isZero()) {
                 res = this.flowControlClient.check(req);
             } else {
                 res =
                         this.flowControlClient
-                                .withDeadlineAfter(timeout.toNanos(), TimeUnit.NANOSECONDS)
+                                .withDeadlineAfter(flowTimeout.toNanos(), TimeUnit.NANOSECONDS)
                                 .check(req);
             }
         } catch (StatusRuntimeException e) {
@@ -120,12 +120,12 @@ public final class ApertureSDK {
 
         CheckHTTPResponse res = null;
         try {
-            if (timeout.isZero()) {
+            if (flowTimeout.isZero()) {
                 res = this.httpFlowControlClient.checkHTTP(req);
             } else {
                 res =
                         this.httpFlowControlClient
-                                .withDeadlineAfter(timeout.toNanos(), TimeUnit.NANOSECONDS)
+                                .withDeadlineAfter(flowTimeout.toNanos(), TimeUnit.NANOSECONDS)
                                 .checkHTTP(req);
             }
         } catch (StatusRuntimeException e) {

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /** A builder for configuring an {@link ApertureSDK}. */
 public final class ApertureSDKBuilder {
-    private Duration timeout;
+    private Duration flowTimeout;
     private String host;
     private int port;
     private boolean useHttpsInOtlpExporter = false;
@@ -52,8 +52,8 @@ public final class ApertureSDKBuilder {
      * @param timeout timeout for connection to Aperture Agent.
      * @return the builder object.
      */
-    public ApertureSDKBuilder setDuration(Duration timeout) {
-        this.timeout = timeout;
+    public ApertureSDKBuilder setFlowTimeout(Duration timeout) {
+        this.flowTimeout = timeout;
         return this;
     }
 
@@ -175,9 +175,9 @@ public final class ApertureSDKBuilder {
             OtlpSpanExporterProtocol = "https";
         }
 
-        Duration timeout = this.timeout;
-        if (timeout == null) {
-            timeout = DEFAULT_RPC_TIMEOUT;
+        Duration flowTimeout = this.flowTimeout;
+        if (flowTimeout == null) {
+            flowTimeout = DEFAULT_RPC_TIMEOUT;
         }
 
         ChannelCredentials creds;
@@ -230,7 +230,7 @@ public final class ApertureSDKBuilder {
                 flowControlClient,
                 httpFlowControlClient,
                 tracer,
-                timeout,
+                flowTimeout,
                 ignoredPaths,
                 ignoredPathsMatchRegex);
     }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
@@ -21,11 +21,11 @@ public final class Flow {
     /**
      * Returns 'true' if flow was accepted by Aperture Agent, or if the Agent did not respond.
      *
-     * @deprecated This method assumes fail-open behavior. Use {@link #result} instead
+     * @deprecated This method assumes fail-open behavior. Use {@link #getDecision} instead
      * @return Whether the flow was accepted.
      */
     public boolean accepted() {
-        return result() == FlowResult.Unreachable || result() == FlowResult.Accepted;
+        return getDecision() == FlowDecision.Unreachable || getDecision() == FlowDecision.Accepted;
     }
 
     /**
@@ -33,15 +33,15 @@ public final class Flow {
      *
      * @return Result of Check query
      */
-    public FlowResult result() {
+    public FlowDecision getDecision() {
         if (this.checkResponse == null) {
-            return FlowResult.Unreachable;
+            return FlowDecision.Unreachable;
         }
         if (this.checkResponse.getDecisionType()
                 == CheckResponse.DecisionType.DECISION_TYPE_ACCEPTED) {
-            return FlowResult.Accepted;
+            return FlowDecision.Accepted;
         }
-        return FlowResult.Rejected;
+        return FlowDecision.Rejected;
     }
 
     public CheckResponse checkResponse() {
@@ -54,8 +54,8 @@ public final class Flow {
      *
      * @return HTTP code of rejection reason
      */
-    public int rejectReason() {
-        if (this.result() == FlowResult.Rejected) {
+    public int getRejectionHttpStatusCode() {
+        if (this.getDecision() == FlowDecision.Rejected) {
             switch (this.checkResponse.getRejectReason()) {
                 case REJECT_REASON_RATE_LIMITED:
                     return HttpStatus.SC_TOO_MANY_REQUESTS;

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowDecision.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowDecision.java
@@ -1,6 +1,6 @@
 package com.fluxninja.aperture.sdk;
 
-public enum FlowResult {
+public enum FlowDecision {
     Accepted,
     Rejected,
     Unreachable

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/TrafficFlow.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/TrafficFlow.java
@@ -32,11 +32,11 @@ public class TrafficFlow {
     /**
      * Returns 'true' if flow was accepted by Aperture Agent, or if the agent did not respond.
      *
-     * @deprecated This method assumes fail-open behavior. Use {@link #result} instead
+     * @deprecated This method assumes fail-open behavior. Use {@link #getDecision} instead
      * @return Whether the flow was accepted.
      */
     public boolean accepted() {
-        return result() == FlowResult.Unreachable || result() == FlowResult.Accepted;
+        return getDecision() == FlowDecision.Unreachable || getDecision() == FlowDecision.Accepted;
     }
 
     /**
@@ -44,14 +44,14 @@ public class TrafficFlow {
      *
      * @return Result of Check query
      */
-    public FlowResult result() {
+    public FlowDecision getDecision() {
         if (this.checkResponse == null) {
-            return FlowResult.Unreachable;
+            return FlowDecision.Unreachable;
         }
         if (this.checkResponse.getStatus().getCode() == Code.OK_VALUE) {
-            return FlowResult.Accepted;
+            return FlowDecision.Accepted;
         }
-        return FlowResult.Rejected;
+        return FlowDecision.Rejected;
     }
 
     public boolean ignored() {
@@ -68,8 +68,8 @@ public class TrafficFlow {
      *
      * @return HTTP code of rejection reason
      */
-    public int rejectReason() {
-        if (this.result() == FlowResult.Rejected) {
+    public int getRejectionHttpStatusCode() {
+        if (this.getDecision() == FlowDecision.Rejected) {
             if (this.checkResponse().hasDeniedResponse()
                     && this.checkResponse().getDeniedResponse().getStatus() != 0) {
                 return this.checkResponse.getDeniedResponse().getStatus();

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -54,10 +54,10 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
             return;
         }
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             try {
@@ -95,7 +95,7 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
             HttpResponseStatus status;
             Map<String, String> headers;
             if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
-                status = HttpResponseStatus.valueOf(flow.rejectReason());
+                status = HttpResponseStatus.valueOf(flow.getRejectionHttpStatusCode());
                 headers = flow.checkResponse().getDeniedResponse().getHeadersMap();
 
             } else {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -37,10 +37,10 @@ public class ApertureFilter implements Filter {
             return;
         }
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             try {
@@ -106,7 +106,7 @@ public class ApertureFilter implements Filter {
             builder.setHost(agentHost);
             builder.setPort(Integer.parseInt(agentPort));
             if (timeoutMs != null) {
-                builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
+                builder.setFlowTimeout(Duration.ofMillis(Integer.parseInt(timeoutMs)));
             }
             builder.useInsecureGrpc(insecureGrpc);
             if (rootCertificateFile != null && !rootCertificateFile.isEmpty()) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
@@ -27,7 +27,7 @@ public class ServletUtils {
 
         int code = 403;
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
-            code = flow.rejectReason();
+            code = flow.getRejectionHttpStatusCode();
             Map<String, String> headers = flow.checkResponse().getDeniedResponse().getHeadersMap();
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 response.setHeader(entry.getKey(), entry.getValue());

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -37,10 +37,10 @@ public class ApertureFilter implements Filter {
             return;
         }
 
-        FlowResult flowResult = flow.result();
+        FlowDecision flowDecision = flow.getDecision();
         boolean flowAccepted =
-                (flowResult == FlowResult.Accepted
-                        || (flowResult == FlowResult.Unreachable && this.failOpen));
+                (flowDecision == FlowDecision.Accepted
+                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
 
         if (flowAccepted) {
             try {
@@ -106,7 +106,7 @@ public class ApertureFilter implements Filter {
             builder.setHost(agentHost);
             builder.setPort(Integer.parseInt(agentPort));
             if (timeoutMs != null) {
-                builder.setDuration(Duration.ofMillis(Integer.parseInt(timeoutMs)));
+                builder.setFlowTimeout(Duration.ofMillis(Integer.parseInt(timeoutMs)));
             }
             builder.useInsecureGrpc(insecureGrpc);
             if (rootCertificateFile != null && !rootCertificateFile.isEmpty()) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
@@ -27,7 +27,7 @@ public class ServletUtils {
 
         int code = 403;
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
-            code = flow.rejectReason();
+            code = flow.getRejectionHttpStatusCode();
             Map<String, String> headers = flow.checkResponse().getDeniedResponse().getHeadersMap();
             for (Map.Entry<String, String> entry : headers.entrySet()) {
                 response.setHeader(entry.getKey(), entry.getValue());


### PR DESCRIPTION
ApertureSDKBuilder.setDuration -> ApertureSDKBuilder.setFlowTimeout
Flow.rejectReason -> Flow.getRejectionHttpStatusCode

### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Renamed `ApertureSDKBuilder.setDuration` to `ApertureSDKBuilder.setFlowTimeout`
- Renamed `Flow.rejectReason` to `Flow.getRejectionHttpStatusCode`
- Changed enum value name from `FlowResult` to `FlowDecision`

> 🎉 A new chapter unfolds, with names refined and bold,
> The code now speaks clearer, its purpose well told. 🚀
> With enums and methods, in harmony they stand,
> A refactor to celebrate, for a future grand! 🌟
<!-- end of auto-generated comment: release notes by openai -->