### PR TITLE
Add QuotaScheduler processing to CheckResponse label adding

### DIFF
--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -59,8 +59,12 @@ const (
 	ApertureDroppingRateLimitersLabel = "aperture.dropping_rate_limiters"
 	// ApertureLoadSchedulersLabel describes load schedulers matched to the traffic.
 	ApertureLoadSchedulersLabel = "aperture.load_schedulers"
+	// ApertureQuotaSchedulersLabel describes quota schedulers matched to the traffic.
+	ApertureQuotaSchedulersLabel = "aperture.quota_schedulers"
 	// ApertureDroppingLoadSchedulersLabel describes load schedulers dropping the traffic.
 	ApertureDroppingLoadSchedulersLabel = "aperture.dropping_load_schedulers"
+	// ApertureDroppingQuotaSchedulersLabel describes quota schedulers dropping the traffic.
+	ApertureDroppingQuotaSchedulersLabel = "aperture.dropping_quota_schedulers"
 	// ApertureSamplersLabel describes samplers matched to the traffic.
 	ApertureSamplersLabel = "aperture.samplers"
 	// ApertureDroppingSamplersLabel describes samplers dropping the traffic.


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Added support for QuotaScheduler processing in the OpenTelemetry Collector
- Introduced new constants related to quota schedulers and their dropping counterparts

> 🎉 A scheduler's tale, now unfolds,
> With quotas managed, and stories told.
> New labels added, updates embraced,
> In OpenTelemetry, performance traced. 🚀
<!-- end of auto-generated comment: release notes by openai -->