### PR TITLE
Refactor and rename in documentation side menu

### DIFF
--- a/docs/content/get-started/get-started.md
+++ b/docs/content/get-started/get-started.md
@@ -3,7 +3,7 @@ title: Get Started
 keywords:
   - setup
   - getting started
-sidebar_position: 3
+sidebar_position: 2
 sidebar_label: Get Started
 ---
 

--- a/docs/content/integrations/integrations.md
+++ b/docs/content/integrations/integrations.md
@@ -6,7 +6,7 @@ keywords:
   - envoy
   - middleware
   - sdk
-sidebar_position: 2
+sidebar_position: 4
 sidebar_label: Integrations
 ---
 

--- a/docs/content/use-cases/auto-scale/auto-scale.md
+++ b/docs/content/use-cases/auto-scale/auto-scale.md
@@ -1,9 +1,9 @@
 ---
-title: Auto Scale
+title: Auto Scaling
 keywords:
   - tutorial
 sidebar_position: 4
-sidebar_label: Auto Scale
+sidebar_label: Auto Scaling
 ---
 
 ## Overview

--- a/docs/content/use-cases/use-cases.md
+++ b/docs/content/use-cases/use-cases.md
@@ -1,6 +1,6 @@
 ---
 title: Use Cases
-sidebar_position: 4
+sidebar_position: 3
 description:
   Explore our step-by-step tutorials on Aperture's use case based policies.
   Learn how to configure policies to improve the reliability and stability of


### PR DESCRIPTION
- Shift Integration to 4th position bringing up Get-Started and Use-Cases
- Rename Auto Scale to Auto Scaling within Use-Cases section

### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Documentation:**
- Moved Integrations section to the 4th position in side menu
- Renamed Auto Scale to Auto Scaling in Use-Cases section

> 🎉 A shift in docs, a change so small,
> Yet clarity blooms, for one and all.
> Integrations rise, Auto Scaling's new name,
> Our docs now refined, user ease is our aim. 🌟
<!-- end of auto-generated comment: release notes by openai -->