### PR TITLE
add agent/controller version on tilt

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -965,7 +965,6 @@ def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_
         if resource == "agent":
             images[0]["build_args"]["APERTURECTL_BUILD_VERSION"] = agent_version
         if race_arg:
-            images = resource_info.get("images",{})
             if resource == "controller":
                 images[0]["build_args"]["APERTURECTL_BUILD_FLAGS"] = "['-race']"
             if resource == "agent":

--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -960,14 +960,10 @@ def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_
         labels = resource_info.get("labels", [])
         images = resource_info.get("images",{})
         agent_version = get_agent_version()
-        if resource == "controller":
-            images[0]["build_args"]["APERTURECTL_BUILD_VERSION"] = agent_version
-        if resource == "agent":
+        if resource in ["controller", "agent"]:
             images[0]["build_args"]["APERTURECTL_BUILD_VERSION"] = agent_version
         if race_arg:
-            if resource == "controller":
-                images[0]["build_args"]["APERTURECTL_BUILD_FLAGS"] = "['-race']"
-            if resource == "agent":
+            if resource in ["controller", "agent"]:
                 images[0]["build_args"]["APERTURECTL_BUILD_FLAGS"] = "['-race']"
         for image in resource_info.get("images", []):
             if 'tag' in image.keys():

--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -943,6 +943,9 @@ def forward_port_delayed(workload, labels, resource_deps, namespace, service, lo
         readiness_probe=readiness_probe,
     )
 
+def get_agent_version():
+    val = str(local("git tag -l --sort='-version:refname' v* | head -n 1")).strip()
+    return val
 
 def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_extension, scenario):
     """
@@ -955,6 +958,12 @@ def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_
     for resource in resources:
         resource_info = inv_dep_tree[resource]
         labels = resource_info.get("labels", [])
+        images = resource_info.get("images",{})
+        agent_version = get_agent_version()
+        if resource == "controller":
+            images[0]["build_args"]["APERTURECTL_BUILD_VERSION"] = agent_version
+        if resource == "agent":
+            images[0]["build_args"]["APERTURECTL_BUILD_VERSION"] = agent_version
         if race_arg:
             images = resource_info.get("images",{})
             if resource == "controller":


### PR DESCRIPTION
### Description of change
Add latest version for agent/controller on Tilt
```
sachinmaurya@sachin:~/fluxninja/aperture (add-agent-version)$ curl localhost:8080/v1/info/version

{"version":"v2.5.0-rc.1", "service":"aperture-agent", "build_host":"buildkitsandbox", "build_os":"linux/amd64", "build_time":"2023-06-13T12:23:52+00:00", "git_branch":"unknown", "git_commit_hash":"unknown"}
```
cc @DariaKunoichi 
##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Automatically fetch and use the latest version of agent/controller from git tags
- Add support for enabling the `-race` flag during build when `race_arg` is True
```

> 🎉 A new dawn rises, with versions fetched,
> The latest and greatest, our code now etched.
> With race flags enabled, we stand secure,
> This PR brings changes, both bright and pure. 🌟
<!-- end of auto-generated comment: release notes by openai -->