### PR TITLE
Do `go mod download` in separate layer

### DIFF
--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -2,6 +2,10 @@
 FROM golang:1.20.4-bullseye AS builder
 
 WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY --link . .
 
 # App build
@@ -19,7 +23,6 @@ RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.aperturectl,id=agent-1.20.4,sharing=private \
   /bin/bash -c \
   'set -eu; \
-  go mod download; \
   ./scripts/build_aperturectl.sh ./cmd/aperturectl; \
   ./scripts/generate_full_build_config.sh ./extensions > build.yaml; \
   ./cmd/aperturectl/aperturectl build agent -c build.yaml -o / --uri .; \

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -2,6 +2,10 @@
 FROM golang:1.20.4-bullseye AS builder
 
 WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY --link . .
 
 # App build
@@ -18,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/ \
   --mount=type=cache,target=/root/.cache/go-build/,id=controller-1.20.4,sharing=private \
   --mount=type=cache,target=/root/.aperturectl,id=controller-1.20.4,sharing=private \
   /bin/bash -c \
-  'go mod download; \
+  'set -eu; \
   ./scripts/build_aperturectl.sh ./cmd/aperturectl; \
   ./cmd/aperturectl/aperturectl build controller -o / --uri .; \
   '


### PR DESCRIPTION
### Description of change
This should speed up building of Agent and Controller.

##### Checklist

- [ ] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Speed up Agent and Controller Docker build process by adding a separate layer for `go mod download`

> 🚀 Faster builds, we celebrate,
> 🎉 With layers separate,
> 🏗️ Agent and Controller now create,
> ⏱️ A Docker image at a quicker rate!
<!-- end of auto-generated comment: release notes by openai -->