### PR TITLE
Use custom PolicyMessage for passing policies to be wrapped

### DIFF
--- a/pkg/policies/controlplane/crwatcher/watcher.go
+++ b/pkg/policies/controlplane/crwatcher/watcher.go
@@ -3,6 +3,7 @@ package crwatcher
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sync"
@@ -20,16 +21,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/yaml"
 
 	languagev1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
-	syncv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/sync/v1"
 	"github.com/fluxninja/aperture/v2/operator/api"
 	policyv1alpha1 "github.com/fluxninja/aperture/v2/operator/api/policy/v1alpha1"
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 	"github.com/fluxninja/aperture/v2/pkg/notifiers"
 	panichandler "github.com/fluxninja/aperture/v2/pkg/panic-handler"
+	"github.com/fluxninja/aperture/v2/pkg/policies/controlplane/iface"
 )
 
 // watcher holds the state of the watcher.
@@ -217,7 +217,7 @@ func (w *watcher) reconcilePolicy(ctx context.Context, instance *policyv1alpha1.
 	}
 
 	annotations := instance.GetObjectMeta().GetAnnotations()
-	policyMessage := &syncv1.PolicyWrapper{
+	policyMessage := &iface.PolicyMessage{
 		Policy: policySpec,
 		PolicyMetadata: &languagev1.PolicyMetadata{
 			Values:        annotations["fluxninja.com/values"],
@@ -225,7 +225,7 @@ func (w *watcher) reconcilePolicy(ctx context.Context, instance *policyv1alpha1.
 			BlueprintName: annotations["fluxninja.com/blueprint-name"],
 		},
 	}
-	bytes, err := yaml.Marshal(policyMessage)
+	bytes, err := json.Marshal(policyMessage)
 	if err != nil {
 		return err
 	}

--- a/pkg/policies/controlplane/iface/policy.go
+++ b/pkg/policies/controlplane/iface/policy.go
@@ -1,10 +1,13 @@
 package iface
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	policylangv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	"github.com/fluxninja/aperture/v2/pkg/status"
@@ -34,4 +37,49 @@ type Policy interface {
 // GetSelectorsShortDescription returns a short description of the selectors.
 func GetSelectorsShortDescription(selectors []*policylangv1.Selector) string {
 	return fmt.Sprintf("%d selectors", len(selectors))
+}
+
+// PolicyMessage is used for passing policies to be wrapped.
+type PolicyMessage struct {
+	*policylangv1.Policy
+	PolicyMetadata *policylangv1.PolicyMetadata `json:"policy_metadata"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (m *PolicyMessage) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	pb, err := m.Policy.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(pb[:len(pb)-1])
+	if m.PolicyMetadata != nil {
+		buf.WriteString(`,"policy_metadata":`)
+		pmb, err := m.PolicyMetadata.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(pmb)
+	}
+
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (m *PolicyMessage) UnmarshalJSON(b []byte) error {
+	unmarshaler := protojson.UnmarshalOptions{DiscardUnknown: true}
+	err := unmarshaler.Unmarshal(b, m.Policy)
+	if err != nil {
+		return err
+	}
+	tmp := struct {
+		PolicyMetadata *policylangv1.PolicyMetadata `json:"policy_metadata"`
+	}{}
+	err = json.Unmarshal(b, &tmp)
+	if err != nil {
+		return err
+	}
+	m.PolicyMetadata = tmp.PolicyMetadata
+	return nil
 }


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Introduced `PolicyMessage` type with custom JSON marshaling and unmarshaling
- Replaced `syncv1.PolicyWrapper` with `iface.PolicyMessage` for improved policy handling

> 🎉 A new dawn for policies, we cheer,
> With `PolicyMessage`, the path is clear.
> Farewell to `syncv1.PolicyWrapper`, old friend,
> Embrace the change, as new features ascend! 🚀
<!-- end of auto-generated comment: release notes by openai -->