### PR TITLE
Fixed typo in aperturectl log

### DIFF
--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -88,7 +88,7 @@ func (c *ControllerConn) InitFlags(flags *flag.FlagSet) {
 // PreRunE verifies flags (optionally loading kubeconfig) and should be run at PreRunE stage.
 func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 	if c.controllerAddr == "" && !c.kube {
-		log.Info().Msg("Neither --controller not --kube flags are set. Assuming --kube=true.")
+		log.Info().Msg("Neither --controller nor --kube flag is set. Assuming --kube=true.")
 		c.kube = true
 	}
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Fixed a minor typo in the log message of cmd/aperturectl/cmd/utils/controller.go
```

> 🎉 A tiny typo fixed, our code now shines,
> With every letter in its place, it gracefully aligns.
> A small change indeed, but worth the cheer,
> For clarity and precision, we hold so dear. 🌟
<!-- end of auto-generated comment: release notes by openai -->