### PR TITLE
global token bucket: remove key lock

### DIFF
--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1267,6 +1267,19 @@ to.
 ReplicaCount is 1 by default.
 
 </dd>
+<dt>sync_replication</dt>
+<dd>
+
+<!-- vale off -->
+
+(bool, default: `false`)
+
+<!-- vale on -->
+
+SyncReplication enables synchronous replication. By default the replication is
+asynchronous.
+
+</dd>
 </dl>
 
 ---

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -394,6 +394,13 @@ definitions:
                 x-go-name: ReplicaCount
                 x-go-tag-default: "1"
                 x-go-tag-json: replica_count
+            sync_replication:
+                default: false
+                description: SyncReplication enables synchronous replication. By default the replication is asynchronous.
+                type: boolean
+                x-go-name: SyncReplication
+                x-go-tag-default: "false"
+                x-go-tag-json: sync_replication
         title: DistCacheConfig configures distributed cache that holds per-label counters in distributed rate limiters.
         type: object
         x-go-package: github.com/fluxninja/aperture/v2/pkg/dist-cache/config

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/looplab/tarjan v0.1.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/moby/locker v1.0.1
 	github.com/natefinch/atomic v1.0.1
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.4
@@ -639,7 +638,7 @@ require (
 )
 
 replace (
-	github.com/buraksezer/olric => github.com/fluxninja/olric v0.5.4-fn.patch.11
+	github.com/buraksezer/olric => github.com/fluxninja/olric v0.5.4-fn.patch.12
 	github.com/jsonnet-bundler/jsonnet-bundler => github.com/fluxninja/jsonnet-bundler v0.5.1-fn.patch.1
 	go.opentelemetry.io/collector => github.com/fluxninja/opentelemetry-collector v0.77.0-fn.patch.2
 	go.opentelemetry.io/collector/component => github.com/fluxninja/opentelemetry-collector/component v0.77.0-fn.patch.2

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/fluxninja/jsonnet-bundler v0.5.1-fn.patch.1 h1:aZbbKMGqnRUQubdJS5tfoZ
 github.com/fluxninja/jsonnet-bundler v0.5.1-fn.patch.1/go.mod h1:Qrdw/7mOFS2SKCOALKFfEH8gdvXJi8XZjw9g5ilpf4I=
 github.com/fluxninja/lumberjack v0.0.0-20220729045908-655029e4d814 h1:AHC1PtYLUw9PWqmgB9VHcxzGEm1GDYGXzC1PRtgIqqs=
 github.com/fluxninja/lumberjack v0.0.0-20220729045908-655029e4d814/go.mod h1:kARLh/xWGaisrwkOGOWKcqk7fagFUFthOTX7mIFVJlw=
-github.com/fluxninja/olric v0.5.4-fn.patch.11 h1:ydG2Ey0cbQiUFOY57gah9VDw8gEX9xVmI0Lv6gqwdNs=
-github.com/fluxninja/olric v0.5.4-fn.patch.11/go.mod h1:ndjlnRvJfFrE8eJlQNBJsDJa11tIsb5BXSfPmTi7qjE=
+github.com/fluxninja/olric v0.5.4-fn.patch.12 h1:Hx7kd8ath8N4tCJlId5uIW0H8QEnnOzqjRnupXxYyDs=
+github.com/fluxninja/olric v0.5.4-fn.patch.12/go.mod h1:ndjlnRvJfFrE8eJlQNBJsDJa11tIsb5BXSfPmTi7qjE=
 github.com/fluxninja/opentelemetry-collector v0.77.0-fn.patch.2 h1:UUGrdDLPV90bWBGh7bB9WXUhMZQkV9CrLmyUkyBIs8k=
 github.com/fluxninja/opentelemetry-collector v0.77.0-fn.patch.2/go.mod h1:DhLxVqYW2XcA+FBhYaj7ZCgMP1IWsYmk/gLrsxE0XXM=
 github.com/fluxninja/opentelemetry-collector/component v0.77.0-fn.patch.2 h1:QT/TZRxIlA4wim+/Zp1zPeckcyfls1D7TWptIP5Y+GY=
@@ -1175,8 +1175,6 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mmcloughlin/avo v0.5.0/go.mod h1:ChHFdoV7ql95Wi7vuq2YT1bwCJqiWdZrQ1im3VujLYM=
-github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
-github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1107,6 +1107,10 @@ spec:
                       replica_count:
                         description: ReplicaCount is 1 by default.
                         type: integer
+                      sync_replication:
+                        description: SyncReplication enables synchronous replication.
+                          By default the replication is asynchronous.
+                        type: boolean
                     type: object
                   etcd:
                     description: Etcd configuration.

--- a/pkg/dist-cache/config/config.go
+++ b/pkg/dist-cache/config/config.go
@@ -21,4 +21,6 @@ type DistCacheConfig struct {
 	MemberlistAdvertiseAddr string `json:"memberlist_advertise_addr" validate:"omitempty,hostname_port"`
 	// ReplicaCount is 1 by default.
 	ReplicaCount int `json:"replica_count" default:"1"`
+	// SyncReplication enables synchronous replication. By default the replication is asynchronous.
+	SyncReplication bool `json:"sync_replication" default:"false"`
 }

--- a/pkg/dist-cache/provider.go
+++ b/pkg/dist-cache/provider.go
@@ -71,10 +71,19 @@ func (constructor DistCacheConstructor) ProvideDistCache(in DistCacheConstructor
 
 	memberlistEnv := "lan"
 	oc := olricconfig.New(memberlistEnv)
-	oc.ReplicaCount = defaultConfig.ReplicaCount
+
 	oc.WriteQuorum = 1
 	oc.ReadQuorum = 1
 	oc.MemberCountQuorum = 1
+	oc.ReadRepair = false
+
+	oc.ReplicaCount = defaultConfig.ReplicaCount
+	if defaultConfig.SyncReplication {
+		oc.ReplicationMode = olricconfig.SyncReplicationMode
+	} else {
+		oc.ReplicationMode = olricconfig.AsyncReplicationMode
+	}
+
 	oc.DMaps.Custom = make(map[string]olricconfig.DMap)
 	oc.Logger = stdlog.New(&OlricLogWriter{Logger: in.Logger}, "", 0)
 


### PR DESCRIPTION
### Description of change

Remove key lock in global token bucket as that is taken within olric
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added `sync_replication` configuration option for global token bucket

**Refactor:**
- Removed unnecessary key lock in `takeN` function of `GlobalTokenBucket`

> 🎉 A new config option we bring,
> To make our token bucket sing! 🎶
> Sync replication, now in sight,
> And a refactor to make things right! ✨
<!-- end of auto-generated comment: release notes by openai -->