### PR TITLE
Fix Java SDK logging imports

### DIFF
--- a/sdks/aperture-java/examples/armeria-example/build.gradle.kts
+++ b/sdks/aperture-java/examples/armeria-example/build.gradle.kts
@@ -21,4 +21,6 @@ dependencies {
     implementation("com.linecorp.armeria:armeria:1.15.0")
     implementation(project(":lib:core"))
     implementation(project(":lib:armeria"))
+
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.0")
 }

--- a/sdks/aperture-java/examples/netty-example/build.gradle.kts
+++ b/sdks/aperture-java/examples/netty-example/build.gradle.kts
@@ -20,4 +20,6 @@ application {
 dependencies {
     implementation(project(":lib:core"))
     implementation(project(":lib:netty"))
+
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.0")
 }

--- a/sdks/aperture-java/examples/spring-example/build.gradle.kts
+++ b/sdks/aperture-java/examples/spring-example/build.gradle.kts
@@ -27,4 +27,6 @@ dependencies {
 
 	implementation(project(":lib:core"))
 	implementation(project(":lib:servlet"))
+
+	runtimeOnly("org.slf4j:slf4j-simple:1.7.0")
 }

--- a/sdks/aperture-java/examples/standalone-example/build.gradle.kts
+++ b/sdks/aperture-java/examples/standalone-example/build.gradle.kts
@@ -31,4 +31,6 @@ dependencies {
     implementation("com.sparkjava:spark-core:2.9.4")
     implementation("io.grpc:grpc-api:1.44.0")
     implementation(project(":lib:core"))
+
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.0")
 }

--- a/sdks/aperture-java/examples/standalone-traffic-flow-example/build.gradle.kts
+++ b/sdks/aperture-java/examples/standalone-traffic-flow-example/build.gradle.kts
@@ -31,4 +31,6 @@ dependencies {
     implementation("com.sparkjava:spark-core:2.9.4")
     implementation("io.grpc:grpc-api:1.44.0")
     implementation(project(":lib:core"))
+
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.0")
 }

--- a/sdks/aperture-java/examples/tomcat-example/build.gradle.kts
+++ b/sdks/aperture-java/examples/tomcat-example/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     implementation(project(":lib:servlet"))
 
     providedCompile("javax.servlet:javax.servlet-api:3.1.0")
+
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.0")
 }
 
 tomcat {

--- a/sdks/aperture-java/javaagent/agent/build.gradle.kts
+++ b/sdks/aperture-java/javaagent/agent/build.gradle.kts
@@ -93,6 +93,8 @@ dependencies {
     implementation(project(":lib:core"))
     implementation(project(":lib:armeria"))
     implementation(project(":lib:netty"))
+
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.0")
 }
 
 repositories {

--- a/sdks/aperture-java/lib/core/build.gradle.kts
+++ b/sdks/aperture-java/lib/core/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("io.grpc:grpc-protobuf:1.44.0")
     implementation("io.grpc:grpc-stub:1.44.0")
     implementation("org.apache.httpcomponents:httpcore:4.4.16")
-    implementation("org.slf4j:slf4j-simple:1.7.0")
+    implementation("org.slf4j:slf4j-api:1.7.0")
 
     runtimeOnly("io.grpc:grpc-netty-shaded:1.49.0")
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Updated logging dependencies in multiple example projects and agent project
  - Added `org.slf4j:slf4j-simple:1.7.0` as a runtime dependency
- Changed logging dependency in core project
  - Replaced `slf4j-simple` with `slf4j-api`

> 🎉 A logging update, oh so fine! 🌟
> In our code, it now does shine. ✨
> With SLF4J, we stand tall, 🌳
> Logging messages for one and all! 📜
<!-- end of auto-generated comment: release notes by openai -->