### PR TITLE
Refactor flow ending for better try...finally compatibility

### DIFF
--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -31,24 +31,31 @@ public class ApertureFeatureFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) res;
 
         // Check whether flow was accepted by Aperture Agent
-        FlowDecision flowDecision = flow.getDecision();
-        boolean flowAccepted =
-                (flowDecision == FlowDecision.Accepted
-                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
-
-        if (flowAccepted) {
+        if (flow.shouldRun()) {
             try {
                 chain.doFilter(request, response);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                flow.setStatus(FlowStatus.Error);
+                throw e;
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow already ended
+                    e.printStackTrace();
+                }
             }
         } else {
             try {
+                flow.setStatus(FlowStatus.Unset);
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Request denied");
-                flow.end(FlowStatus.Error);
-            } catch (ApertureSDKException e) {
-                e.printStackTrace();
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow already ended
+                    e.printStackTrace();
+                }
             }
         }
     }

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -93,25 +93,30 @@ public class App {
 
         // See whether flow was accepted by Aperture Agent.
         if (flow.shouldRun()) {
-            // Simulate work being done
             try {
+                // Simulate work being done
                 res.status(202);
                 Thread.sleep(2000);
-                // Need to call end() on the Flow in order to provide telemetry to Aperture
-                // Agent for completing the control loop.
-                // The first argument captures whether the feature captured by the Flow was
-                // successful or resulted in an error.
-                // The second argument is error message for further diagnosis.
-                flow.end(FlowStatus.OK);
-            } catch (InterruptedException | ApertureSDKException e) {
-                e.printStackTrace();
+            } catch (InterruptedException e) {
+                // Flow Status captures whether the feature captured by the Flow was
+                // successful or resulted in an error. When not explicitly set,
+                // the default value is FlowStatus.OK .
+                flow.setStatus(FlowStatus.Error);
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow had already been ended.
+                    e.printStackTrace();
+                }
             }
         } else {
             // Flow has been rejected by Aperture Agent.
+            res.status(flow.getRejectionHttpStatusCode());
             try {
-                res.status(flow.getRejectionHttpStatusCode());
-                flow.end(FlowStatus.Error);
+                flow.end();
             } catch (ApertureSDKException e) {
+                // Error: Flow had already been ended.
                 e.printStackTrace();
             }
         }

--- a/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
@@ -115,25 +115,30 @@ public class App {
 
         // See whether flow was accepted by Aperture Agent.
         if (flow.shouldRun()) {
-            // Simulate work being done
             try {
+                // Simulate work being done
                 res.status(202);
                 Thread.sleep(2000);
-                // Need to call end() on the Flow in order to provide telemetry to Aperture
-                // Agent for completing the control loop.
-                // The first argument captures whether the feature captured by the Flow was
-                // successful or resulted in an error.
-                // The second argument is error message for further diagnosis.
-                flow.end(FlowStatus.OK);
-            } catch (InterruptedException | ApertureSDKException e) {
-                e.printStackTrace();
+            } catch (InterruptedException e) {
+                // Flow Status captures whether the feature captured by the Flow was
+                // successful or resulted in an error. When not explicitly set,
+                // the default value is FlowStatus.OK .
+                flow.setStatus(FlowStatus.Error);
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow had already been ended.
+                    e.printStackTrace();
+                }
             }
         } else {
             // Flow has been rejected by Aperture Agent.
+            res.status(flow.getRejectionHttpStatusCode());
             try {
-                res.status(flow.getRejectionHttpStatusCode());
-                flow.end(FlowStatus.Error);
+                flow.end();
             } catch (ApertureSDKException e) {
+                // Error: Flow had already been ended.
                 e.printStackTrace();
             }
         }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
@@ -6,7 +6,6 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
@@ -70,18 +69,11 @@ public class ApertureHTTPClient extends SimpleDecoratingHttpClient {
                 ctx.updateRequest(newRequest);
 
                 res = unwrap().execute(ctx, newRequest);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
@@ -3,7 +3,6 @@ package com.fluxninja.aperture.armeria;
 import com.fluxninja.aperture.sdk.*;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
@@ -70,19 +69,11 @@ public class ApertureHTTPService extends SimpleDecoratingHttpService {
                 ctx.updateRequest(newRequest);
 
                 res = unwrap().serve(ctx, newRequest);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClient.java
@@ -57,18 +57,11 @@ public class ApertureRPCClient extends SimpleDecoratingRpcClient {
             RpcResponse res;
             try {
                 res = unwrap().execute(ctx, req);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return RpcResponse.ofFailure(e);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCService.java
@@ -57,18 +57,11 @@ public class ApertureRPCService extends SimpleDecoratingRpcService {
             RpcResponse res;
             try {
                 res = unwrap().serve(ctx, req);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return RpcResponse.ofFailure(e);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
@@ -14,8 +14,10 @@ import java.util.Map;
 class HttpUtils {
     protected static HttpResponse handleRejectedFlow(TrafficFlow flow) {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
+            // Flow already ended
             e.printStackTrace();
         }
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
@@ -11,7 +11,8 @@ import java.util.Map;
 class RpcUtils {
     protected static HttpStatus handleRejectedFlow(Flow flow) {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "2.2.0";
+    public static final String LIBRARY_VERSION = "2.4.0";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -67,27 +67,21 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
                 HttpRequest newRequest = NettyUtils.updateHeaders(req, newHeaders);
 
                 ctx.fireChannelRead(newRequest);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                FullHttpResponse response =
-                        new DefaultFullHttpResponse(
-                                HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
-                ctx.write(response);
-                ctx.flush();
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // ending flow failed
+                    e.printStackTrace();
+                }
             }
         } else {
             try {
-                flow.end(FlowStatus.Unset);
+                flow.setStatus(FlowStatus.Unset);
+                flow.end();
             } catch (ApertureSDKException e) {
                 e.printStackTrace();
             }

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -50,18 +50,16 @@ public class ApertureFilter implements Filter {
                 }
                 ServletRequest newRequest = ServletUtils.updateHeaders(request, newHeaders);
                 chain.doFilter(newRequest, response);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
             } catch (Exception e) {
+                flow.setStatus(FlowStatus.Error);
+                throw e;
+            } finally {
                 try {
-                    flow.end(FlowStatus.Error);
+                    flow.end();
                 } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
+                    // Error: Flow already ended
                     ae.printStackTrace();
                 }
-                throw e;
             }
         } else {
             ServletUtils.handleRejectedFlow(flow, response);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
@@ -16,7 +16,8 @@ public class ServletUtils {
     protected static void handleRejectedFlow(TrafficFlow flow, HttpServletResponse response)
             throws IOException {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -50,18 +50,16 @@ public class ApertureFilter implements Filter {
                 }
                 ServletRequest newRequest = ServletUtils.updateHeaders(request, newHeaders);
                 chain.doFilter(newRequest, response);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
             } catch (Exception e) {
+                flow.setStatus(FlowStatus.Error);
+                throw e;
+            } finally {
                 try {
-                    flow.end(FlowStatus.Error);
+                    flow.end();
                 } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
+                    // Error: Flow already ended
                     ae.printStackTrace();
                 }
-                throw e;
             }
         } else {
             ServletUtils.handleRejectedFlow(flow, response);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
@@ -16,7 +16,8 @@ public class ServletUtils {
     protected static void handleRejectedFlow(TrafficFlow flow, HttpServletResponse response)
             throws IOException {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "2.2.0"
+  var ver = "2.4.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Improved try...finally compatibility in various classes and examples
- Updated Flow and TrafficFlow classes with new flowStatus field and setStatus method

**Chore:**
- Updated library version from 2.2.0 to 2.4.0
- Changed default RPC timeout duration

> 🎉 With try...finally refined, our code now shines! 🌟
> Compatibility improved, the user experience soothed. 😌
> A new version we embrace, as we continue our race. 🏁
> To make Aperture better, together, at a steady pace. 🚀
<!-- end of auto-generated comment: release notes by openai -->