### PR TITLE
Fix confirmation generation in service protection blueprint

### DIFF
--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/definitions.json
@@ -51,13 +51,7 @@
           "properties": {
             "overload_confirmations": {
               "description": "List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.",
-              "default": [
-                {
-                  "operator": "__REQUIRED_FIELD__",
-                  "query_string": "__REQUIRED_FIELD__",
-                  "threshold": "__REQUIRED_FIELD__"
-                }
-              ],
+              "default": [],
               "type": "array",
               "items": {
                 "type": "object",

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values-required.yaml
@@ -21,10 +21,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []policies/service-protection/average-latency:schema:overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
@@ -21,10 +21,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []policies/service-protection/average-latency:schema:overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/definitions.json
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/definitions.json
@@ -63,13 +63,7 @@
           "properties": {
             "overload_confirmations": {
               "description": "List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.",
-              "default": [
-                {
-                  "operator": "__REQUIRED_FIELD__",
-                  "query_string": "__REQUIRED_FIELD__",
-                  "threshold": "__REQUIRED_FIELD__"
-                }
-              ],
+              "default": [],
               "type": "array",
               "items": {
                 "type": "object",

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values-required.yaml
@@ -29,10 +29,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []policies/service-protection/promql:schema:overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
@@ -29,10 +29,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []policies/service-protection/promql:schema:overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/blueprints/policies/service-protection/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection/average-latency/gen/definitions.json
@@ -50,13 +50,7 @@
           "properties": {
             "overload_confirmations": {
               "description": "List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.",
-              "default": [
-                {
-                  "operator": "__REQUIRED_FIELD__",
-                  "query_string": "__REQUIRED_FIELD__",
-                  "threshold": "__REQUIRED_FIELD__"
-                }
-              ],
+              "default": [],
               "type": "array",
               "items": {
                 "type": "object",
@@ -191,18 +185,18 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
-          "default": "__REQUIRED_FIELD__",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "The threshold for the overload confirmation criteria.",
-          "default": "__REQUIRED_FIELD__",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "operator": {
           "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`",
-          "default": "__REQUIRED_FIELD__",
+          "default": null,
           "type": "string"
         }
       }

--- a/blueprints/policies/service-protection/average-latency/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values-required.yaml
@@ -21,10 +21,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/blueprints/policies/service-protection/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values.yaml
@@ -21,10 +21,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/blueprints/policies/service-protection/base/config-defaults.libsonnet
+++ b/blueprints/policies/service-protection/base/config-defaults.libsonnet
@@ -3,14 +3,8 @@ local selectors_defaults = [{
   control_point: '__REQUIRED_FIELD__',
 }];
 
-local overload_confirmation_defaults = {
-  query_string: '__REQUIRED_FIELD__',
-  threshold: '__REQUIRED_FIELD__',
-  operator: '__REQUIRED_FIELD__',
-};
-
 local service_protection_core_defaults = {
-  overload_confirmations: [overload_confirmation_defaults],
+  overload_confirmations: [],
 
   adaptive_load_scheduler: {
     load_scheduler: {
@@ -56,6 +50,4 @@ local service_protection_core_defaults = {
   },
 
   selectors: selectors_defaults,
-
-  overload_confirmation: overload_confirmation_defaults,
 }

--- a/blueprints/policies/service-protection/base/policy.libsonnet
+++ b/blueprints/policies/service-protection/base/policy.libsonnet
@@ -57,7 +57,7 @@ function(cfg, metadata={}) {
 
   local confirmationAccumulator = std.foldl(
     addOverloadConfirmation,
-    (if std.objectHas(params, 'overload_confirmations') then params.policy.overload_confirmations else []),
+    (if std.objectHas(params.policy.service_protection_core, 'overload_confirmations') then params.policy.service_protection_core.overload_confirmations else []),
     confirmationAccumulatorInitial
   ),
 

--- a/blueprints/policies/service-protection/promql/gen/definitions.json
+++ b/blueprints/policies/service-protection/promql/gen/definitions.json
@@ -56,13 +56,7 @@
           "properties": {
             "overload_confirmations": {
               "description": "List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.",
-              "default": [
-                {
-                  "operator": "__REQUIRED_FIELD__",
-                  "query_string": "__REQUIRED_FIELD__",
-                  "threshold": "__REQUIRED_FIELD__"
-                }
-              ],
+              "default": [],
               "type": "array",
               "items": {
                 "type": "object",
@@ -161,18 +155,18 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
-          "default": "__REQUIRED_FIELD__",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "The threshold for the overload confirmation criteria.",
-          "default": "__REQUIRED_FIELD__",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "operator": {
           "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`",
-          "default": "__REQUIRED_FIELD__",
+          "default": null,
           "type": "string"
         }
       }

--- a/blueprints/policies/service-protection/promql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/promql/gen/values-required.yaml
@@ -25,10 +25,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/blueprints/policies/service-protection/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection/promql/gen/values.yaml
@@ -25,10 +25,7 @@ policy:
   service_protection_core:
     # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
     # Type: []overload_confirmation
-    overload_confirmations:
-      - operator: __REQUIRED_FIELD__
-        query_string: __REQUIRED_FIELD__
-        threshold: __REQUIRED_FIELD__
+    overload_confirmations: []
     # Parameters for Adaptive Load Scheduler.
     # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
     # Required: True

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency.md
@@ -162,7 +162,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.'
     type='Array of Object (policies/service-protection/average-latency:schema:overload_confirmation)'
     reference='../../../bundled-blueprints/policies/service-protection/average-latency#overload-confirmation'
-    value='[{"operator": "__REQUIRED_FIELD__", "query_string": "__REQUIRED_FIELD__", "threshold": "__REQUIRED_FIELD__"}]'
+    value='[]'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql.md
@@ -130,7 +130,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.'
     type='Array of Object (policies/service-protection/promql:schema:overload_confirmation)'
     reference='../../../bundled-blueprints/policies/service-protection/promql#overload-confirmation'
-    value='[{"operator": "__REQUIRED_FIELD__", "query_string": "__REQUIRED_FIELD__", "threshold": "__REQUIRED_FIELD__"}]'
+    value='[]'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection/average-latency.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection/average-latency.md
@@ -150,7 +150,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.'
     type='Array of Object (overload_confirmation)'
     reference='#overload-confirmation'
-    value='[{"operator": "__REQUIRED_FIELD__", "query_string": "__REQUIRED_FIELD__", "threshold": "__REQUIRED_FIELD__"}]'
+    value='[]'
 />
 
 <!-- vale on -->
@@ -362,7 +362,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='The Prometheus query to be run. Must return a scalar or a vector with a single element.'
     type='string'
     reference=''
-    value='"__REQUIRED_FIELD__"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -376,7 +376,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='The threshold for the overload confirmation criteria.'
     type='Number (double)'
     reference=''
-    value='"__REQUIRED_FIELD__"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -390,7 +390,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`'
     type='string'
     reference=''
-    value='"__REQUIRED_FIELD__"'
+    value='null'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/policies/bundled-blueprints/policies/service-protection/promql.md
+++ b/docs/content/reference/policies/bundled-blueprints/policies/service-protection/promql.md
@@ -129,7 +129,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.'
     type='Array of Object (overload_confirmation)'
     reference='#overload-confirmation'
-    value='[{"operator": "__REQUIRED_FIELD__", "query_string": "__REQUIRED_FIELD__", "threshold": "__REQUIRED_FIELD__"}]'
+    value='[]'
 />
 
 <!-- vale on -->
@@ -279,7 +279,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='The Prometheus query to be run. Must return a scalar or a vector with a single element.'
     type='string'
     reference=''
-    value='"__REQUIRED_FIELD__"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -293,7 +293,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='The threshold for the overload confirmation criteria.'
     type='Number (double)'
     reference=''
-    value='"__REQUIRED_FIELD__"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -307,7 +307,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`'
     type='string'
     reference=''
-    value='"__REQUIRED_FIELD__"'
+    value='null'
 />
 
 <!-- vale on -->


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Changed the source of `overload_confirmations` in service protection policy
- Removed default values for some fields in XML files

**Documentation:**
- Updated default values in blueprint documentation

> 🎉 A change so small, yet profound,
> Refactoring code, making it sound.
> Docs updated too, with care,
> Celebrate this PR, a breath of fresh air! 🌬️
<!-- end of auto-generated comment: release notes by openai -->