### PR TITLE
Fixed issue of incorrect value of setpoint constant variable

### DIFF
--- a/pkg/policies/controlplane/components/variable.go
+++ b/pkg/policies/controlplane/components/variable.go
@@ -66,6 +66,7 @@ func (v *Variable) DynamicConfigUpdate(event notifiers.Event, unmarshaller confi
 	// read dynamic config
 	if !unmarshaller.IsSet(key) {
 		v.constantOutput = runtime.ConstantSignalFromProto(v.variableProto.GetConstantOutput())
+		return
 	}
 	constantSignalProto := &policylangv1.ConstantSignal{}
 	if err := unmarshaller.UnmarshalKey(key, constantSignalProto); err != nil {


### PR DESCRIPTION
Ref #2052 

##### Checklist

- [x] Tested in playground or other setup
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
### Optimization
- Improved performance in `pkg/policies/controlplane/components/variable.go` by adding an early return statement to avoid unnecessary computation.
```

> 🎉 A leap in code, swift and wise,
> 🚀 With early returns, performance flies!
> 🌟 Optimized, our code now gleams,
> 😄 For better software, we all dream!
<!-- end of auto-generated comment: release notes by openai -->