### PR TITLE
Java SDK: Add shouldRun() method to Flow classes

### DIFF
--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -91,9 +91,8 @@ public class App {
         // Flow.
         Flow flow = this.apertureSDK.startFlow(this.featureName, labels);
 
-        FlowDecision flowDecision = flow.getDecision();
         // See whether flow was accepted by Aperture Agent.
-        if (flowDecision != FlowDecision.Rejected) {
+        if (flow.shouldRun()) {
             // Simulate work being done
             try {
                 res.status(202);


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added `shouldRun()` method to `Flow` and `TrafficFlow` classes
- Introduced `failOpen` instance variable and `withNoFailOpen()` method for disabling fail-open behavior

> 🎉 A new feature we bring, with logic so fine,
> To control the flow, in this code of mine.
> Fail-open behavior, now we can tame,
> With `shouldRun()` and `withNoFailOpen()`, our code shall never be the same! 🚀
<!-- end of auto-generated comment: release notes by openai -->