### PR TITLE
Make flow.end() argumentless and exception-free

### DIFF
--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -31,24 +31,31 @@ public class ApertureFeatureFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) res;
 
         // Check whether flow was accepted by Aperture Agent
-        FlowDecision flowDecision = flow.getDecision();
-        boolean flowAccepted =
-                (flowDecision == FlowDecision.Accepted
-                        || (flowDecision == FlowDecision.Unreachable && this.failOpen));
-
-        if (flowAccepted) {
+        if (flow.shouldRun()) {
             try {
                 chain.doFilter(request, response);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                flow.setStatus(FlowStatus.Error);
+                throw e;
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow already ended
+                    e.printStackTrace();
+                }
             }
         } else {
             try {
+                flow.setStatus(FlowStatus.Unset);
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Request denied");
-                flow.end(FlowStatus.Error);
-            } catch (ApertureSDKException e) {
-                e.printStackTrace();
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow already ended
+                    e.printStackTrace();
+                }
             }
         }
     }

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -31,32 +31,18 @@ public class ApertureFeatureFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) res;
 
         // Check whether flow was accepted by Aperture Agent
-        if (flow.shouldRun()) {
-            try {
+        try {
+            if (flow.shouldRun()) {
                 chain.doFilter(request, response);
-            } catch (Exception e) {
-                flow.setStatus(FlowStatus.Error);
-                throw e;
-            } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException e) {
-                    // Error: Flow already ended
-                    e.printStackTrace();
-                }
-            }
-        } else {
-            try {
+            } else {
                 flow.setStatus(FlowStatus.Unset);
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Request denied");
-            } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException e) {
-                    // Error: Flow already ended
-                    e.printStackTrace();
-                }
             }
+        } catch (Exception e) {
+            flow.setStatus(FlowStatus.Error);
+            throw e;
+        } finally {
+            flow.end();
         }
     }
 

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -93,25 +93,30 @@ public class App {
 
         // See whether flow was accepted by Aperture Agent.
         if (flow.shouldRun()) {
-            // Simulate work being done
             try {
+                // Simulate work being done
                 res.status(202);
                 Thread.sleep(2000);
-                // Need to call end() on the Flow in order to provide telemetry to Aperture
-                // Agent for completing the control loop.
-                // The first argument captures whether the feature captured by the Flow was
-                // successful or resulted in an error.
-                // The second argument is error message for further diagnosis.
-                flow.end(FlowStatus.OK);
-            } catch (InterruptedException | ApertureSDKException e) {
-                e.printStackTrace();
+            } catch (InterruptedException e) {
+                // Flow Status captures whether the feature captured by the Flow was
+                // successful or resulted in an error. When not explicitly set,
+                // the default value is FlowStatus.OK .
+                flow.setStatus(FlowStatus.Error);
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow had already been ended.
+                    e.printStackTrace();
+                }
             }
         } else {
             // Flow has been rejected by Aperture Agent.
+            res.status(flow.getRejectionHttpStatusCode());
             try {
-                res.status(flow.getRejectionHttpStatusCode());
-                flow.end(FlowStatus.Error);
+                flow.end();
             } catch (ApertureSDKException e) {
+                // Error: Flow had already been ended.
                 e.printStackTrace();
             }
         }

--- a/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
@@ -115,25 +115,30 @@ public class App {
 
         // See whether flow was accepted by Aperture Agent.
         if (flow.shouldRun()) {
-            // Simulate work being done
             try {
+                // Simulate work being done
                 res.status(202);
                 Thread.sleep(2000);
-                // Need to call end() on the Flow in order to provide telemetry to Aperture
-                // Agent for completing the control loop.
-                // The first argument captures whether the feature captured by the Flow was
-                // successful or resulted in an error.
-                // The second argument is error message for further diagnosis.
-                flow.end(FlowStatus.OK);
-            } catch (InterruptedException | ApertureSDKException e) {
-                e.printStackTrace();
+            } catch (InterruptedException e) {
+                // Flow Status captures whether the feature captured by the Flow was
+                // successful or resulted in an error. When not explicitly set,
+                // the default value is FlowStatus.OK .
+                flow.setStatus(FlowStatus.Error);
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // Error: Flow had already been ended.
+                    e.printStackTrace();
+                }
             }
         } else {
             // Flow has been rejected by Aperture Agent.
+            res.status(flow.getRejectionHttpStatusCode());
             try {
-                res.status(flow.getRejectionHttpStatusCode());
-                flow.end(FlowStatus.Error);
+                flow.end();
             } catch (ApertureSDKException e) {
+                // Error: Flow had already been ended.
                 e.printStackTrace();
             }
         }

--- a/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
@@ -7,6 +7,8 @@ import io.grpc.ManagedChannelBuilder;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.Spark;
 
 public class App {
@@ -16,6 +18,8 @@ public class App {
     public static final String DEFAULT_FEATURE_NAME = "awesome_feature";
     public static final String DEFAULT_INSECURE_GRPC = "true";
     public static final String DEFAULT_ROOT_CERT = "";
+
+    public static final Logger logger = LoggerFactory.getLogger(App.class);
 
     private final ApertureSDK apertureSDK;
     private final ManagedChannel channel;
@@ -114,33 +118,23 @@ public class App {
         TrafficFlow flow = this.apertureSDK.startTrafficFlow(apertureRequest);
 
         // See whether flow was accepted by Aperture Agent.
-        if (flow.shouldRun()) {
-            try {
+        try {
+            if (flow.shouldRun()) {
                 // Simulate work being done
                 res.status(202);
                 Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                // Flow Status captures whether the feature captured by the Flow was
-                // successful or resulted in an error. When not explicitly set,
-                // the default value is FlowStatus.OK .
-                flow.setStatus(FlowStatus.Error);
-            } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException e) {
-                    // Error: Flow had already been ended.
-                    e.printStackTrace();
-                }
+            } else {
+                // Flow has been rejected by Aperture Agent.
+                res.status(flow.getRejectionHttpStatusCode());
             }
-        } else {
-            // Flow has been rejected by Aperture Agent.
-            res.status(flow.getRejectionHttpStatusCode());
-            try {
-                flow.end();
-            } catch (ApertureSDKException e) {
-                // Error: Flow had already been ended.
-                e.printStackTrace();
-            }
+        } catch (Exception e) {
+            // Flow Status captures whether the feature captured by the Flow was
+            // successful or resulted in an error. When not explicitly set,
+            // the default value is FlowStatus.OK .
+            flow.setStatus(FlowStatus.Error);
+            logger.error("Error in flow execution", e);
+        } finally {
+            flow.end();
         }
         return "";
     }

--- a/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
+++ b/sdks/aperture-java/examples/tomcat-example/src/main/java/com/fluxninja/example/filter/ApertureFeatureFilter.java
@@ -30,32 +30,18 @@ public class ApertureFeatureFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) res;
 
         // Check whether flow was accepted by Aperture Agent
-        if (flow.shouldRun()) {
-            try {
+        try {
+            if (flow.shouldRun()) {
                 chain.doFilter(request, response);
-            } catch (Exception e) {
-                flow.setStatus(FlowStatus.Error);
-                throw e;
-            } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException e) {
-                    // Error: Flow already ended
-                    e.printStackTrace();
-                }
-            }
-        } else {
-            try {
+            } else {
                 flow.setStatus(FlowStatus.Unset);
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Request denied");
-            } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException e) {
-                    // Error: Flow already ended
-                    e.printStackTrace();
-                }
             }
+        } catch (Exception e) {
+            flow.setStatus(FlowStatus.Error);
+            throw e;
+        } finally {
+            flow.end();
         }
     }
 

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPClient.java
@@ -6,7 +6,6 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
@@ -70,18 +69,11 @@ public class ApertureHTTPClient extends SimpleDecoratingHttpClient {
                 ctx.updateRequest(newRequest);
 
                 res = unwrap().execute(ctx, newRequest);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureHTTPService.java
@@ -3,7 +3,6 @@ package com.fluxninja.aperture.armeria;
 import com.fluxninja.aperture.sdk.*;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
@@ -70,19 +69,11 @@ public class ApertureHTTPService extends SimpleDecoratingHttpService {
                 ctx.updateRequest(newRequest);
 
                 res = unwrap().serve(ctx, newRequest);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClient.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCClient.java
@@ -57,18 +57,11 @@ public class ApertureRPCClient extends SimpleDecoratingRpcClient {
             RpcResponse res;
             try {
                 res = unwrap().execute(ctx, req);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return RpcResponse.ofFailure(e);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCService.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/ApertureRPCService.java
@@ -57,18 +57,11 @@ public class ApertureRPCService extends SimpleDecoratingRpcService {
             RpcResponse res;
             try {
                 res = unwrap().serve(ctx, req);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                return RpcResponse.ofFailure(e);
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                flow.end();
             }
             return res;
         } else {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
@@ -13,13 +13,8 @@ import java.util.Map;
 
 class HttpUtils {
     protected static HttpResponse handleRejectedFlow(TrafficFlow flow) {
-        try {
-            flow.setStatus(FlowStatus.Unset);
-            flow.end();
-        } catch (ApertureSDKException e) {
-            // Flow already ended
-            e.printStackTrace();
-        }
+        flow.setStatus(FlowStatus.Unset);
+        flow.end();
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {
             int httpStatusCode = flow.getRejectionHttpStatusCode();
             HttpResponseBuilder resBuilder = HttpResponse.builder();

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/HttpUtils.java
@@ -14,8 +14,10 @@ import java.util.Map;
 class HttpUtils {
     protected static HttpResponse handleRejectedFlow(TrafficFlow flow) {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
+            // Flow already ended
             e.printStackTrace();
         }
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
@@ -11,7 +11,8 @@ import java.util.Map;
 class RpcUtils {
     protected static HttpStatus handleRejectedFlow(Flow flow) {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }

--- a/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
+++ b/sdks/aperture-java/lib/armeria/src/main/java/com/fluxninja/aperture/armeria/RpcUtils.java
@@ -1,6 +1,5 @@
 package com.fluxninja.aperture.armeria;
 
-import com.fluxninja.aperture.sdk.ApertureSDKException;
 import com.fluxninja.aperture.sdk.Flow;
 import com.fluxninja.aperture.sdk.FlowStatus;
 import com.linecorp.armeria.common.HttpStatus;
@@ -10,12 +9,8 @@ import java.util.Map;
 
 class RpcUtils {
     protected static HttpStatus handleRejectedFlow(Flow flow) {
-        try {
-            flow.setStatus(FlowStatus.Unset);
-            flow.end();
-        } catch (ApertureSDKException e) {
-            e.printStackTrace();
-        }
+        flow.setStatus(FlowStatus.Unset);
+        flow.end();
         return HttpStatus.valueOf(flow.getRejectionHttpStatusCode());
     }
 

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDK.java
@@ -40,7 +40,7 @@ public final class ApertureSDK {
     private final List<String> ignoredPaths;
     private final boolean ignoredPathsMatchRegex;
 
-    private static Logger logger = LoggerFactory.getLogger(ApertureSDK.class);
+    private static final Logger logger = LoggerFactory.getLogger(ApertureSDK.class);
 
     ApertureSDK(
             FlowControlServiceGrpc.FlowControlServiceBlockingStub flowControlClient,

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKBuilder.java
@@ -33,7 +33,7 @@ public final class ApertureSDKBuilder {
     private final List<String> ignoredPaths;
     private boolean ignoredPathsMatchRegex = false;
 
-    private static Logger logger = LoggerFactory.getLogger(ApertureSDKBuilder.class);
+    private static final Logger logger = LoggerFactory.getLogger(ApertureSDKBuilder.class);
 
     ApertureSDKBuilder() {
         ignoredPaths = new ArrayList<>();

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKException.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/ApertureSDKException.java
@@ -1,6 +1,6 @@
 package com.fluxninja.aperture.sdk;
 
-/** Exception thrown by Aperture SDK when it cannot be constructed, or when used incorrectly. */
+/** Exception thrown by Aperture SDK when it cannot be constructed. */
 public class ApertureSDKException extends Exception {
     public ApertureSDKException(String message) {
         super(message);

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Constants.java
@@ -6,7 +6,7 @@ public final class Constants {
     // Library name and version can be used by the user to create a resource that
     // connects to telemetry export.
     public static final String LIBRARY_NAME = "aperture-java";
-    public static final String LIBRARY_VERSION = "2.2.0";
+    public static final String LIBRARY_VERSION = "2.4.0";
 
     // Config defaults.
     public static final Duration DEFAULT_RPC_TIMEOUT = Duration.ofMillis(200);

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/aperture/sdk/Flow.java
@@ -6,6 +6,8 @@ import com.fluxninja.generated.aperture.flowcontrol.check.v1.CheckResponse;
 import com.google.protobuf.util.JsonFormat;
 import io.opentelemetry.api.trace.Span;
 import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A Flow that can be accepted or rejected by Aperture Agent based on provided labels. */
 public final class Flow {
@@ -14,6 +16,8 @@ public final class Flow {
     private boolean ended;
     private boolean failOpen;
     private FlowStatus flowStatus;
+
+    private static final Logger logger = LoggerFactory.getLogger(Flow.class);
 
     Flow(CheckResponse checkResponse, Span span, boolean ended) {
         this.checkResponse = checkResponse;
@@ -112,6 +116,9 @@ public final class Flow {
      * @param status Status of the flow to be finished.
      */
     public void setStatus(FlowStatus status) {
+        if (this.ended) {
+            logger.warn("Trying to change status of an already ended flow");
+        }
         this.flowStatus = status;
     }
 
@@ -119,9 +126,10 @@ public final class Flow {
      * Ends the flow, notifying the Aperture Agent whether it succeeded. Flow's Status is assumed to
      * be "OK" and can be set using {@link #setStatus}.
      */
-    public void end() throws ApertureSDKException {
+    public void end() {
         if (this.ended) {
-            throw new ApertureSDKException("Flow already ended");
+            logger.warn("Trying to end an already ended flow with status " + this.flowStatus);
+            return;
         }
         this.ended = true;
 
@@ -131,8 +139,10 @@ public final class Flow {
                 checkResponseJSONBytes = JsonFormat.printer().print(this.checkResponse);
             }
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            throw new ApertureSDKException(e);
+            logger.warn("Could not attach check response when ending flow", e);
         }
+
+        logger.debug("Ending flow with status " + this.flowStatus);
 
         this.span
                 .setAttribute(FLOW_STATUS_LABEL, this.flowStatus.name())

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -67,27 +67,21 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
                 HttpRequest newRequest = NettyUtils.updateHeaders(req, newHeaders);
 
                 ctx.fireChannelRead(newRequest);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
-                FullHttpResponse response =
-                        new DefaultFullHttpResponse(
-                                HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
-                ctx.write(response);
-                ctx.flush();
             } catch (Exception e) {
-                try {
-                    flow.end(FlowStatus.Error);
-                } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
-                    ae.printStackTrace();
-                }
+                flow.setStatus(FlowStatus.Error);
                 throw e;
+            } finally {
+                try {
+                    flow.end();
+                } catch (ApertureSDKException e) {
+                    // ending flow failed
+                    e.printStackTrace();
+                }
             }
         } else {
             try {
-                flow.end(FlowStatus.Unset);
+                flow.setStatus(FlowStatus.Unset);
+                flow.end();
             } catch (ApertureSDKException e) {
                 e.printStackTrace();
             }

--- a/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
+++ b/sdks/aperture-java/lib/netty/src/main/java/com/fluxninja/aperture/netty/ApertureServerHandler.java
@@ -71,20 +71,11 @@ public class ApertureServerHandler extends SimpleChannelInboundHandler<HttpReque
                 flow.setStatus(FlowStatus.Error);
                 throw e;
             } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException e) {
-                    // ending flow failed
-                    e.printStackTrace();
-                }
+                flow.end();
             }
         } else {
-            try {
-                flow.setStatus(FlowStatus.Unset);
-                flow.end();
-            } catch (ApertureSDKException e) {
-                e.printStackTrace();
-            }
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
             HttpResponseStatus status;
             Map<String, String> headers;
             if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -54,12 +54,7 @@ public class ApertureFilter implements Filter {
                 flow.setStatus(FlowStatus.Error);
                 throw e;
             } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException ae) {
-                    // Error: Flow already ended
-                    ae.printStackTrace();
-                }
+                flow.end();
             }
         } else {
             ServletUtils.handleRejectedFlow(flow, response);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ApertureFilter.java
@@ -50,18 +50,16 @@ public class ApertureFilter implements Filter {
                 }
                 ServletRequest newRequest = ServletUtils.updateHeaders(request, newHeaders);
                 chain.doFilter(newRequest, response);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
             } catch (Exception e) {
+                flow.setStatus(FlowStatus.Error);
+                throw e;
+            } finally {
                 try {
-                    flow.end(FlowStatus.Error);
+                    flow.end();
                 } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
+                    // Error: Flow already ended
                     ae.printStackTrace();
                 }
-                throw e;
             }
         } else {
             ServletUtils.handleRejectedFlow(flow, response);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
@@ -16,7 +16,8 @@ public class ServletUtils {
     protected static void handleRejectedFlow(TrafficFlow flow, HttpServletResponse response)
             throws IOException {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/jakarta/ServletUtils.java
@@ -15,12 +15,8 @@ import java.util.*;
 public class ServletUtils {
     protected static void handleRejectedFlow(TrafficFlow flow, HttpServletResponse response)
             throws IOException {
-        try {
-            flow.setStatus(FlowStatus.Unset);
-            flow.end();
-        } catch (ApertureSDKException e) {
-            e.printStackTrace();
-        }
+        flow.setStatus(FlowStatus.Unset);
+        flow.end();
 
         int code = 403;
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -54,12 +54,7 @@ public class ApertureFilter implements Filter {
                 flow.setStatus(FlowStatus.Error);
                 throw e;
             } finally {
-                try {
-                    flow.end();
-                } catch (ApertureSDKException ae) {
-                    // Error: Flow already ended
-                    ae.printStackTrace();
-                }
+                flow.end();
             }
         } else {
             ServletUtils.handleRejectedFlow(flow, response);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ApertureFilter.java
@@ -50,18 +50,16 @@ public class ApertureFilter implements Filter {
                 }
                 ServletRequest newRequest = ServletUtils.updateHeaders(request, newHeaders);
                 chain.doFilter(newRequest, response);
-                flow.end(FlowStatus.OK);
-            } catch (ApertureSDKException e) {
-                // ending flow failed
-                e.printStackTrace();
             } catch (Exception e) {
+                flow.setStatus(FlowStatus.Error);
+                throw e;
+            } finally {
                 try {
-                    flow.end(FlowStatus.Error);
+                    flow.end();
                 } catch (ApertureSDKException ae) {
-                    e.printStackTrace();
+                    // Error: Flow already ended
                     ae.printStackTrace();
                 }
-                throw e;
             }
         } else {
             ServletUtils.handleRejectedFlow(flow, response);

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
@@ -16,7 +16,8 @@ public class ServletUtils {
     protected static void handleRejectedFlow(TrafficFlow flow, HttpServletResponse response)
             throws IOException {
         try {
-            flow.end(FlowStatus.Unset);
+            flow.setStatus(FlowStatus.Unset);
+            flow.end();
         } catch (ApertureSDKException e) {
             e.printStackTrace();
         }

--- a/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
+++ b/sdks/aperture-java/lib/servlet/src/main/java/com/fluxninja/aperture/servlet/javax/ServletUtils.java
@@ -15,12 +15,8 @@ import javax.servlet.http.HttpServletResponse;
 public class ServletUtils {
     protected static void handleRejectedFlow(TrafficFlow flow, HttpServletResponse response)
             throws IOException {
-        try {
-            flow.setStatus(FlowStatus.Unset);
-            flow.end();
-        } catch (ApertureSDKException e) {
-            e.printStackTrace();
-        }
+        flow.setStatus(FlowStatus.Unset);
+        flow.end();
 
         int code = 403;
         if (flow.checkResponse() != null && flow.checkResponse().hasDeniedResponse()) {

--- a/sdks/aperture-java/version.gradle.kts
+++ b/sdks/aperture-java/version.gradle.kts
@@ -1,7 +1,7 @@
 val snapshot = true
 
 allprojects {
-  var ver = "2.2.0"
+  var ver = "2.4.0"
   if (snapshot) {
     ver += "-SNAPSHOT"
   }


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Refactor:**
- Made `flow.end()` argumentless and exception-free
- Updated error handling and flow control structures
- Added logger to some classes

**Chore:**
- Updated dependency version in `version.gradle.kts`

> 🎉 With graceful ease, the code now flows,
> Exception-free, as the river goes.
> Error handling refined, a logger aligned,
> A new chapter begins, with these changes combined. 🚀
<!-- end of auto-generated comment: release notes by openai -->