### PR TITLE
Revert "Send policy metadata in heartbeats (#2047)"

### DIFF
--- a/pkg/policies/controlplane/crwatcher/watcher.go
+++ b/pkg/policies/controlplane/crwatcher/watcher.go
@@ -20,13 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/yaml"
 
-	languagev1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
-	syncv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/sync/v1"
 	"github.com/fluxninja/aperture/v2/operator/api"
 	policyv1alpha1 "github.com/fluxninja/aperture/v2/operator/api/policy/v1alpha1"
-	"github.com/fluxninja/aperture/v2/pkg/config"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 	"github.com/fluxninja/aperture/v2/pkg/notifiers"
 	panichandler "github.com/fluxninja/aperture/v2/pkg/panic-handler"
@@ -209,27 +205,7 @@ func (w *watcher) updateStatus(ctx context.Context, instance *policyv1alpha1.Pol
 
 // reconcilePolicy sends a write event to notifier to get it uploaded on the Etcd.
 func (w *watcher) reconcilePolicy(ctx context.Context, instance *policyv1alpha1.Policy) error {
-	policySpec := &languagev1.Policy{}
-	unmarshalErr := config.UnmarshalYAML(instance.Spec.Raw, policySpec)
-	if unmarshalErr != nil {
-		log.Warn().Err(unmarshalErr).Msg("Failed to unmarshal policy")
-		return unmarshalErr
-	}
-
-	annotations := instance.GetObjectMeta().GetAnnotations()
-	policyMessage := &syncv1.PolicyWrapper{
-		Policy: policySpec,
-		PolicyMetadata: &languagev1.PolicyMetadata{
-			Values:        annotations["fluxninja.com/values"],
-			BlueprintsUri: annotations["fluxninja.com/blueprints-uri"],
-			BlueprintName: annotations["fluxninja.com/blueprint-name"],
-		},
-	}
-	bytes, err := yaml.Marshal(policyMessage)
-	if err != nil {
-		return err
-	}
-	w.WriteEvent(notifiers.Key(instance.GetName()), bytes)
+	w.WriteEvent(notifiers.Key(instance.GetName()), instance.Spec.Raw)
 	w.policyDynamicConfigTrackers.WriteEvent(notifiers.Key(instance.GetName()), instance.DynamicConfig.Raw)
 
 	w.recorder.Eventf(instance, corev1.EventTypeWarning, "UploadSuccessful", "Uploaded policy to trackers.")

--- a/pkg/policies/controlplane/policy-service.go
+++ b/pkg/policies/controlplane/policy-service.go
@@ -77,6 +77,7 @@ func (s *PolicyService) GetPolicy(ctx context.Context, request *policylangv1.Get
 // UpsertPolicy creates/updates policy to the system.
 func (s *PolicyService) UpsertPolicy(ctx context.Context, req *policylangv1.UpsertPolicyRequest) (*emptypb.Empty, error) {
 	updateMask := req.UpdateMask != nil && len(req.UpdateMask.GetPaths()) > 0
+
 	policy, err := s.GetPolicy(ctx, &policylangv1.GetPolicyRequest{Name: req.PolicyName})
 	if err != nil && updateMask {
 		return nil, err
@@ -102,6 +103,7 @@ func (s *PolicyService) UpsertPolicy(ctx context.Context, req *policylangv1.Upse
 	if err != nil {
 		return nil, fmt.Errorf("failed to write policy '%s' to etcd: '%s'", req.PolicyName, err)
 	}
+
 	return new(emptypb.Empty), nil
 }
 

--- a/pkg/policies/controlplane/policy.go
+++ b/pkg/policies/controlplane/policy.go
@@ -75,7 +75,7 @@ func newPolicyOptions(wrapperMessage *policysyncv1.PolicyWrapper, registry statu
 
 // CompilePolicy takes policyMessage and returns a compiled policy. This is a helper method for standalone consumption of policy compiler.
 func CompilePolicy(policyMessage *policylangv1.Policy, registry status.Registry) (*circuitfactory.Circuit, error) {
-	wrapperMessage, err := hashAndPolicyWrap(policyMessage, "DoesNotMatter", nil)
+	wrapperMessage, err := hashAndPolicyWrap(policyMessage, "DoesNotMatter")
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func (policy *Policy) GetStatusRegistry() status.Registry {
 }
 
 // hashAndPolicyWrap wraps a proto message with a config properties wrapper and hashes it.
-func hashAndPolicyWrap(policyMessage *policylangv1.Policy, policyName string, metadata *policylangv1.PolicyMetadata) (*policysyncv1.PolicyWrapper, error) {
+func hashAndPolicyWrap(policyMessage *policylangv1.Policy, policyName string) (*policysyncv1.PolicyWrapper, error) {
 	jsonDat, marshalErr := json.Marshal(policyMessage)
 	if marshalErr != nil {
 		log.Error().Err(marshalErr).Msgf("Failed to marshal proto message %+v", policyMessage)
@@ -281,6 +281,5 @@ func hashAndPolicyWrap(policyMessage *policylangv1.Policy, policyName string, me
 			PolicyName: policyName,
 			PolicyHash: hash,
 		},
-		PolicyMetadata: metadata,
 	}, nil
 }

--- a/pkg/policies/controlplane/provider.go
+++ b/pkg/policies/controlplane/provider.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/multierr"
 	"sigs.k8s.io/yaml"
 
-	syncv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/sync/v1"
+	policylangv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
 	etcdnotifier "github.com/fluxninja/aperture/v2/pkg/etcd/notifier"
@@ -122,13 +122,13 @@ func setupPoliciesNotifier(
 		}
 		switch etype {
 		case notifiers.Write:
-			policyMessage := &syncv1.PolicyWrapper{}
-			unmarshalErr := yaml.Unmarshal(bytes, policyMessage)
+			policyMessage := &policylangv1.Policy{}
+			unmarshalErr := config.UnmarshalYAML(bytes, policyMessage)
 			if unmarshalErr != nil {
 				log.Warn().Err(unmarshalErr).Msg("Failed to unmarshal policy")
 				return key, nil, unmarshalErr
 			}
-			wrapper, wrapErr := hashAndPolicyWrap(policyMessage.GetPolicy(), string(key), policyMessage.GetPolicyMetadata())
+			wrapper, wrapErr := hashAndPolicyWrap(policyMessage, string(key))
 			if wrapErr != nil {
 				log.Warn().Err(wrapErr).Msg("Failed to wrap message in config properties")
 				return key, nil, wrapErr

--- a/pkg/policies/controlplane/validator.go
+++ b/pkg/policies/controlplane/validator.go
@@ -89,7 +89,6 @@ func ValidateAndCompile(ctx context.Context, name string, yamlSrc []byte) (*circ
 	if err != nil {
 		return nil, nil, err
 	}
-	// TODO: this is a hack to make unmarshal work. We should configure unmarshaller to not fail on unknown fields.
 	delete(yamlRaw, "metadata")
 	yamlSrc, err = yaml.Marshal(yamlRaw)
 	if err != nil {


### PR DESCRIPTION
That commit introduced a bug and controller was crashing on umarshaling
policy messages.

### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Revert commit causing controller crash on unmarshaling policy messages
- Write raw policy directly to notifier instead of marshaling
- Add check for `updateMask` in `GetPolicy` call

Style:
- Remove TODO comment and delete "metadata" field from YAML map in validator.go
```

> 🎉 A bug we found, a fix we made,
> Unmarshaling woes begin to fade.
> UpdateMask checks now in place,
> Our code moves forward with newfound grace. 🚀
<!-- end of auto-generated comment: release notes by openai -->