### PR TITLE
Support policies metadata for policies created by api

### DIFF
--- a/pkg/policies/paths/paths.go
+++ b/pkg/policies/paths/paths.go
@@ -14,8 +14,8 @@ var (
 	StatusPrefix = path.Join("/status")
 	// PoliciesAPIConfigPath is config path in etcd for policies via API.
 	PoliciesAPIConfigPath = path.Join(ConfigPrefix, "api", "policies")
-	// PoliciesMetadataAPIConfigPath is config path in etcd for policies metadatavia API.
-	PoliciesMetadataAPIConfigPath = path.Join(ConfigPrefix, "api", "policies-metadata")
+	// PoliciesMetadataAPIConfigPath is config path in etcd for policies metadata via API.
+	PoliciesMetadataAPIConfigPath = path.Join(ConfigPrefix, "api", "policy-metadata")
 	// PoliciesAPIDynamicConfigPath is config path in etcd for  dynamic configuration of policies via API.
 	PoliciesAPIDynamicConfigPath = path.Join(ConfigPrefix, "api", "dynamic-config-policies")
 	// PoliciesConfigPath is config path in etcd for policies.


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added support for policy metadata in API-created policies
  - Modified `UpsertPolicy` and `DeletePolicy` functions in policy-service.go to handle policy metadata in etcd
  - Updated provider.go to retrieve policy metadata from etcd if not present in the policy message

> 🎉 A new feature's here, so grand,
> Policy metadata now at hand! 📜
> Upsert, delete, and provide,
> With etcd by our side. 🌟
<!-- end of auto-generated comment: release notes by openai -->