### PR TITLE
Remove default kubelet scraper

### DIFF
--- a/cmd/aperture-agent/agent/otel-config.go
+++ b/cmd/aperture-agent/agent/otel-config.go
@@ -51,10 +51,6 @@ func provideAgent(
 	addMetricsPipeline(otelCfg, &agentCfg, tlsConfig, lis, promClient)
 
 	customConfig := map[string]*policylangv1.InfraMeter{}
-	if !agentCfg.DisableKubeletScraper {
-		customConfig[otelconsts.ReceiverKubeletStats] = inframeter.InfraMeterForKubeletStats()
-	}
-
 	if err := inframeter.AddInfraMeters(otelCfg, customConfig); err != nil {
 		return nil, fmt.Errorf("adding builtin custom metrics pipelines: %w", err)
 	}

--- a/cmd/aperture-agent/config/types.go
+++ b/cmd/aperture-agent/config/types.go
@@ -27,6 +27,7 @@ type AgentOTelConfig struct {
 	// DisableKubernetesScraper disables the default metrics collection for Kubernetes resources.
 	DisableKubernetesScraper bool `json:"disable_kubernetes_scraper" default:"false"`
 	// DisableKubeletScraper disables the default metrics collection for kubelet.
+	// Deprecated: kubelet scraper is removed entirely, so this flag makes no difference.
 	DisableKubeletScraper bool `json:"disable_kubelet_scraper" default:"false"`
 }
 

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -800,6 +800,8 @@ AgentOTelConfig is the configuration for Agent's OTel collector.
 <!-- vale on -->
 
 DisableKubeletScraper disables the default metrics collection for kubelet.
+Deprecated: kubelet scraper is removed entirely, so this flag makes no
+difference.
 
 </dd>
 <dt>disable_kubernetes_scraper</dt>

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -71,7 +71,9 @@ definitions:
                 x-go-tag-json: batch_prerollup
             disable_kubelet_scraper:
                 default: false
-                description: DisableKubeletScraper disables the default metrics collection for kubelet.
+                description: |-
+                    DisableKubeletScraper disables the default metrics collection for kubelet.
+                    Deprecated: kubelet scraper is removed entirely, so this flag makes no difference.
                 type: boolean
                 x-go-name: DisableKubeletScraper
                 x-go-tag-default: "false"

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1531,8 +1531,9 @@ spec:
                             type: string
                         type: object
                       disable_kubelet_scraper:
-                        description: DisableKubeletScraper disables the default metrics
-                          collection for kubelet.
+                        description: 'DisableKubeletScraper disables the default metrics
+                          collection for kubelet. Deprecated: kubelet scraper is removed
+                          entirely, so this flag makes no difference.'
                         type: boolean
                       disable_kubernetes_scraper:
                         description: DisableKubernetesScraper disables the default

--- a/pkg/otelcollector/infra-meter/infra-meter.go
+++ b/pkg/otelcollector/infra-meter/infra-meter.go
@@ -6,13 +6,11 @@ import (
 	"strings"
 
 	policylangv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
-	"github.com/fluxninja/aperture/v2/pkg/log"
 	otelconfig "github.com/fluxninja/aperture/v2/pkg/otelcollector/config"
 	otelconsts "github.com/fluxninja/aperture/v2/pkg/otelcollector/consts"
 	"github.com/fluxninja/aperture/v2/pkg/otelcollector/leaderonlyreceiver"
 	"go.opentelemetry.io/collector/component"
 	"golang.org/x/exp/maps"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // AddInfraMeters adds infra metrics pipelines to the given OTelConfig.
@@ -137,98 +135,4 @@ func normalizeComponentName(pipelineName, componentName string) string {
 		return suffix
 	}
 	return fmt.Sprintf("%s/%s", componentName, suffix)
-}
-
-// InfraMeterForKubeletStats returns an InfraMeter for kubelet stats.
-func InfraMeterForKubeletStats() *policylangv1.InfraMeter {
-	kubeletStatsReceiver, err := structpb.NewStruct(map[string]any{
-		"collection_interval":  "10s",
-		"auth_type":            "serviceAccount",
-		"endpoint":             "https://${NODE_NAME}:10250",
-		"insecure_skip_verify": true,
-		"metric_groups": []any{
-			"pod",
-		},
-	})
-	if err != nil {
-		log.Panic().Err(err).Msg("failed to create kubelet stats config")
-	}
-
-	receivers := map[string]*structpb.Struct{
-		otelconsts.ReceiverKubeletStats: kubeletStatsReceiver,
-	}
-
-	kubeletStatsProcessor, err := structpb.NewStruct(map[string]any{
-		"metrics": map[string]any{
-			"include": map[string]any{
-				"match_type": "strict",
-				"metric_names": []any{
-					"k8s.pod.cpu.utilization",
-					"k8s.pod.memory.available",
-					"k8s.pod.memory.usage",
-					"k8s.pod.memory.working_set",
-				},
-			},
-		},
-	})
-	if err != nil {
-		log.Panic().Err(err).Msg("failed to create kubelet stats processor config")
-	}
-
-	k8sAttributesProcessor, err := structpb.NewStruct(map[string]any{
-		"auth_type":   "serviceAccount",
-		"passthrough": false,
-		"filter": map[string]any{
-			"node_from_env_var": "NODE_NAME",
-		},
-		"extract": map[string]any{
-			"metadata": []any{
-				"k8s.daemonset.name",
-				"k8s.cronjob.name",
-				"k8s.deployment.name",
-				"k8s.job.name",
-				"k8s.namespace.name",
-				"k8s.node.name",
-				"k8s.pod.name",
-				"k8s.pod.uid",
-				"k8s.replicaset.name",
-				"k8s.statefulset.name",
-			},
-			"labels": []any{
-				map[string]any{
-					"key_regex": "^app.kubernetes.io/.*",
-				},
-			},
-		},
-		"pod_association": []any{
-			map[string]any{
-				"sources": map[string]any{
-					"from": "resource_attribute",
-					"name": "k8s.pod.uid",
-				},
-			},
-		},
-	})
-	if err != nil {
-		log.Panic().Err(err).Msg("failed to create k8s attributes processor config")
-	}
-
-	processors := map[string]*structpb.Struct{
-		otelconsts.ProcessorFilterKubeletStats: kubeletStatsProcessor,
-		otelconsts.ProcessorK8sAttributes:      k8sAttributesProcessor,
-	}
-
-	return &policylangv1.InfraMeter{
-		Receivers:  receivers,
-		Processors: processors,
-		Pipeline: &policylangv1.InfraMeter_MetricsPipeline{
-			Receivers: []string{
-				otelconsts.ReceiverKubeletStats,
-			},
-			Processors: []string{
-				otelconsts.ProcessorFilterKubeletStats,
-				otelconsts.ProcessorK8sAttributes,
-			},
-		},
-	}
 }


### PR DESCRIPTION
### Description of change
We don't want to collect any metrics which are not directly needed by a policy.

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Removed**: Kubelet scraper functionality
- Removed kubelet scraper from customConfig
- Deprecated and removed `DisableKubeletScraper` flag
- Updated documentation to reflect changes
- Deleted `InfraMeterForKubeletStats` function

> 🎉 Farewell, kubelet scraper, we part ways,
> No more shall you collect metrics in our days.
> With lighter code, we now stride ahead,
> Embracing the future, where new paths are tread. 🚀
<!-- end of auto-generated comment: release notes by openai -->