### PR TITLE
Don't install go tools in a background loop

### DIFF
--- a/scripts/install_go_tools.sh
+++ b/scripts/install_go_tools.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 
 set -euo pipefail
 

--- a/scripts/install_go_tools.sh
+++ b/scripts/install_go_tools.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 set -euo pipefail
 

--- a/scripts/install_go_tools.sh
+++ b/scripts/install_go_tools.sh
@@ -37,5 +37,3 @@ if asdf where golang &>/dev/null; then
 fi
 
 popd >/dev/null
-
-find ~/ -name controller-gen

--- a/scripts/install_go_tools.sh
+++ b/scripts/install_go_tools.sh
@@ -39,3 +39,5 @@ if asdf where golang &>/dev/null; then
 fi
 
 popd >/dev/null
+
+find ~/ -name controller-gen

--- a/scripts/install_go_tools.sh
+++ b/scripts/install_go_tools.sh
@@ -26,10 +26,8 @@ go mod download
 tools=$(grep _ tools.go | awk -F'"' '{print $2}')
 
 echo "$tools" | while IFS= read -r tool; do
-    go install "$tool" &
+    go install "$tool"
 done
-
-wait  # Wait for all background jobs to complete
 
 
 popd >/dev/null


### PR DESCRIPTION
### Description of change

Made installation of go tools be done in the background as the background implementation seems flaky in our CI.
