### PR TITLE
Filter out high cardinality platform metrics

### DIFF
--- a/cmd/aperture-agent/agent/otel-config.go
+++ b/cmd/aperture-agent/agent/otel-config.go
@@ -178,7 +178,7 @@ func addMetricsPipeline(
 	processors := []string{
 		otelconsts.ProcessorAgentGroup,
 	}
-	if agentConfig.DisableHighCardinalityPlatformMetrics {
+	if !agentConfig.EnableHighCardinalityPlatformMetrics {
 		otelconfig.AddHighCardinalityMetricsFilterProcessor(config)
 		// Prepending processor so we drop metrics as soon as possible without any unnecessary operation on them.
 		processors = append([]string{otelconsts.ProcessorFilterHighCardinalityMetrics}, processors...)

--- a/cmd/aperture-agent/agent/otel-config.go
+++ b/cmd/aperture-agent/agent/otel-config.go
@@ -175,12 +175,18 @@ func addMetricsPipeline(
 ) {
 	addPrometheusReceiver(config, agentConfig, tlsConfig, lis)
 	otelconfig.AddPrometheusRemoteWriteExporter(config, promClient)
+	processors := []string{
+		otelconsts.ProcessorAgentGroup,
+	}
+	if !agentConfig.DisableHighCardinalityPlatformMetrics {
+		otelconfig.AddHighCardinalityMetricsFilterProcessor(config)
+		// Prepending processor so we drop metrics as soon as possible without any unnecessary operation on them.
+		processors = append([]string{otelconsts.ProcessorFilterHighCardinalityMetrics}, processors...)
+	}
 	config.Service.AddPipeline("metrics/fast", otelconfig.Pipeline{
-		Receivers: []string{otelconsts.ReceiverPrometheus},
-		Processors: []string{
-			otelconsts.ProcessorAgentGroup,
-		},
-		Exporters: []string{otelconsts.ExporterPrometheusRemoteWrite},
+		Receivers:  []string{otelconsts.ReceiverPrometheus},
+		Processors: processors,
+		Exporters:  []string{otelconsts.ExporterPrometheusRemoteWrite},
 	})
 }
 

--- a/cmd/aperture-agent/agent/otel-config.go
+++ b/cmd/aperture-agent/agent/otel-config.go
@@ -178,7 +178,7 @@ func addMetricsPipeline(
 	processors := []string{
 		otelconsts.ProcessorAgentGroup,
 	}
-	if !agentConfig.DisableHighCardinalityPlatformMetrics {
+	if agentConfig.DisableHighCardinalityPlatformMetrics {
 		otelconfig.AddHighCardinalityMetricsFilterProcessor(config)
 		// Prepending processor so we drop metrics as soon as possible without any unnecessary operation on them.
 		processors = append([]string{otelconsts.ProcessorFilterHighCardinalityMetrics}, processors...)

--- a/cmd/aperture-agent/config/types.go
+++ b/cmd/aperture-agent/config/types.go
@@ -29,7 +29,7 @@ type AgentOTelConfig struct {
 	// DisableKubeletScraper disables the default metrics collection for kubelet.
 	// Deprecated: kubelet scraper is removed entirely, so this flag makes no difference.
 	DisableKubeletScraper bool `json:"disable_kubelet_scraper" default:"false"`
-	// DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+	// EnableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
 	// published to Prometheus. Filtered out metrics are:
 	//   * "grpc_server_handled_total.*"
 	//   * "grpc_server_handling_seconds.*"
@@ -39,7 +39,7 @@ type AgentOTelConfig struct {
 	//   * "grpc_server_msg_received_total.*"
 	//   * "grpc_server_msg_sent_total.*"
 	//   * "grpc_server_started_total.*"
-	DisableHighCardinalityPlatformMetrics bool `json:"disable_high_cardinality_platform_metrics" default:"true"`
+	EnableHighCardinalityPlatformMetrics bool `json:"enable_high_cardinality_platform_metrics" default:"false"`
 }
 
 // BatchPrerollupConfig defines configuration for OTel batch processor.

--- a/cmd/aperture-agent/config/types.go
+++ b/cmd/aperture-agent/config/types.go
@@ -29,6 +29,17 @@ type AgentOTelConfig struct {
 	// DisableKubeletScraper disables the default metrics collection for kubelet.
 	// Deprecated: kubelet scraper is removed entirely, so this flag makes no difference.
 	DisableKubeletScraper bool `json:"disable_kubelet_scraper" default:"false"`
+	// DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+	// published to Prometheus. Filtered out metrics are:
+	//   * "grpc_server_handled_total.*"
+	//   * "grpc_server_handling_seconds.*"
+	//   * "grpc_server_handling_seconds_bucket.*"
+	//   * "grpc_server_handling_seconds_count.*"
+	//   * "grpc_server_handling_seconds_sum.*"
+	//   * "grpc_server_msg_received_total.*"
+	//   * "grpc_server_msg_sent_total.*"
+	//   * "grpc_server_started_total.*"
+	DisableHighCardinalityPlatformMetrics bool `json:"disable_high_cardinality_platform_metrics" default:"true"`
 }
 
 // BatchPrerollupConfig defines configuration for OTel batch processor.

--- a/cmd/aperture-controller/config/types.go
+++ b/cmd/aperture-controller/config/types.go
@@ -18,4 +18,15 @@ import (
 // +kubebuilder:object:generate=true
 type ControllerOTelConfig struct {
 	otelconfig.CommonOTelConfig `json:",inline"`
+	// DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+	// published to Prometheus. Filtered out metrics are:
+	//   * "grpc_server_handled_total.*"
+	//   * "grpc_server_handling_seconds.*"
+	//   * "grpc_server_handling_seconds_bucket.*"
+	//   * "grpc_server_handling_seconds_count.*"
+	//   * "grpc_server_handling_seconds_sum.*"
+	//   * "grpc_server_msg_received_total.*"
+	//   * "grpc_server_msg_sent_total.*"
+	//   * "grpc_server_started_total.*"
+	DisableHighCardinalityPlatformMetrics bool `json:"disable_high_cardinality_platform_metrics" default:"true"`
 }

--- a/cmd/aperture-controller/config/types.go
+++ b/cmd/aperture-controller/config/types.go
@@ -18,7 +18,7 @@ import (
 // +kubebuilder:object:generate=true
 type ControllerOTelConfig struct {
 	otelconfig.CommonOTelConfig `json:",inline"`
-	// DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+	// EnableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
 	// published to Prometheus. Filtered out metrics are:
 	//   * "grpc_server_handled_total.*"
 	//   * "grpc_server_handling_seconds.*"
@@ -28,5 +28,5 @@ type ControllerOTelConfig struct {
 	//   * "grpc_server_msg_received_total.*"
 	//   * "grpc_server_msg_sent_total.*"
 	//   * "grpc_server_started_total.*"
-	DisableHighCardinalityPlatformMetrics bool `json:"disable_high_cardinality_platform_metrics" default:"true"`
+	EnableHighCardinalityPlatformMetrics bool `json:"enable_high_cardinality_platform_metrics" default:"false"`
 }

--- a/cmd/aperture-controller/controller/otel-component.go
+++ b/cmd/aperture-controller/controller/otel-component.go
@@ -5,6 +5,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 	"go.opentelemetry.io/collector/exporter"
@@ -85,6 +86,7 @@ func ControllerOTelComponents(
 		batchprocessor.NewFactory(),
 		attributesprocessor.NewFactory(),
 		transformprocessor.NewFactory(),
+		filterprocessor.NewFactory(),
 	}
 	// processorsFactory = append(processorsFactory, otelContribProcessors()...)
 	pf = append(pf, processorFactories...)

--- a/cmd/aperture-controller/controller/otel-config.go
+++ b/cmd/aperture-controller/controller/otel-config.go
@@ -44,9 +44,15 @@ func addMetricsPipeline(
 ) {
 	addPrometheusReceiver(config, controllerConfig, tlsConfig, lis)
 	otelconfig.AddPrometheusRemoteWriteExporter(config, promClient)
+	processors := []string{}
+	if !controllerConfig.DisableHighCardinalityPlatformMetrics {
+		otelconfig.AddHighCardinalityMetricsFilterProcessor(config)
+		// Prepending processor so we drop metrics as soon as possible without any unnecessary operation on them.
+		processors = append([]string{otelconsts.ProcessorFilterHighCardinalityMetrics}, processors...)
+	}
 	config.Service.AddPipeline("metrics/controller-fast", otelconfig.Pipeline{
 		Receivers:  []string{otelconsts.ReceiverPrometheus},
-		Processors: []string{},
+		Processors: processors,
 		Exporters:  []string{otelconsts.ExporterPrometheusRemoteWrite},
 	})
 }

--- a/cmd/aperture-controller/controller/otel-config.go
+++ b/cmd/aperture-controller/controller/otel-config.go
@@ -45,7 +45,7 @@ func addMetricsPipeline(
 	addPrometheusReceiver(config, controllerConfig, tlsConfig, lis)
 	otelconfig.AddPrometheusRemoteWriteExporter(config, promClient)
 	processors := []string{}
-	if controllerConfig.DisableHighCardinalityPlatformMetrics {
+	if !controllerConfig.EnableHighCardinalityPlatformMetrics {
 		otelconfig.AddHighCardinalityMetricsFilterProcessor(config)
 		// Prepending processor so we drop metrics as soon as possible without any unnecessary operation on them.
 		processors = append([]string{otelconsts.ProcessorFilterHighCardinalityMetrics}, processors...)
@@ -53,7 +53,7 @@ func addMetricsPipeline(
 	config.Service.AddPipeline("metrics/controller-fast", otelconfig.Pipeline{
 		Receivers:  []string{otelconsts.ReceiverPrometheus},
 		Processors: processors,
-		Exporters:  []string{otelconsts.ExporterPrometheusRemoteWrite},
+		Exporters:  []string{otelconsts.ExporterPrometheusRemoteWrite, otelconsts.ExporterLogging},
 	})
 }
 

--- a/cmd/aperture-controller/controller/otel-config.go
+++ b/cmd/aperture-controller/controller/otel-config.go
@@ -45,7 +45,7 @@ func addMetricsPipeline(
 	addPrometheusReceiver(config, controllerConfig, tlsConfig, lis)
 	otelconfig.AddPrometheusRemoteWriteExporter(config, promClient)
 	processors := []string{}
-	if !controllerConfig.DisableHighCardinalityPlatformMetrics {
+	if controllerConfig.DisableHighCardinalityPlatformMetrics {
 		otelconfig.AddHighCardinalityMetricsFilterProcessor(config)
 		// Prepending processor so we drop metrics as soon as possible without any unnecessary operation on them.
 		processors = append([]string{otelconsts.ProcessorFilterHighCardinalityMetrics}, processors...)

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -790,23 +790,6 @@ example, Flux Meters, Rate Limiters and so on).
 AgentOTelConfig is the configuration for Agent's OTel collector.
 
 <dl>
-<dt>disable_high_cardinality_platform_metrics</dt>
-<dd>
-
-<!-- vale off -->
-
-(bool, default: `true`)
-
-<!-- vale on -->
-
-DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture
-platform metrics from being published to Prometheus. Filtered out metrics are:
-"grpc_server_handled_total._" "grpc_server_handling_seconds._"
-"grpc_server_handling_seconds_bucket._" "grpc_server_handling_seconds_count._"
-"grpc_server_handling_seconds_sum._" "grpc_server_msg_received_total._"
-"grpc_server_msg_sent_total._" "grpc_server_started_total._"
-
-</dd>
 <dt>disable_kubelet_scraper</dt>
 <dd>
 
@@ -832,6 +815,23 @@ difference.
 
 DisableKubernetesScraper disables the default metrics collection for Kubernetes
 resources.
+
+</dd>
+<dt>enable_high_cardinality_platform_metrics</dt>
+<dd>
+
+<!-- vale off -->
+
+(bool, default: `false`)
+
+<!-- vale on -->
+
+EnableHighCardinalityPlatformMetrics filters out high cardinality Aperture
+platform metrics from being published to Prometheus. Filtered out metrics are:
+"grpc_server_handled_total._" "grpc_server_handling_seconds._"
+"grpc_server_handling_seconds_bucket._" "grpc_server_handling_seconds_count._"
+"grpc_server_handling_seconds_sum._" "grpc_server_msg_received_total._"
+"grpc_server_msg_sent_total._" "grpc_server_started_total._"
 
 </dd>
 <dt>batch_alerts</dt>

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -790,6 +790,23 @@ example, Flux Meters, Rate Limiters and so on).
 AgentOTelConfig is the configuration for Agent's OTel collector.
 
 <dl>
+<dt>disable_high_cardinality_platform_metrics</dt>
+<dd>
+
+<!-- vale off -->
+
+(bool, default: `true`)
+
+<!-- vale on -->
+
+DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture
+platform metrics from being published to Prometheus. Filtered out metrics are:
+"grpc_server_handled_total._" "grpc_server_handling_seconds._"
+"grpc_server_handling_seconds_bucket._" "grpc_server_handling_seconds_count._"
+"grpc_server_handling_seconds_sum._" "grpc_server_msg_received_total._"
+"grpc_server_msg_sent_total._" "grpc_server_started_total._"
+
+</dd>
 <dt>disable_kubelet_scraper</dt>
 <dd>
 

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -789,6 +789,23 @@ ClientTLSConfig is the configuration for client TLS.
 ControllerOTelConfig is the configuration for Controller's OTel collector.
 
 <dl>
+<dt>disable_high_cardinality_platform_metrics</dt>
+<dd>
+
+<!-- vale off -->
+
+(bool, default: `true`)
+
+<!-- vale on -->
+
+DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture
+platform metrics from being published to Prometheus. Filtered out metrics are:
+"grpc_server_handled_total._" "grpc_server_handling_seconds._"
+"grpc_server_handling_seconds_bucket._" "grpc_server_handling_seconds_count._"
+"grpc_server_handling_seconds_sum._" "grpc_server_msg_received_total._"
+"grpc_server_msg_sent_total._" "grpc_server_started_total._"
+
+</dd>
 <dt>batch_alerts</dt>
 <dd>
 

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -789,16 +789,16 @@ ClientTLSConfig is the configuration for client TLS.
 ControllerOTelConfig is the configuration for Controller's OTel collector.
 
 <dl>
-<dt>disable_high_cardinality_platform_metrics</dt>
+<dt>enable_high_cardinality_platform_metrics</dt>
 <dd>
 
 <!-- vale off -->
 
-(bool, default: `true`)
+(bool, default: `false`)
 
 <!-- vale on -->
 
-DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture
+EnableHighCardinalityPlatformMetrics filters out high cardinality Aperture
 platform metrics from being published to Prometheus. Filtered out metrics are:
 "grpc_server_handled_total._" "grpc_server_handling_seconds._"
 "grpc_server_handling_seconds_bucket._" "grpc_server_handling_seconds_count._"

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -69,6 +69,23 @@ definitions:
                 $ref: '#/definitions/BatchPrerollupConfig'
                 description: BatchPrerollup configures the OTel batch pre-processor.
                 x-go-tag-json: batch_prerollup
+            disable_high_cardinality_platform_metrics:
+                default: true
+                description: |-
+                    DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+                    published to Prometheus. Filtered out metrics are:
+                    "grpc_server_handled_total.*"
+                    "grpc_server_handling_seconds.*"
+                    "grpc_server_handling_seconds_bucket.*"
+                    "grpc_server_handling_seconds_count.*"
+                    "grpc_server_handling_seconds_sum.*"
+                    "grpc_server_msg_received_total.*"
+                    "grpc_server_msg_sent_total.*"
+                    "grpc_server_started_total.*"
+                type: boolean
+                x-go-name: DisableHighCardinalityPlatformMetrics
+                x-go-tag-default: "true"
+                x-go-tag-json: disable_high_cardinality_platform_metrics
             disable_kubelet_scraper:
                 default: false
                 description: |-

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -69,23 +69,6 @@ definitions:
                 $ref: '#/definitions/BatchPrerollupConfig'
                 description: BatchPrerollup configures the OTel batch pre-processor.
                 x-go-tag-json: batch_prerollup
-            disable_high_cardinality_platform_metrics:
-                default: true
-                description: |-
-                    DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
-                    published to Prometheus. Filtered out metrics are:
-                    "grpc_server_handled_total.*"
-                    "grpc_server_handling_seconds.*"
-                    "grpc_server_handling_seconds_bucket.*"
-                    "grpc_server_handling_seconds_count.*"
-                    "grpc_server_handling_seconds_sum.*"
-                    "grpc_server_msg_received_total.*"
-                    "grpc_server_msg_sent_total.*"
-                    "grpc_server_started_total.*"
-                type: boolean
-                x-go-name: DisableHighCardinalityPlatformMetrics
-                x-go-tag-default: "true"
-                x-go-tag-json: disable_high_cardinality_platform_metrics
             disable_kubelet_scraper:
                 default: false
                 description: |-
@@ -102,6 +85,23 @@ definitions:
                 x-go-name: DisableKubernetesScraper
                 x-go-tag-default: "false"
                 x-go-tag-json: disable_kubernetes_scraper
+            enable_high_cardinality_platform_metrics:
+                default: false
+                description: |-
+                    EnableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+                    published to Prometheus. Filtered out metrics are:
+                    "grpc_server_handled_total.*"
+                    "grpc_server_handling_seconds.*"
+                    "grpc_server_handling_seconds_bucket.*"
+                    "grpc_server_handling_seconds_count.*"
+                    "grpc_server_handling_seconds_sum.*"
+                    "grpc_server_msg_received_total.*"
+                    "grpc_server_msg_sent_total.*"
+                    "grpc_server_started_total.*"
+                type: boolean
+                x-go-name: EnableHighCardinalityPlatformMetrics
+                x-go-tag-default: "false"
+                x-go-tag-json: enable_high_cardinality_platform_metrics
             ports:
                 $ref: '#/definitions/PortsConfig'
                 description: Ports configures debug, health and extension ports values.

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -214,6 +214,23 @@ definitions:
                 $ref: '#/definitions/BatchAlertsConfig'
                 description: BatchAlerts configures batch alerts processor.
                 x-go-tag-json: batch_alerts
+            disable_high_cardinality_platform_metrics:
+                default: true
+                description: |-
+                    DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+                    published to Prometheus. Filtered out metrics are:
+                    "grpc_server_handled_total.*"
+                    "grpc_server_handling_seconds.*"
+                    "grpc_server_handling_seconds_bucket.*"
+                    "grpc_server_handling_seconds_count.*"
+                    "grpc_server_handling_seconds_sum.*"
+                    "grpc_server_msg_received_total.*"
+                    "grpc_server_msg_sent_total.*"
+                    "grpc_server_started_total.*"
+                type: boolean
+                x-go-name: DisableHighCardinalityPlatformMetrics
+                x-go-tag-default: "true"
+                x-go-tag-json: disable_high_cardinality_platform_metrics
             ports:
                 $ref: '#/definitions/PortsConfig'
                 description: Ports configures debug, health and extension ports values.

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -214,10 +214,10 @@ definitions:
                 $ref: '#/definitions/BatchAlertsConfig'
                 description: BatchAlerts configures batch alerts processor.
                 x-go-tag-json: batch_alerts
-            disable_high_cardinality_platform_metrics:
-                default: true
+            enable_high_cardinality_platform_metrics:
+                default: false
                 description: |-
-                    DisableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
+                    EnableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
                     published to Prometheus. Filtered out metrics are:
                     "grpc_server_handled_total.*"
                     "grpc_server_handling_seconds.*"
@@ -228,9 +228,9 @@ definitions:
                     "grpc_server_msg_sent_total.*"
                     "grpc_server_started_total.*"
                 type: boolean
-                x-go-name: DisableHighCardinalityPlatformMetrics
-                x-go-tag-default: "true"
-                x-go-tag-json: disable_high_cardinality_platform_metrics
+                x-go-name: EnableHighCardinalityPlatformMetrics
+                x-go-tag-default: "false"
+                x-go-tag-json: enable_high_cardinality_platform_metrics
             ports:
                 $ref: '#/definitions/PortsConfig'
                 description: Ports configures debug, health and extension ports values.

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1530,6 +1530,15 @@ spec:
                               will be sent regardless of size.
                             type: string
                         type: object
+                      disable_high_cardinality_platform_metrics:
+                        description: 'DisableHighCardinalityPlatformMetrics filters
+                          out high cardinality Aperture platform metrics from being
+                          published to Prometheus. Filtered out metrics are: * "grpc_server_handled_total.*"
+                          * "grpc_server_handling_seconds.*" * "grpc_server_handling_seconds_bucket.*"
+                          * "grpc_server_handling_seconds_count.*" * "grpc_server_handling_seconds_sum.*"
+                          * "grpc_server_msg_received_total.*" * "grpc_server_msg_sent_total.*"
+                          * "grpc_server_started_total.*"'
+                        type: boolean
                       disable_kubelet_scraper:
                         description: 'DisableKubeletScraper disables the default metrics
                           collection for kubelet. Deprecated: kubelet scraper is removed

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1530,15 +1530,6 @@ spec:
                               will be sent regardless of size.
                             type: string
                         type: object
-                      disable_high_cardinality_platform_metrics:
-                        description: 'DisableHighCardinalityPlatformMetrics filters
-                          out high cardinality Aperture platform metrics from being
-                          published to Prometheus. Filtered out metrics are: * "grpc_server_handled_total.*"
-                          * "grpc_server_handling_seconds.*" * "grpc_server_handling_seconds_bucket.*"
-                          * "grpc_server_handling_seconds_count.*" * "grpc_server_handling_seconds_sum.*"
-                          * "grpc_server_msg_received_total.*" * "grpc_server_msg_sent_total.*"
-                          * "grpc_server_started_total.*"'
-                        type: boolean
                       disable_kubelet_scraper:
                         description: 'DisableKubeletScraper disables the default metrics
                           collection for kubelet. Deprecated: kubelet scraper is removed
@@ -1547,6 +1538,15 @@ spec:
                       disable_kubernetes_scraper:
                         description: DisableKubernetesScraper disables the default
                           metrics collection for Kubernetes resources.
+                        type: boolean
+                      enable_high_cardinality_platform_metrics:
+                        description: 'EnableHighCardinalityPlatformMetrics filters
+                          out high cardinality Aperture platform metrics from being
+                          published to Prometheus. Filtered out metrics are: * "grpc_server_handled_total.*"
+                          * "grpc_server_handling_seconds.*" * "grpc_server_handling_seconds_bucket.*"
+                          * "grpc_server_handling_seconds_count.*" * "grpc_server_handling_seconds_sum.*"
+                          * "grpc_server_msg_received_total.*" * "grpc_server_msg_sent_total.*"
+                          * "grpc_server_started_total.*"'
                         type: boolean
                       ports:
                         description: Ports configures debug, health and extension

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1297,6 +1297,15 @@ spec:
                               will be sent regardless of size.
                             type: string
                         type: object
+                      disable_high_cardinality_platform_metrics:
+                        description: 'DisableHighCardinalityPlatformMetrics filters
+                          out high cardinality Aperture platform metrics from being
+                          published to Prometheus. Filtered out metrics are: * "grpc_server_handled_total.*"
+                          * "grpc_server_handling_seconds.*" * "grpc_server_handling_seconds_bucket.*"
+                          * "grpc_server_handling_seconds_count.*" * "grpc_server_handling_seconds_sum.*"
+                          * "grpc_server_msg_received_total.*" * "grpc_server_msg_sent_total.*"
+                          * "grpc_server_started_total.*"'
+                        type: boolean
                       ports:
                         description: Ports configures debug, health and extension
                           ports values.

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1297,8 +1297,8 @@ spec:
                               will be sent regardless of size.
                             type: string
                         type: object
-                      disable_high_cardinality_platform_metrics:
-                        description: 'DisableHighCardinalityPlatformMetrics filters
+                      enable_high_cardinality_platform_metrics:
+                        description: 'EnableHighCardinalityPlatformMetrics filters
                           out high cardinality Aperture platform metrics from being
                           published to Prometheus. Filtered out metrics are: * "grpc_server_handled_total.*"
                           * "grpc_server_handling_seconds.*" * "grpc_server_handling_seconds_bucket.*"

--- a/operator/controllers/agent/config_test.tpl
+++ b/operator/controllers/agent/config_test.tpl
@@ -151,7 +151,7 @@ otel:
     timeout: 1s
   disable_kubernetes_scraper: false
   disable_kubelet_scraper: false
-  disable_high_cardinality_platform_metrics: true
+  enable_high_cardinality_platform_metrics: false
   ports:
     debug_port: 8888
     health_check_port: 13133

--- a/operator/controllers/agent/config_test.tpl
+++ b/operator/controllers/agent/config_test.tpl
@@ -151,6 +151,7 @@ otel:
     timeout: 1s
   disable_kubernetes_scraper: false
   disable_kubelet_scraper: false
+  disable_high_cardinality_platform_metrics: true
   ports:
     debug_port: 8888
     health_check_port: 13133

--- a/operator/controllers/agent/configmaps_test.go
+++ b/operator/controllers/agent/configmaps_test.go
@@ -104,6 +104,7 @@ var _ = Describe("ConfigMap for Agent", func() {
 								SendBatchSize:    100,
 								SendBatchMaxSize: 200,
 							},
+							DisableHighCardinalityPlatformMetrics: true,
 						},
 					},
 				},

--- a/operator/controllers/agent/configmaps_test.go
+++ b/operator/controllers/agent/configmaps_test.go
@@ -104,7 +104,7 @@ var _ = Describe("ConfigMap for Agent", func() {
 								SendBatchSize:    100,
 								SendBatchMaxSize: 200,
 							},
-							DisableHighCardinalityPlatformMetrics: true,
+							EnableHighCardinalityPlatformMetrics: false,
 						},
 					},
 				},

--- a/operator/controllers/controller/config_test.tpl
+++ b/operator/controllers/controller/config_test.tpl
@@ -91,7 +91,7 @@ otel:
     health_check_port: 13133
     pprof_port: 1777
     zpages_port: 55679
-  disable_high_cardinality_platform_metrics: true
+  enable_high_cardinality_platform_metrics: false
 policies:
   cr_watcher:
     enabled: false

--- a/operator/controllers/controller/config_test.tpl
+++ b/operator/controllers/controller/config_test.tpl
@@ -91,6 +91,7 @@ otel:
     health_check_port: 13133
     pprof_port: 1777
     zpages_port: 55679
+  disable_high_cardinality_platform_metrics: true
 policies:
   cr_watcher:
     enabled: false

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -95,6 +95,7 @@ var _ = Describe("ConfigMap for Controller", func() {
 									ZpagesPort:      55679,
 								},
 							},
+							DisableHighCardinalityPlatformMetrics: true,
 						},
 					},
 				},

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -95,7 +95,7 @@ var _ = Describe("ConfigMap for Controller", func() {
 									ZpagesPort:      55679,
 								},
 							},
-							DisableHighCardinalityPlatformMetrics: true,
+							EnableHighCardinalityPlatformMetrics: false,
 						},
 					},
 				},

--- a/pkg/otelcollector/config/builtin_config.go
+++ b/pkg/otelcollector/config/builtin_config.go
@@ -118,7 +118,6 @@ func AddHighCardinalityMetricsFilterProcessor(config *Config) {
 			"exclude": map[string]interface{}{
 				"match_type": "regexp",
 				"metric_names": []string{
-					// Filter our high cardinality Aperture platform metrics.
 					"grpc_server_handled_total.*",
 					"grpc_server_handling_seconds.*",
 					"grpc_server_handling_seconds_bucket.*",

--- a/pkg/otelcollector/config/builtin_config.go
+++ b/pkg/otelcollector/config/builtin_config.go
@@ -109,3 +109,26 @@ func BuildOTelScrapeConfig(name string, cfg CommonOTelConfig) map[string]any {
 		},
 	}
 }
+
+// AddHighCardinalityMetricsFilterProcessor adds filter processor which filters
+// out high cardinality Aperture platform metrics.
+func AddHighCardinalityMetricsFilterProcessor(config *Config) {
+	config.AddProcessor(otelconsts.ProcessorFilterHighCardinalityMetrics, map[string]any{
+		"metrics": map[string]interface{}{
+			"exclude": map[string]interface{}{
+				"match_type": "regexp",
+				"metric_names": []string{
+					// Filter our high cardinality Aperture platform metrics.
+					"grpc_server_handled_total.*",
+					"grpc_server_handling_seconds.*",
+					"grpc_server_handling_seconds_bucket.*",
+					"grpc_server_handling_seconds_count.*",
+					"grpc_server_handling_seconds_sum.*",
+					"grpc_server_msg_received_total.*",
+					"grpc_server_msg_sent_total.*",
+					"grpc_server_started_total.*",
+				},
+			},
+		},
+	})
+}

--- a/pkg/otelcollector/config/builtin_config.go
+++ b/pkg/otelcollector/config/builtin_config.go
@@ -117,15 +117,15 @@ func AddHighCardinalityMetricsFilterProcessor(config *Config) {
 		"metrics": map[string]interface{}{
 			"exclude": map[string]interface{}{
 				"match_type": "regexp",
+				"regexp": map[string]interface{}{
+					"cacheenabled":       true,
+					"cachemaxnumentries": 1000,
+				},
 				"metric_names": []string{
-					"grpc_server_handled_total.*",
-					"grpc_server_handling_seconds.*",
-					"grpc_server_handling_seconds_bucket.*",
-					"grpc_server_handling_seconds_count.*",
-					"grpc_server_handling_seconds_sum.*",
-					"grpc_server_msg_received_total.*",
-					"grpc_server_msg_sent_total.*",
-					"grpc_server_started_total.*",
+					"grpc_server_handled.*",
+					"grpc_server_handling.*",
+					"grpc_server_msg.*",
+					"grpc_server_started.*",
 				},
 			},
 		},

--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -171,6 +171,8 @@ const (
 	ProcessorAlertsNamespace = "attributes/alerts"
 	// ProcessorFilterKubeletStats filters in only metrics of interest.
 	ProcessorFilterKubeletStats = "filter/kubeletstats"
+	// ProcessorFilterHighCardinalityMetrics filters out high cardinality Aperture platform metrics.
+	ProcessorFilterHighCardinalityMetrics = "filter/high_cardinality_metrics"
 	// ProcessorK8sAttributes enriches metrics with k8s metadata.
 	ProcessorK8sAttributes = "k8sattributes/kubeletstats"
 


### PR DESCRIPTION
### Description of change
To decrease load on Prometheus in large scale this makes pushing high cardinality platform metrics optional.

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added optional high cardinality metrics filter processor to OpenTelemetry pipeline for Aperture agent and controller
- Introduced configuration options to disable publishing high cardinality Aperture platform metrics to Prometheus

**Documentation:**
- Updated documentation with new configuration options for disabling high cardinality metrics in agent and controller

> 🎉 High cardinality, no more a foe,
> With filters in place, our metrics will flow.
> Prometheus breathes easy, the load is light,
> Scaling up smoothly, we conquer the night! 🚀
<!-- end of auto-generated comment: release notes by openai -->