### PR TITLE
Added dashboard panels for overload confirmation signals

### DIFF
--- a/playground/scripts/deps_install.sh
+++ b/playground/scripts/deps_install.sh
@@ -49,7 +49,7 @@ for path in "${CHARTS_DIR}"/*; do
 	fi
 	pushd "$path" >/dev/null
 	echo "Processing $path"
-	if helm dependency list | grep -q missing$; then
+	if helm dependency list | grep -q -e missing -e 'wrong version'$; then
 		helm dependency update
 	fi
 	popd >/dev/null


### PR DESCRIPTION
### Description of change

We had support for adding `overload_confirmations` in the `Service Protection` blueprints but we were not plotting them in the Grafana dashboard and were loosing some visibility.

![image](https://github.com/fluxninja/aperture/assets/34568645/32786535-4fb2-4881-91a0-c572e5d08bfe)

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Added support for plotting overload confirmation signals in Grafana dashboard

Bug fix:
- Improved helm dependency update command to check for 'wrong version' dependencies

Chore:
- Removed line skipping tool installation in CircleCI job
```

> 🎉 A new feature takes the stage,
> Overload signals now engage.
> Helm's watchful eye grows keener,
> CircleCI's job a bit cleaner. 🚀
<!-- end of auto-generated comment: release notes by openai -->