### PR TITLE
Do not get stats in ProvideDistCache

### DIFF
--- a/pkg/dist-cache/provider.go
+++ b/pkg/dist-cache/provider.go
@@ -152,10 +152,6 @@ func (constructor DistCacheConstructor) ProvideDistCache(in DistCacheConstructor
 	job := jobs.NewBasicJob(distCacheMetricsJobName, dc.scrapeMetrics)
 	in.Lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			defer func() {
-				utils.Shutdown(in.Shutdowner)
-			}()
-
 			// Register metrics with Prometheus.
 			err := dc.metrics.registerMetrics(in.PrometheusRegistry)
 			if err != nil {
@@ -164,6 +160,10 @@ func (constructor DistCacheConstructor) ProvideDistCache(in DistCacheConstructor
 			}
 
 			panichandler.Go(func() {
+				defer func() {
+					utils.Shutdown(in.Shutdowner)
+				}()
+
 				startErr := dc.olric.Start()
 				if startErr != nil {
 					log.Error().Err(startErr).Msg("Failed to start distcache")

--- a/playground/scenarios/quota-scheduler/policies/quota-scheduler-cr.yaml
+++ b/playground/scenarios/quota-scheduler/policies/quota-scheduler-cr.yaml
@@ -6,12 +6,12 @@ metadata:
     fluxninja.com/blueprints-uri: local
     fluxninja.com/values: '{"policy": {"policy_name": "quota-scheduler", "quota_scheduler":
       {"bucket_capacity": 500, "fill_amount": 25, "rate_limiter": {"interval": "1s",
-      "label_key": "http.request.header.api_key", "lazy_sync": {"enabled": true, "num_sync":
-      4}}, "scheduler": {"workloads": [{"label_matcher": {"match_labels": {"http.request.header.user_type":
-      "guest"}}, "name": "guest", "parameters": {"priority": 50}}, {"label_matcher":
-      {"match_labels": {"http.request.header.user_type": "subscriber"}}, "name": "subscriber",
-      "parameters": {"priority": 200}}]}, "selectors": [{"control_point": "ingress",
-      "service": "service1-demo-app.demoapp.svc.cluster.local"}]}}}'
+      "label_key": "http.request.header.api_key", "lazy_sync": {"enabled": false,
+      "num_sync": 4}}, "scheduler": {"workloads": [{"label_matcher": {"match_labels":
+      {"http.request.header.user_type": "guest"}}, "name": "guest", "parameters":
+      {"priority": 50}}, {"label_matcher": {"match_labels": {"http.request.header.user_type":
+      "subscriber"}}, "name": "subscriber", "parameters": {"priority": 200}}]}, "selectors":
+      [{"control_point": "ingress", "service": "service1-demo-app.demoapp.svc.cluster.local"}]}}}'
   labels:
     fluxninja.com/validate: "true"
   name: quota-scheduler
@@ -31,7 +31,7 @@ spec:
             interval: 1s
             label_key: http.request.header.api_key
             lazy_sync:
-              enabled: true
+              enabled: false
               num_sync: 4
           scheduler:
             workloads:

--- a/playground/scenarios/quota-scheduler/policies/quota-scheduler.yaml
+++ b/playground/scenarios/quota-scheduler/policies/quota-scheduler.yaml
@@ -14,7 +14,7 @@ policy:
       label_key: http.request.header.api_key
       interval: 1s
       lazy_sync:
-        enabled: true
+        enabled: false
         num_sync: 4
     scheduler:
       workloads:


### PR DESCRIPTION
### Description of change

![screencapture-localhost-3000-d-1271a5153713edf320f070459528f54dee4fcd78-aperture-quota-scheduler-2023-06-01-12_10_17](https://github.com/fluxninja/aperture/assets/1553055/4722537e-1dc9-4085-997d-1f23b347a469)

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Removed unnecessary call to `dc.client.Stats` in `ProvideDistCache` function
- Added deferred call to `utils.Shutdown` for proper Olric instance shutdown

```

> 🎉 A bug we found, a fix we made,
> In the cache provider, improvements laid.
> Stats call removed, shutdown ensured,
> Our code's performance and health secured. 🚀
<!-- end of auto-generated comment: release notes by openai -->