### PR TITLE
wfq: refactor locking

### DIFF
--- a/pkg/policies/flowcontrol/actuators/quota-scheduler/quota-scheduler.go
+++ b/pkg/policies/flowcontrol/actuators/quota-scheduler/quota-scheduler.go
@@ -403,7 +403,6 @@ func (qs *quotaScheduler) Decide(ctx context.Context, labels map[string]string) 
 			qs.proto.Scheduler,
 			qs,
 			tokenBucket,
-			qs.clock,
 			qs.schedulerMetrics,
 		)
 		if err != nil {
@@ -424,14 +423,14 @@ func (qs *quotaScheduler) Decide(ctx context.Context, labels map[string]string) 
 }
 
 // Revert returns the tokens to the limiter.
-func (qs *quotaScheduler) Revert(labels map[string]string, decision *flowcontrolv1.LimiterDecision) {
+func (qs *quotaScheduler) Revert(ctx context.Context, labels map[string]string, decision *flowcontrolv1.LimiterDecision) {
 	// return to the underlying rate limiter
 	if qsDecision, ok := decision.GetDetails().(*flowcontrolv1.LimiterDecision_QuotaSchedulerInfo_); ok {
 		tokens := qsDecision.QuotaSchedulerInfo.SchedulerInfo.TokensConsumed
 		if tokens > 0 {
 			label, found := qs.getLabelKey(labels)
 			if found {
-				qs.limiter.TakeIfAvailable(label, float64(-tokens))
+				qs.limiter.TakeIfAvailable(ctx, label, float64(-tokens))
 			}
 		}
 	}

--- a/pkg/policies/flowcontrol/actuators/rate-limiter/rate-limiter.go
+++ b/pkg/policies/flowcontrol/actuators/rate-limiter/rate-limiter.go
@@ -330,7 +330,7 @@ func (rl *rateLimiter) Decide(ctx context.Context, labels map[string]string) *fl
 		}
 	}
 
-	label, ok, remaining, current := rl.TakeIfAvailable(labels, tokens)
+	label, ok, remaining, current := rl.TakeIfAvailable(ctx, labels, tokens)
 
 	tokensConsumed := float64(0)
 	if ok {
@@ -359,17 +359,17 @@ func (rl *rateLimiter) Decide(ctx context.Context, labels map[string]string) *fl
 }
 
 // Revert returns the tokens to the limiter.
-func (rl *rateLimiter) Revert(labels map[string]string, decision *flowcontrolv1.LimiterDecision) {
+func (rl *rateLimiter) Revert(ctx context.Context, labels map[string]string, decision *flowcontrolv1.LimiterDecision) {
 	if rateLimiterDecision, ok := decision.GetDetails().(*flowcontrolv1.LimiterDecision_RateLimiterInfo_); ok {
 		tokens := rateLimiterDecision.RateLimiterInfo.TokensConsumed
 		if tokens > 0 {
-			rl.TakeIfAvailable(labels, -tokens)
+			rl.TakeIfAvailable(ctx, labels, -tokens)
 		}
 	}
 }
 
 // TakeIfAvailable takes n tokens from the limiter.
-func (rl *rateLimiter) TakeIfAvailable(labels map[string]string, n float64) (label string, ok bool, remaining float64, current float64) {
+func (rl *rateLimiter) TakeIfAvailable(ctx context.Context, labels map[string]string, n float64) (label string, ok bool, remaining float64, current float64) {
 	if rl.limiter.GetPassThrough() {
 		return label, true, 0, 0
 	}
@@ -385,7 +385,7 @@ func (rl *rateLimiter) TakeIfAvailable(labels map[string]string, n float64) (lab
 		label = labelKey + ":" + labelValue
 	}
 
-	ok, remaining, current = rl.limiter.TakeIfAvailable(label, n)
+	ok, remaining, current = rl.limiter.TakeIfAvailable(ctx, label, n)
 	return
 }
 

--- a/pkg/policies/flowcontrol/actuators/regulator/regulator.go
+++ b/pkg/policies/flowcontrol/actuators/regulator/regulator.go
@@ -192,15 +192,15 @@ func (frf *regulatorFactory) newRegulatorOptions(
 }
 
 type regulator struct {
-	passthroughLabelValuesMutex sync.RWMutex
 	iface.Component
-	registry               status.Registry
-	factory                *regulatorFactory
-	proto                  *policylangv1.Regulator
-	passthroughLabelValues map[string]bool
-	name                   string
-	labelKey               string
-	acceptPercentage       float64
+	registry                    status.Registry
+	factory                     *regulatorFactory
+	proto                       *policylangv1.Regulator
+	passthroughLabelValues      map[string]bool
+	name                        string
+	labelKey                    string
+	acceptPercentage            float64
+	passthroughLabelValuesMutex sync.RWMutex
 }
 
 // Make sure regulator implements iface.Limiter.
@@ -358,7 +358,7 @@ func (fr *regulator) Decide(ctx context.Context,
 }
 
 // Revert implements the Revert method of the flowcontrolv1.Regulator interface.
-func (fr *regulator) Revert(_ map[string]string, _ *flowcontrolv1.LimiterDecision) {
+func (fr *regulator) Revert(_ context.Context, _ map[string]string, _ *flowcontrolv1.LimiterDecision) {
 	// No-op
 }
 

--- a/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
+++ b/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
@@ -278,7 +277,6 @@ func (metrics *SchedulerMetrics) Delete() error {
 
 // Scheduler implements load scheduler on the flowcontrol side.
 type Scheduler struct {
-	mutex                 sync.RWMutex
 	component             iface.Component
 	scheduler             scheduler.Scheduler
 	registry              status.Registry
@@ -286,6 +284,7 @@ type Scheduler struct {
 	workloadMultiMatcher  *multiMatcher
 	tokensByWorkloadIndex map[string]uint64
 	metrics               *SchedulerMetrics
+	mutex                 sync.RWMutex
 }
 
 // NewScheduler returns fx options for the load scheduler fx app.
@@ -294,7 +293,6 @@ func (wsFactory *Factory) NewScheduler(
 	proto *policylangv1.Scheduler,
 	component iface.Component,
 	tokenManger scheduler.TokenManager,
-	clock clockwork.Clock,
 	metrics *SchedulerMetrics,
 ) (*Scheduler, error) {
 	mm := multimatcher.New[int, multiMatchResult]()
@@ -329,7 +327,7 @@ func (wsFactory *Factory) NewScheduler(
 	}
 
 	// setup scheduler
-	ws.scheduler = scheduler.NewWFQScheduler(tokenManger, clock, wfqMetrics)
+	ws.scheduler = scheduler.NewWFQScheduler(tokenManger, wfqMetrics)
 
 	return ws, nil
 }
@@ -447,11 +445,11 @@ func (ws *Scheduler) Decide(ctx context.Context, labels map[string]string) *flow
 }
 
 // Revert reverts the decision made by the limiter.
-func (ws *Scheduler) Revert(labels map[string]string, decision *flowcontrolv1.LimiterDecision) {
+func (ws *Scheduler) Revert(ctx context.Context, labels map[string]string, decision *flowcontrolv1.LimiterDecision) {
 	if lsDecision, ok := decision.GetDetails().(*flowcontrolv1.LimiterDecision_LoadSchedulerInfo); ok {
 		tokens := lsDecision.LoadSchedulerInfo.TokensConsumed
 		if tokens > 0 {
-			ws.scheduler.Revert(tokens)
+			ws.scheduler.Revert(ctx, tokens)
 		}
 	}
 }

--- a/pkg/policies/flowcontrol/engine.go
+++ b/pkg/policies/flowcontrol/engine.go
@@ -66,7 +66,6 @@ func (e *Engine) GetAgentInfo() *agentinfo.AgentInfo {
 // (1) Get schedulers given a service, control point and set of labels.
 // (2) Get flux meter histogram given a metric id.
 type Engine struct {
-	mutex         sync.RWMutex
 	agentInfo     *agentinfo.AgentInfo
 	fluxMeters    map[iface.FluxMeterID]iface.FluxMeter
 	schedulers    map[iface.LimiterID]iface.Scheduler
@@ -74,6 +73,7 @@ type Engine struct {
 	regulators    map[iface.LimiterID]iface.Limiter
 	labelPreviews map[iface.PreviewID]iface.LabelPreview
 	multiMatchers map[selectors.ControlPointID]*multiMatcher
+	mutex         sync.RWMutex
 }
 
 // ProcessRequest .
@@ -207,7 +207,7 @@ func revertRemaining(
 	}
 	for l, d := range limiterDecisions {
 		if !d.Dropped && d.Reason == flowcontrolv1.LimiterDecision_LIMITER_REASON_UNSPECIFIED {
-			go l.Revert(labelsCopy, d)
+			go l.Revert(context.TODO(), labelsCopy, d)
 		}
 	}
 }

--- a/pkg/policies/flowcontrol/iface/limiter.go
+++ b/pkg/policies/flowcontrol/iface/limiter.go
@@ -29,7 +29,7 @@ type Limiter interface {
 	GetPolicyName() string
 	GetSelectors() []*policylangv1.Selector
 	Decide(ctx context.Context, labels map[string]string) *flowcontrolv1.LimiterDecision
-	Revert(labels map[string]string, decision *flowcontrolv1.LimiterDecision)
+	Revert(ctx context.Context, labels map[string]string, decision *flowcontrolv1.LimiterDecision)
 	GetLimiterID() LimiterID
 	GetRequestCounter(labels map[string]string) prometheus.Counter
 }
@@ -37,7 +37,7 @@ type Limiter interface {
 // RateLimiter interface.
 type RateLimiter interface {
 	Limiter
-	TakeIfAvailable(labels map[string]string, count float64) (label string, ok bool, remaining float64, current float64)
+	TakeIfAvailable(ctx context.Context, labels map[string]string, count float64) (label string, ok bool, remaining float64, current float64)
 }
 
 // Scheduler interface.

--- a/pkg/policies/mocks/mock_limiter.go
+++ b/pkg/policies/mocks/mock_limiter.go
@@ -109,15 +109,15 @@ func (mr *MockLimiterMockRecorder) GetSelectors() *gomock.Call {
 }
 
 // Revert mocks base method.
-func (m *MockLimiter) Revert(labels map[string]string, decision *checkv1.LimiterDecision) {
+func (m *MockLimiter) Revert(ctx context.Context, labels map[string]string, decision *checkv1.LimiterDecision) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Revert", labels, decision)
+	m.ctrl.Call(m, "Revert", ctx, labels, decision)
 }
 
 // Revert indicates an expected call of Revert.
-func (mr *MockLimiterMockRecorder) Revert(labels, decision interface{}) *gomock.Call {
+func (mr *MockLimiterMockRecorder) Revert(ctx, labels, decision interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockLimiter)(nil).Revert), labels, decision)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockLimiter)(nil).Revert), ctx, labels, decision)
 }
 
 // MockRateLimiter is a mock of RateLimiter interface.
@@ -214,21 +214,21 @@ func (mr *MockRateLimiterMockRecorder) GetSelectors() *gomock.Call {
 }
 
 // Revert mocks base method.
-func (m *MockRateLimiter) Revert(labels map[string]string, decision *checkv1.LimiterDecision) {
+func (m *MockRateLimiter) Revert(ctx context.Context, labels map[string]string, decision *checkv1.LimiterDecision) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Revert", labels, decision)
+	m.ctrl.Call(m, "Revert", ctx, labels, decision)
 }
 
 // Revert indicates an expected call of Revert.
-func (mr *MockRateLimiterMockRecorder) Revert(labels, decision interface{}) *gomock.Call {
+func (mr *MockRateLimiterMockRecorder) Revert(ctx, labels, decision interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockRateLimiter)(nil).Revert), labels, decision)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockRateLimiter)(nil).Revert), ctx, labels, decision)
 }
 
 // TakeIfAvailable mocks base method.
-func (m *MockRateLimiter) TakeIfAvailable(labels map[string]string, count float64) (string, bool, float64, float64) {
+func (m *MockRateLimiter) TakeIfAvailable(ctx context.Context, labels map[string]string, count float64) (string, bool, float64, float64) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TakeIfAvailable", labels, count)
+	ret := m.ctrl.Call(m, "TakeIfAvailable", ctx, labels, count)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(float64)
@@ -237,9 +237,9 @@ func (m *MockRateLimiter) TakeIfAvailable(labels map[string]string, count float6
 }
 
 // TakeIfAvailable indicates an expected call of TakeIfAvailable.
-func (mr *MockRateLimiterMockRecorder) TakeIfAvailable(labels, count interface{}) *gomock.Call {
+func (mr *MockRateLimiterMockRecorder) TakeIfAvailable(ctx, labels, count interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeIfAvailable", reflect.TypeOf((*MockRateLimiter)(nil).TakeIfAvailable), labels, count)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TakeIfAvailable", reflect.TypeOf((*MockRateLimiter)(nil).TakeIfAvailable), ctx, labels, count)
 }
 
 // MockScheduler is a mock of Scheduler interface.
@@ -350,13 +350,13 @@ func (mr *MockSchedulerMockRecorder) GetSelectors() *gomock.Call {
 }
 
 // Revert mocks base method.
-func (m *MockScheduler) Revert(labels map[string]string, decision *checkv1.LimiterDecision) {
+func (m *MockScheduler) Revert(ctx context.Context, labels map[string]string, decision *checkv1.LimiterDecision) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Revert", labels, decision)
+	m.ctrl.Call(m, "Revert", ctx, labels, decision)
 }
 
 // Revert indicates an expected call of Revert.
-func (mr *MockSchedulerMockRecorder) Revert(labels, decision interface{}) *gomock.Call {
+func (mr *MockSchedulerMockRecorder) Revert(ctx, labels, decision interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockScheduler)(nil).Revert), labels, decision)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockScheduler)(nil).Revert), ctx, labels, decision)
 }

--- a/pkg/rate-limiter/iface.go
+++ b/pkg/rate-limiter/iface.go
@@ -1,13 +1,16 @@
 package ratelimiter
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // RateLimiter is a generic limiter interface.
 type RateLimiter interface {
 	Name() string
-	TakeIfAvailable(label string, count float64) (ok bool, remaining float64, current float64)
-	Take(label string, count float64) (ok bool, waitTime time.Duration, remaining float64, current float64)
-	Return(label string, count float64) (remaining float64, current float64)
+	TakeIfAvailable(ctx context.Context, label string, count float64) (ok bool, remaining float64, current float64)
+	Take(ctx context.Context, label string, count float64) (ok bool, waitTime time.Duration, remaining float64, current float64)
+	Return(ctx context.Context, label string, count float64) (remaining float64, current float64)
 	SetPassThrough(passthrough bool)
 	GetPassThrough() bool
 	Close() error

--- a/pkg/rate-limiter/test/rate-limiter_test.go
+++ b/pkg/rate-limiter/test/rate-limiter_test.go
@@ -1,6 +1,7 @@
 package ratelimiter
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -43,9 +44,9 @@ type flow struct {
 }
 
 type flowRunner struct {
-	wg       sync.WaitGroup
 	limiters []ratelimiter.RateLimiter
 	flows    []*flow
+	wg       sync.WaitGroup
 	duration time.Duration
 	limit    float64
 }
@@ -68,7 +69,7 @@ func (fr *flowRunner) runFlows(t *testing.T) {
 				randomLimiterIndex := rand.Intn(len(fr.limiters))
 				limiter := fr.limiters[randomLimiterIndex]
 				atomic.AddInt32(&f.totalRequests, 1)
-				accepted, _, _ := limiter.TakeIfAvailable(f.requestlabel, 1)
+				accepted, _, _ := limiter.TakeIfAvailable(context.TODO(), f.requestlabel, 1)
 				if accepted {
 					atomic.AddInt32(&f.acceptedRequests, 1)
 				}

--- a/pkg/scheduler/global-token-bucket.go
+++ b/pkg/scheduler/global-token-bucket.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"time"
 
 	ratelimiter "github.com/fluxninja/aperture/v2/pkg/rate-limiter"
@@ -33,23 +34,23 @@ func (rltb *GlobalTokenBucket) GetPassThrough() bool {
 }
 
 // PreprocessRequest is a no-op.
-func (rltb *GlobalTokenBucket) PreprocessRequest(now time.Time, request Request) bool {
+func (rltb *GlobalTokenBucket) PreprocessRequest(_ context.Context, request Request) bool {
 	return rltb.GetPassThrough()
 }
 
 // TakeIfAvailable takes tokens if available.
-func (rltb *GlobalTokenBucket) TakeIfAvailable(now time.Time, tokens float64) bool {
-	ok, _, _ := rltb.limiter.TakeIfAvailable(rltb.key, tokens)
+func (rltb *GlobalTokenBucket) TakeIfAvailable(ctx context.Context, tokens float64) bool {
+	ok, _, _ := rltb.limiter.TakeIfAvailable(ctx, rltb.key, tokens)
 	return ok
 }
 
 // Take takes tokens.
-func (rltb *GlobalTokenBucket) Take(now time.Time, tokens float64) (time.Duration, bool) {
-	ok, waitTime, _, _ := rltb.limiter.Take(rltb.key, tokens)
+func (rltb *GlobalTokenBucket) Take(ctx context.Context, tokens float64) (time.Duration, bool) {
+	ok, waitTime, _, _ := rltb.limiter.Take(ctx, rltb.key, tokens)
 	return waitTime, ok
 }
 
 // Return returns tokens.
-func (rltb *GlobalTokenBucket) Return(tokens float64) {
-	rltb.limiter.Return(rltb.key, tokens)
+func (rltb *GlobalTokenBucket) Return(ctx context.Context, tokens float64) {
+	rltb.limiter.Return(ctx, rltb.key, tokens)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -21,7 +21,7 @@ type Scheduler interface {
 	// Useful in case the request was rejected by any
 	// other scheduler and the tokens are returned
 	// back to the scheduler.
-	Revert(tokens uint64)
+	Revert(ctx context.Context, tokens uint64)
 	// Info returns the last access time and number of requests that are currently in the queue.
 	Info() (time.Time, int)
 }
@@ -29,13 +29,13 @@ type Scheduler interface {
 // TokenManager : Interface for token managers.
 type TokenManager interface {
 	// Take tokens if available, otherwise return false
-	TakeIfAvailable(now time.Time, tokens float64) bool
+	TakeIfAvailable(ctx context.Context, tokens float64) bool
 	// Take tokens even if available tokens are less than asked - returns wait time if tokens are not available immediately. The other return value conveys whether the operation was successful or not.
-	Take(now time.Time, tokens float64) (time.Duration, bool)
+	Take(ctx context.Context, tokens float64) (time.Duration, bool)
 	// Return tokens, useful when requests choose to drop themselves on timeout or cancellation
-	Return(tokens float64)
+	Return(ctx context.Context, tokens float64)
 	// Provides TokenManager the request that the scheduler processing -- some TokenManager implementations use this level of visibility for their algorithms. Return value decides whether the request has to be accepted right away in case TokenManger is not yet ready or configured to accept all traffic (short circuit).
-	PreprocessRequest(now time.Time, request Request) (accept bool)
+	PreprocessRequest(ctx context.Context, request Request) (accept bool)
 	// SetPassThrough sets the pass through flag for the token manager.
 	SetPassThrough(passThrough bool)
 	// GetPassThrough returns the pass through flag for the token manager.

--- a/pkg/scheduler/token-bucket.go
+++ b/pkg/scheduler/token-bucket.go
@@ -1,9 +1,11 @@
 package scheduler
 
 import (
+	"context"
 	"sync"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -23,6 +25,15 @@ type tokenBucketBase struct {
 	bucketCapacity  float64 // Overall capacity of the bucket, currently the same as fillRate
 	availableTokens float64 // Available Tokens as of latestTime (can be a negative or a fractional number)
 	passThrough     bool
+	clk             clockwork.Clock
+}
+
+func newTokenBucket(clk clockwork.Clock, metrics *TokenBucketMetrics) *tokenBucketBase {
+	return &tokenBucketBase{
+		clk:        clk,
+		metrics:    metrics,
+		latestTime: clk.Now(),
+	}
 }
 
 func (tbb *tokenBucketBase) setFillRateGauge(v float64) {
@@ -43,20 +54,17 @@ func (tbb *tokenBucketBase) setAvailableTokensGauge(v float64) {
 	}
 }
 
-func (tbb *tokenBucketBase) adjustTokens(now time.Time) {
-	if tbb.latestTime.IsZero() {
-		tbb.latestTime = now
-	}
-
+func (tbb *tokenBucketBase) adjustTokens() {
+	now := tbb.clk.Now()
 	toAdd := float64(now.Sub(tbb.latestTime)) * float64(tbb.fillRate) / 1e9
 	tbb.latestTime = now
 	tbb.addTokens(toAdd)
 }
 
 // setFillRate : Adjust tokens fill rate (tokens/sec) at runtime.
-func (tbb *tokenBucketBase) setFillRate(now time.Time, fillRate float64) {
+func (tbb *tokenBucketBase) setFillRate(fillRate float64) {
 	// adjust availableTokens
-	tbb.adjustTokens(now)
+	tbb.adjustTokens()
 	// subsequent requests get scheduled based on the new rate
 	tbb.fillRate = fillRate
 	tbb.setFillRateGauge(tbb.fillRate)
@@ -81,13 +89,13 @@ func (tbb *tokenBucketBase) returnTokens(toReturn float64) {
 	}
 }
 
-func (tbb *tokenBucketBase) take(now time.Time, tokens float64) (time.Duration, bool) {
+func (tbb *tokenBucketBase) take(ctx context.Context, tokens float64) (time.Duration, bool) {
 	// if tokens aren't coming do not provide any more tokens
 	if tbb.fillRate == 0 {
 		return time.Duration(0), false
 	}
 
-	tbb.adjustTokens(now)
+	tbb.adjustTokens()
 	tbb.addTokens(-tokens)
 
 	if tbb.availableTokens >= 0 {
@@ -96,11 +104,19 @@ func (tbb *tokenBucketBase) take(now time.Time, tokens float64) (time.Duration, 
 	// figure out when the tokens will be available
 	waitTime := time.Duration(-tbb.availableTokens * float64(1e9) / float64(tbb.fillRate))
 
+	// get deadline from context
+	deadline, ok := ctx.Deadline()
+	if ok && deadline.Sub(tbb.latestTime) < waitTime {
+		// return tokens
+		tbb.addTokens(tokens)
+		return time.Duration(0), false
+	}
+
 	return waitTime, true
 }
 
-func (tbb *tokenBucketBase) takeIfAvailable(now time.Time, tokens float64) bool {
-	tbb.adjustTokens(now)
+func (tbb *tokenBucketBase) takeIfAvailable(tokens float64) bool {
+	tbb.adjustTokens()
 	if tbb.availableTokens > tokens {
 		tbb.addTokens(-tokens)
 		return true
@@ -125,57 +141,51 @@ var _ TokenManager = &BasicTokenBucket{}
 
 // BasicTokenBucket is a basic token bucket implementation.
 type BasicTokenBucket struct {
-	lock sync.Mutex
 	tbb  *tokenBucketBase
+	lock sync.Mutex
 }
 
 // NewBasicTokenBucket creates a new BasicTokenBucket with adjusted fill rate.
-func NewBasicTokenBucket(now time.Time, fillRate float64, metrics *TokenBucketMetrics) *BasicTokenBucket {
-	btb := &BasicTokenBucket{
-		tbb: &tokenBucketBase{},
-	}
-
-	if metrics != nil {
-		btb.tbb.metrics = metrics
-	}
-
-	btb.tbb.setFillRate(now, fillRate)
+func NewBasicTokenBucket(clk clockwork.Clock, fillRate float64, metrics *TokenBucketMetrics) *BasicTokenBucket {
+	btb := &BasicTokenBucket{}
+	btb.tbb = newTokenBucket(clk, metrics)
+	btb.tbb.setFillRate(fillRate)
 	return btb
 }
 
 // TakeIfAvailable takes tokens from the basic token bucket if available, otherwise return false.
-func (btb *BasicTokenBucket) TakeIfAvailable(now time.Time, tokens float64) bool {
+func (btb *BasicTokenBucket) TakeIfAvailable(_ context.Context, tokens float64) bool {
 	btb.lock.Lock()
 	defer btb.lock.Unlock()
-	return btb.tbb.takeIfAvailable(now, tokens)
+	return btb.tbb.takeIfAvailable(tokens)
 }
 
 // Take takes tokens from the basic token bucket even if available tokens are less than asked.
 // If tokens are not available at the moment, it will return amount of wait time and checks
 // whether the operation was successful or not.
-func (btb *BasicTokenBucket) Take(now time.Time, tokens float64) (time.Duration, bool) {
+func (btb *BasicTokenBucket) Take(ctx context.Context, tokens float64) (time.Duration, bool) {
 	btb.lock.Lock()
 	defer btb.lock.Unlock()
-	return btb.tbb.take(now, tokens)
+	return btb.tbb.take(ctx, tokens)
 }
 
 // Return returns tokens to the basic token bucket.
-func (btb *BasicTokenBucket) Return(tokens float64) {
+func (btb *BasicTokenBucket) Return(_ context.Context, tokens float64) {
 	btb.lock.Lock()
 	defer btb.lock.Unlock()
 	btb.tbb.returnTokens(tokens)
 }
 
 // PreprocessRequest decides whether to proactively accept a request.
-func (btb *BasicTokenBucket) PreprocessRequest(now time.Time, request Request) bool {
+func (btb *BasicTokenBucket) PreprocessRequest(_ context.Context, request Request) bool {
 	return btb.tbb.getPassThrough()
 }
 
 // SetFillRate adjusts the fill rate of the BasicTokenBucket.
-func (btb *BasicTokenBucket) SetFillRate(now time.Time, fillRate float64) {
+func (btb *BasicTokenBucket) SetFillRate(fillRate float64) {
 	btb.lock.Lock()
 	defer btb.lock.Unlock()
-	btb.tbb.setFillRate(now, fillRate)
+	btb.tbb.setFillRate(fillRate)
 }
 
 // GetFillRate returns the fill rate of the BasicTokenBucket.

--- a/pkg/scheduler/wfq.go
+++ b/pkg/scheduler/wfq.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -118,9 +117,8 @@ func init() {
 
 // WFQScheduler : Weighted Fair Queue Scheduler.
 type WFQScheduler struct {
-	lock    sync.Mutex
-	manager TokenManager
-	clk     clockwork.Clock
+	lastAccessTime time.Time
+	manager        TokenManager
 	// metrics
 	metrics *WFQMetrics
 	// flows
@@ -129,20 +127,19 @@ type WFQScheduler struct {
 	vt       uint64 // virtual time
 	// generation helps close the queue in face of concurrent requests leaving the queue while new requests also arrive.
 	generation uint64
+	lock       sync.Mutex
 	queueOpen  bool // This tracks overload state
-	lastAccess time.Time
 }
 
 // NewWFQScheduler creates a new weighted fair queue scheduler.
-func NewWFQScheduler(tokenManger TokenManager, clk clockwork.Clock, metrics *WFQMetrics) Scheduler {
+func NewWFQScheduler(tokenManger TokenManager, metrics *WFQMetrics) Scheduler {
 	sched := new(WFQScheduler)
 	sched.queueOpen = false
 	sched.generation = 0
+	sched.lastAccessTime = time.Now()
 	sched.vt = 0
 	sched.flows = make(map[string]*flowInfo)
 	sched.manager = tokenManger
-	sched.clk = clk
-	sched.lastAccess = sched.clk.Now()
 
 	if metrics != nil {
 		sched.metrics = metrics
@@ -158,16 +155,26 @@ func (sched *WFQScheduler) Schedule(ctx context.Context, request Request) bool {
 		return true
 	}
 
-	// Unable to schedule right now, so queue the request
-	admitted, qRequest := sched.queueRequest(request)
-	if admitted {
-		// scheduler is not in overload situation and the request was able to get tokens
+	sched.lock.Lock()
+	queueOpen := sched.queueOpen
+	sched.lastAccessTime = time.Now()
+	sched.lock.Unlock()
+
+	if sched.manager.PreprocessRequest(ctx, request) {
 		return true
 	}
 
-	if qRequest == nil {
-		return false
+	// try to schedule right now
+	if !queueOpen {
+		ok := sched.manager.TakeIfAvailable(ctx, float64(request.Tokens))
+		if ok {
+			// we got the tokens, no need to queue
+			return true
+		}
 	}
+
+	// Unable to schedule right now, so queue the request
+	qRequest := sched.queueRequest(ctx, request)
 
 	// scheduler is in overload situation and we have to wait for ready signal and tokens
 	select {
@@ -190,26 +197,9 @@ func (sched *WFQScheduler) flowID(fairnessLabel string, priority uint8, generati
 // If admitted == false, might return a valid heapRequest
 // If admitted == false and qRequest == nil, request was neither admitted nor
 // queued (rejected right away).
-func (sched *WFQScheduler) queueRequest(request Request) (admitted bool, qRequest *queuedRequest) {
+func (sched *WFQScheduler) queueRequest(ctx context.Context, request Request) (qRequest *queuedRequest) {
 	sched.lock.Lock()
 	defer sched.lock.Unlock()
-
-	now := sched.clk.Now()
-
-	sched.lastAccess = now
-
-	if sched.manager.PreprocessRequest(now, request) {
-		return true, nil
-	}
-
-	// try to schedule right now
-	if !sched.queueOpen {
-		ok := sched.manager.TakeIfAvailable(now, float64(request.Tokens))
-		if ok {
-			// we got the tokens, no need to queue
-			return true, nil
-		}
-	}
 
 	firstRequest := false
 
@@ -266,7 +256,7 @@ func (sched *WFQScheduler) queueRequest(request Request) (admitted bool, qReques
 		qRequest.ready <- struct{}{}
 	}
 
-	return false, qRequest
+	return qRequest
 }
 
 // adjust queue counters. Note: qRequest pointer should not be used after calling this function as it will get recycled via Pool.
@@ -274,25 +264,10 @@ func (sched *WFQScheduler) scheduleRequest(ctx context.Context,
 	request Request,
 	qRequest *queuedRequest,
 ) (allowed bool) {
-	sched.lock.Lock()
-	defer sched.lock.Unlock()
-
 	// This request has been selected to be executed next
-	now := sched.clk.Now()
-	waitTime, allowed := sched.manager.Take(now, float64(request.Tokens))
+	waitTime, allowed := sched.manager.Take(ctx, float64(request.Tokens))
 	// check if we need to wait
 	if allowed && waitTime > 0 {
-		// unlock the lock before waiting
-		sched.lock.Unlock()
-		// check whether ctx has deadline
-		// and if deadline is less than waitTime
-		// return tokens immediately
-		if dl, o := ctx.Deadline(); o {
-			if dl.Sub(now) < waitTime {
-				allowed = false
-				sched.manager.Return(float64(request.Tokens))
-			}
-		}
 		if allowed {
 			timer := time.NewTimer(waitTime)
 			defer timer.Stop()
@@ -301,13 +276,15 @@ func (sched *WFQScheduler) scheduleRequest(ctx context.Context,
 			case <-ctx.Done():
 				allowed = false
 				// return the tokens
-				sched.manager.Return(float64(request.Tokens))
+				sched.manager.Return(ctx, float64(request.Tokens))
 			case <-timer.C:
 			}
 		}
-		// grab the lock again
-		sched.lock.Lock()
 	}
+
+	sched.lock.Lock()
+	defer sched.lock.Unlock()
+
 	if allowed {
 		// move the flow's VT forward
 		qRequest.fInfo.vt += qRequest.cost
@@ -425,8 +402,8 @@ func (sched *WFQScheduler) cleanup(qRequest *queuedRequest) {
 }
 
 // Revert returns tokens to the token bucket.
-func (sched *WFQScheduler) Revert(tokens uint64) {
-	sched.manager.Return(float64(tokens))
+func (sched *WFQScheduler) Revert(ctx context.Context, tokens uint64) {
+	sched.manager.Return(ctx, float64(tokens))
 }
 
 func (sched *WFQScheduler) setFlowsGauge(v float64) {
@@ -445,7 +422,7 @@ func (sched *WFQScheduler) setRequestsGauge(v float64) {
 func (sched *WFQScheduler) Info() (time.Time, int) {
 	sched.lock.Lock()
 	defer sched.lock.Unlock()
-	return sched.lastAccess, sched.requests.Len()
+	return sched.lastAccessTime, sched.requests.Len()
 }
 
 // GetPendingFlows returns the number of flows in the scheduler.


### PR DESCRIPTION
### Description of change

Now that we have global token buckets, we need to release locks before accessing the token bucket in order to unblock parallel requests.

![Screenshot 2023-05-30 at 9 53 45 PM](https://github.com/fluxninja/aperture/assets/18579817/550fed37-6b78-42d6-a2b6-e8f5ec45eb71)
![Screenshot 2023-05-30 at 10 11 03 PM](https://github.com/fluxninja/aperture/assets/18579817/cc7fdaad-f964-4d46-878e-0d628bd7b985)



<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Updated locking mechanisms in various flow control actuators and schedulers to unblock parallel requests
- Added `context.Context` parameter to `Limiter`, `RateLimiter`, and `Scheduler` interfaces for better lock handling

**Test:**
- Modified `MockLimiter`, `MockRateLimiter`, and `MockScheduler` methods to include a `context.Context` parameter

> 🎉 Parallel requests now fly, 🚀
> Unblocked, soaring through the sky. 🌌
> Locks released with context's grace, 🔓
> Our code performs at a swifter pace! 💨
<!-- end of auto-generated comment: release notes by openai -->