### PR TITLE
Java SDK: Add missing javadoc comments

### DIFF
--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
@@ -22,6 +22,13 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+/**
+ * The Aperture SDK provides a set of tools and functionalities for flow control by enabling the
+ * initiation of flows.
+ *
+ * <p>To start using the Aperture SDK, create an instance of this class using the {@link
+ * ApertureSDKBuilder} and utilize its methods to initiate and control flows in your application.
+ */
 public final class ApertureSDK {
     private final FlowControlServiceGrpc.FlowControlServiceBlockingStub flowControlClient;
     private final FlowControlServiceHTTPGrpc.FlowControlServiceHTTPBlockingStub
@@ -49,11 +56,21 @@ public final class ApertureSDK {
     /**
      * Returns a new {@link ApertureSDKBuilder} for configuring an instance of {@linkplain
      * ApertureSDK the Aperture SDK}.
+     *
+     * @return A new ApertureSDKBuilder object.
      */
     public static ApertureSDKBuilder builder() {
         return new ApertureSDKBuilder();
     }
 
+    /**
+     * Starts a new flow, asking the Aperture Agent to accept or reject it based on provided labels.
+     * Additional labels will be extracted from current Baggage context.
+     *
+     * @param controlPoint Name of the control point
+     * @param explicitLabels Labels sent to Aperture Agent
+     * @return A Flow object
+     */
     public Flow startFlow(String controlPoint, Map<String, String> explicitLabels) {
         Map<String, String> labels = new HashMap<>();
 

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -39,11 +39,23 @@ public final class ApertureSDKBuilder {
         ignoredPaths = new ArrayList<>();
     }
 
+    /**
+     * Set hostname of Aperture Agent to connect to.
+     *
+     * @param host hostname of Aperture Agent to connect to.
+     * @return the builder object.
+     */
     public ApertureSDKBuilder setHost(String host) {
         this.host = host;
         return this;
     }
 
+    /**
+     * Set port number of Aperture Agent to connect to.
+     *
+     * @param port port number of Aperture Agent to connect to.
+     * @return the builder object.
+     */
     public ApertureSDKBuilder setPort(int port) {
         this.port = port;
         return this;
@@ -72,6 +84,12 @@ public final class ApertureSDKBuilder {
         return this;
     }
 
+    /**
+     * Sets custom root CA certificate to be used by SSL connection.
+     *
+     * @param filename path to file containing custom root CA certificate.
+     * @return the builder object.
+     */
     public ApertureSDKBuilder setRootCertificateFile(String filename) {
         this.certFile = filename;
         return this;
@@ -162,6 +180,11 @@ public final class ApertureSDKBuilder {
         return this;
     }
 
+    /**
+     * Build an ApertureSDK object using the configured parameters.
+     *
+     * @return The constructed ApertureSDK object.
+     */
     public ApertureSDK build() throws ApertureSDKException {
         String host = this.host;
         if (host == null) {

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKException.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKException.java
@@ -1,5 +1,6 @@
 package com.fluxninja.aperture.sdk;
 
+/** Exception thrown by Aperture SDK when it cannot be constructed, or when used incorrectly. */
 public class ApertureSDKException extends Exception {
     public ApertureSDKException(String message) {
         super(message);

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
@@ -7,6 +7,7 @@ import com.google.protobuf.util.JsonFormat;
 import io.opentelemetry.api.trace.Span;
 import org.apache.http.HttpStatus;
 
+/** A Flow that can be accepted or rejected by Aperture Agent based on provided labels. */
 public final class Flow {
     private final CheckResponse checkResponse;
     private final Span span;
@@ -70,6 +71,11 @@ public final class Flow {
         return this;
     }
 
+    /**
+     * Returns raw CheckResponse returned by Aperture Agent.
+     *
+     * @return raw CheckResponse returned by Aperture Agent.
+     */
     public CheckResponse checkResponse() {
         return this.checkResponse;
     }
@@ -97,6 +103,11 @@ public final class Flow {
         }
     }
 
+    /**
+     * Ends the flow, notifying the Aperture Agent whether it succeeded.
+     *
+     * @param statusCode Status of the finished flow.
+     */
     public void end(FlowStatus statusCode) throws ApertureSDKException {
         if (this.ended) {
             throw new ApertureSDKException("Flow already ended");

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowDecision.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowDecision.java
@@ -1,5 +1,9 @@
 package com.fluxninja.aperture.sdk;
 
+/**
+ * Represents a decision made by Aperture Agent on a {@link Flow} or {@link TrafficFlow}, or a lack
+ * thereof.
+ */
 public enum FlowDecision {
     Accepted,
     Rejected,

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowStatus.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/FlowStatus.java
@@ -1,5 +1,9 @@
 package com.fluxninja.aperture.sdk;
 
+/**
+ * Status of a finished flow, sent to Aperture Agent when calling {@link
+ * com.fluxninja.aperture.sdk.Flow#end Flow#end}
+ */
 public enum FlowStatus {
     OK,
     Error,

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/TrafficFlow.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/TrafficFlow.java
@@ -10,6 +10,10 @@ import com.google.rpc.Code;
 import io.opentelemetry.api.trace.Span;
 import org.apache.http.HttpStatus;
 
+/**
+ * A Flow that can be accepted or rejected by Aperture Agent based on provided HTTP request
+ * parameters.
+ */
 public class TrafficFlow {
     private final CheckHTTPResponse checkResponse;
     private final Span span;
@@ -61,7 +65,7 @@ public class TrafficFlow {
      * Returns whether the flow should be allowed to run, based on flow fail-open configuration and
      * Aperture Agent response.
      *
-     * @return Whether the flow should be allowed to run
+     * @return Whether the flow should be allowed to run.
      */
     public boolean shouldRun() {
         return getDecision() == FlowDecision.Accepted
@@ -79,10 +83,20 @@ public class TrafficFlow {
         return this;
     }
 
+    /**
+     * Returns 'true' if the flow should be ignored based on provided path ignore configuration.
+     *
+     * @return Whether the flow should be ignored.
+     */
     public boolean ignored() {
         return this.ignored;
     }
 
+    /**
+     * Returns raw CheckHTTPResponse returned by Aperture Agent.
+     *
+     * @return raw CheckHTTPResponse returned by Aperture Agent.
+     */
     public CheckHTTPResponse checkResponse() {
         return this.checkResponse;
     }
@@ -106,6 +120,11 @@ public class TrafficFlow {
         }
     }
 
+    /**
+     * Ends the flow, notifying the Aperture Agent whether it succeeded.
+     *
+     * @param statusCode Status of the finished flow.
+     */
     public void end(FlowStatus statusCode) throws ApertureSDKException {
         if (this.ignored) {
             // span has not been started, and so doesn't need to be ended.


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added methods to `ApertureSDKBuilder` for setting hostname, port number, and root certificate file
- Introduced a method to build an `ApertureSDK` object using the configured parameters

**Documentation:**
- Added missing Javadoc comments to various classes and methods in the Aperture Java SDK

> 🎉 A new dawn for Aperture SDK,
> With settings flexible as can be! 🌟
> Hostname, port, and cert we set,
> And Javadocs make it complete. 📚
> Rejoice, developers, far and wide,
> For now, with ease, you shall glide! 🚀
<!-- end of auto-generated comment: release notes by openai -->