### PR TITLE
Fix nfpm installer

### DIFF
--- a/.circleci/scripts/install_nfpm.sh
+++ b/.circleci/scripts/install_nfpm.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 set -x
 
-filename="nfpm_amd64.deb"
+base_path="https://github.com/goreleaser/nfpm/releases"
+version=$(curl --silent -I "${base_path}/latest" | grep location: | awk -F '/' '{print $NF}' | tr -d 'v\r\n')
+filename="nfpm_${version}_amd64.deb"
 file="/tmp/${filename}"
-curl --silent --show-error --location https://github.com/goreleaser/nfpm/releases/latest/download/${filename} -o "${file}"
+curl --silent --show-error --location "${base_path}/download/v${version}/${filename}" -o "${file}"
 sudo dpkg -i "${file}"


### PR DESCRIPTION
### Description of change
Newest version of goreleaser changed how release artifacts are named.

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Update nfpm installer script to use the latest version of goreleaser

> 🎉 A new release, we celebrate,
> With nfpm and goreleaser update,
> The artifacts' names have changed,
> But our code's logic remains unchanged. 🚀
<!-- end of auto-generated comment: release notes by openai -->