### PR TITLE
Added blueprint for PostgreSQL service protection

### DIFF
--- a/blueprints/blueprint-assets-generator.py
+++ b/blueprints/blueprint-assets-generator.py
@@ -542,7 +542,7 @@ JSON_SCHEMA_DEFINITIONS_TPL = """
 YAML_TPL = """
 # Generated values file for {{ blueprint_name }} blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ {{ blueprint_name }}
+# https://docs.fluxninja.com/reference/blueprints/{{ blueprint_name }}
 {%- macro render_value(value, level) %}
 {%- if value is mapping %}
 {%- if not value.items() %}

--- a/blueprints/dashboards/auto-scale/gen/dynamic-config-values-required.yaml
+++ b/blueprints/dashboards/auto-scale/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/auto-scale blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/auto-scale
+# https://docs.fluxninja.com/reference/blueprints/dashboards/auto-scale

--- a/blueprints/dashboards/auto-scale/gen/dynamic-config-values.yaml
+++ b/blueprints/dashboards/auto-scale/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/auto-scale blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/auto-scale
+# https://docs.fluxninja.com/reference/blueprints/dashboards/auto-scale

--- a/blueprints/dashboards/auto-scale/gen/values-required.yaml
+++ b/blueprints/dashboards/auto-scale/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/auto-scale blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/auto-scale
+# https://docs.fluxninja.com/reference/blueprints/dashboards/auto-scale
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/auto-scale/gen/values.yaml
+++ b/blueprints/dashboards/auto-scale/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/auto-scale blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/auto-scale
+# https://docs.fluxninja.com/reference/blueprints/dashboards/auto-scale
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/adaptive-load-scheduler/dashboard.libsonnet
+++ b/blueprints/dashboards/flow-control/adaptive-load-scheduler/dashboard.libsonnet
@@ -140,8 +140,7 @@ function(cfg) {
   local basequotaSchedular = quotaSchedular(params).dashboard,
 
   local overloadConfirmationPanels =
-    if std.objectHas(params.policy, 'service_protection_core')
-    then if std.objectHas(params.policy.service_protection_core, 'overload_confirmations') then [
+    if std.objectHas(params.policy, 'service_protection_core') && std.objectHas(params.policy.service_protection_core, 'overload_confirmations') then [
       local query = params.policy.service_protection_core.overload_confirmations[idx];
       newGraphPanel(
         'Overload Confirmation Query %s - %s - %s' % [(idx + 1), query.operator, query.threshold],
@@ -153,7 +152,6 @@ function(cfg) {
       }
       for idx in std.range(0, std.length(params.policy.service_protection_core.overload_confirmations) - 1)
     ]
-    else []
     else [],
 
   local overloadConfirmationPanelsLength = std.length(overloadConfirmationPanels),

--- a/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/dynamic-config-values-required.yaml
+++ b/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/adaptive-load-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/adaptive-load-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/adaptive-load-scheduler

--- a/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/dynamic-config-values.yaml
+++ b/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/adaptive-load-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/adaptive-load-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/adaptive-load-scheduler

--- a/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/values-required.yaml
+++ b/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/adaptive-load-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/adaptive-load-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/adaptive-load-scheduler
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/values.yaml
+++ b/blueprints/dashboards/flow-control/adaptive-load-scheduler/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/adaptive-load-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/adaptive-load-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/adaptive-load-scheduler
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/load-ramp/gen/dynamic-config-values-required.yaml
+++ b/blueprints/dashboards/flow-control/load-ramp/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/load-ramp blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/load-ramp
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/load-ramp

--- a/blueprints/dashboards/flow-control/load-ramp/gen/dynamic-config-values.yaml
+++ b/blueprints/dashboards/flow-control/load-ramp/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/load-ramp blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/load-ramp
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/load-ramp

--- a/blueprints/dashboards/flow-control/load-ramp/gen/values-required.yaml
+++ b/blueprints/dashboards/flow-control/load-ramp/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/load-ramp blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/load-ramp
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/load-ramp
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/load-ramp/gen/values.yaml
+++ b/blueprints/dashboards/flow-control/load-ramp/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/load-ramp blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/load-ramp
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/load-ramp
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/quota-scheduler/gen/dynamic-config-values-required.yaml
+++ b/blueprints/dashboards/flow-control/quota-scheduler/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/quota-scheduler

--- a/blueprints/dashboards/flow-control/quota-scheduler/gen/dynamic-config-values.yaml
+++ b/blueprints/dashboards/flow-control/quota-scheduler/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/quota-scheduler

--- a/blueprints/dashboards/flow-control/quota-scheduler/gen/values-required.yaml
+++ b/blueprints/dashboards/flow-control/quota-scheduler/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/quota-scheduler
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/quota-scheduler/gen/values.yaml
+++ b/blueprints/dashboards/flow-control/quota-scheduler/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/quota-scheduler
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/rate-limiter/gen/dynamic-config-values-required.yaml
+++ b/blueprints/dashboards/flow-control/rate-limiter/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/rate-limiter blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/rate-limiter
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/rate-limiter

--- a/blueprints/dashboards/flow-control/rate-limiter/gen/dynamic-config-values.yaml
+++ b/blueprints/dashboards/flow-control/rate-limiter/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/flow-control/rate-limiter blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/rate-limiter
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/rate-limiter

--- a/blueprints/dashboards/flow-control/rate-limiter/gen/values-required.yaml
+++ b/blueprints/dashboards/flow-control/rate-limiter/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/rate-limiter blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/rate-limiter
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/rate-limiter
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/flow-control/rate-limiter/gen/values.yaml
+++ b/blueprints/dashboards/flow-control/rate-limiter/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/flow-control/rate-limiter blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/flow-control/rate-limiter
+# https://docs.fluxninja.com/reference/blueprints/dashboards/flow-control/rate-limiter
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/signals/gen/dynamic-config-values-required.yaml
+++ b/blueprints/dashboards/signals/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/signals blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/signals
+# https://docs.fluxninja.com/reference/blueprints/dashboards/signals

--- a/blueprints/dashboards/signals/gen/dynamic-config-values.yaml
+++ b/blueprints/dashboards/signals/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for dashboards/signals blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/signals
+# https://docs.fluxninja.com/reference/blueprints/dashboards/signals

--- a/blueprints/dashboards/signals/gen/values-required.yaml
+++ b/blueprints/dashboards/signals/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/signals blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/signals
+# https://docs.fluxninja.com/reference/blueprints/dashboards/signals
 
 policy:
   # Name of the policy.

--- a/blueprints/dashboards/signals/gen/values.yaml
+++ b/blueprints/dashboards/signals/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for dashboards/signals blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ dashboards/signals
+# https://docs.fluxninja.com/reference/blueprints/dashboards/signals
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/auto-scaling/pod-auto-scaler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/auto-scaling/pod-auto-scaler
+# https://docs.fluxninja.com/reference/blueprints/policies/auto-scaling/pod-auto-scaler

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/auto-scaling/pod-auto-scaler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/auto-scaling/pod-auto-scaler
+# https://docs.fluxninja.com/reference/blueprints/policies/auto-scaling/pod-auto-scaler
 
 # Dynamic configuration for setting dry run mode at runtime without restarting this policy. Dry run mode ensures that no scaling is invoked by this auto scaler. This is useful for observing the behavior of auto scaler without disrupting any real deployment.
 # Type: bool

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values-required.yaml
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/auto-scaling/pod-auto-scaler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/auto-scaling/pod-auto-scaler
+# https://docs.fluxninja.com/reference/blueprints/policies/auto-scaling/pod-auto-scaler
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values.yaml
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/auto-scaling/pod-auto-scaler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/auto-scaling/pod-auto-scaler
+# https://docs.fluxninja.com/reference/blueprints/policies/auto-scaling/pod-auto-scaler
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/feature-rollout/average-latency/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/feature-rollout/average-latency/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/feature-rollout/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/average-latency

--- a/blueprints/policies/feature-rollout/average-latency/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/feature-rollout/average-latency/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/average-latency
 
 # Specify certain label values to be always accepted by the _Sampler_ regardless of accept percentage. This configuration can be updated at the runtime without shutting down the policy.
 # Type: []string

--- a/blueprints/policies/feature-rollout/average-latency/gen/values-required.yaml
+++ b/blueprints/policies/feature-rollout/average-latency/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/average-latency
 
 # Configuration for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/feature-rollout/average-latency/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/average-latency/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/average-latency
 
 # Configuration for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/feature-rollout/base/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/feature-rollout/base/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/feature-rollout/base blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/base
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/base

--- a/blueprints/policies/feature-rollout/base/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/feature-rollout/base/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/base blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/base
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/base
 
 # Specify certain label values to be always accepted by the _Sampler_ regardless of accept percentage. This configuration can be updated at the runtime without shutting down the policy.
 # Type: []string

--- a/blueprints/policies/feature-rollout/base/gen/values-required.yaml
+++ b/blueprints/policies/feature-rollout/base/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/base blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/base
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/base
 
 # Parameters for the Feature Rollout policy.
 # Type: rollout_policy

--- a/blueprints/policies/feature-rollout/base/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/base/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/base blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/base
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/base
 
 # Parameters for the Feature Rollout policy.
 # Type: rollout_policy

--- a/blueprints/policies/feature-rollout/ema-latency/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/feature-rollout/ema-latency/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/feature-rollout/ema-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/ema-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/ema-latency

--- a/blueprints/policies/feature-rollout/ema-latency/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/feature-rollout/ema-latency/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/ema-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/ema-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/ema-latency
 
 # Specify certain label values to be always accepted by the _Sampler_ regardless of accept percentage. This configuration can be updated at the runtime without shutting down the policy.
 # Type: []string

--- a/blueprints/policies/feature-rollout/ema-latency/gen/values-required.yaml
+++ b/blueprints/policies/feature-rollout/ema-latency/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/ema-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/ema-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/ema-latency
 
 # Parameters for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/feature-rollout/ema-latency/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/ema-latency/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/ema-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/ema-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/ema-latency
 
 # Parameters for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/feature-rollout/percentile-latency/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/feature-rollout/percentile-latency/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/feature-rollout/percentile-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/percentile-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/percentile-latency

--- a/blueprints/policies/feature-rollout/percentile-latency/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/feature-rollout/percentile-latency/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/percentile-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/percentile-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/percentile-latency
 
 # Specify certain label values to be always accepted by the _Sampler_ regardless of accept percentage. This configuration can be updated at the runtime without shutting down the policy.
 # Type: []string

--- a/blueprints/policies/feature-rollout/percentile-latency/gen/values-required.yaml
+++ b/blueprints/policies/feature-rollout/percentile-latency/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/percentile-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/percentile-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/percentile-latency
 
 # Parameters for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/feature-rollout/percentile-latency/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/percentile-latency/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/percentile-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/percentile-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/percentile-latency
 
 # Parameters for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/feature-rollout/promql/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/feature-rollout/promql/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/feature-rollout/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/promql

--- a/blueprints/policies/feature-rollout/promql/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/feature-rollout/promql/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/promql
 
 # Specify certain label values to be always accepted by the _Sampler_ regardless of accept percentage. This configuration can be updated at the runtime without shutting down the policy.
 # Type: []string

--- a/blueprints/policies/feature-rollout/promql/gen/values-required.yaml
+++ b/blueprints/policies/feature-rollout/promql/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/promql
 
 # Parameters for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/feature-rollout/promql/gen/values.yaml
+++ b/blueprints/policies/feature-rollout/promql/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/feature-rollout/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/feature-rollout/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/feature-rollout/promql
 
 # Parameters for the Feature Rollout policy.
 # Type: policies/feature-rollout/base:schema:rollout_policy

--- a/blueprints/policies/policies.libsonnet
+++ b/blueprints/policies/policies.libsonnet
@@ -3,6 +3,7 @@
   QuotaScheduler: import 'quota-scheduler/quota-scheduler.libsonnet',
   FeatureRollout: import 'feature-rollout/base/feature-rollout.libsonnet',
   PromQLServiceProtection: import 'service-protection/promql/promql.libsonnet',
+  PostgreSQLServiceProtection: import 'service-protection/postgresql/postgresql.libsonnet',
   ServiceProtectionAverageLatency: import 'service-protection/average-latency/average-latency.libsonnet',
   PodAutoScaler: import 'pod-auto-scaler/pod-auto-scaler.libsonnet',
   ServiceProtectionAverageLatencyWithPodAutoScaler: import 'service-protection-with-load-based-pod-auto-scaler/average-latency/average-latency.libsonnet',

--- a/blueprints/policies/quota-scheduler/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/quota-scheduler/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/policies/quota-scheduler

--- a/blueprints/policies/quota-scheduler/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/quota-scheduler/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/policies/quota-scheduler

--- a/blueprints/policies/quota-scheduler/gen/values-required.yaml
+++ b/blueprints/policies/quota-scheduler/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/policies/quota-scheduler
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/quota-scheduler/gen/values.yaml
+++ b/blueprints/policies/quota-scheduler/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/quota-scheduler blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/quota-scheduler
+# https://docs.fluxninja.com/reference/blueprints/policies/quota-scheduler
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/rate-limiting/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/rate-limiting/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/rate-limiting blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/rate-limiting
+# https://docs.fluxninja.com/reference/blueprints/policies/rate-limiting

--- a/blueprints/policies/rate-limiting/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/rate-limiting/gen/dynamic-config-values.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/rate-limiting blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/rate-limiting
+# https://docs.fluxninja.com/reference/blueprints/policies/rate-limiting

--- a/blueprints/policies/rate-limiting/gen/values-required.yaml
+++ b/blueprints/policies/rate-limiting/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/rate-limiting blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/rate-limiting
+# https://docs.fluxninja.com/reference/blueprints/policies/rate-limiting
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/rate-limiting/gen/values.yaml
+++ b/blueprints/policies/rate-limiting/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/rate-limiting blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/rate-limiting
+# https://docs.fluxninja.com/reference/blueprints/policies/rate-limiting
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency
 
 # Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. The Auto Scaler does not perform any scaling in dry mode. This mode is useful for observing the behavior of load scheduler and auto scaler without disrupting any real deployment or traffic.
 # Type: bool

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency
 
 # Configuration for the Service Protection policy.
 # Type: policies/service-protection/average-latency:param:policy

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency
 
 # Configuration for the Service Protection policy.
 # Type: policies/service-protection/average-latency:param:policy

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql
 
 # Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. The Auto Scaler does not perform any scaling in dry mode. This mode is useful for observing the behavior of load scheduler and auto scaler without disrupting any real deployment or traffic.
 # Type: bool

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql
 
 # Configuration for the Service Protection policy.
 # Type: policies/service-protection/promql:param:policy

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection-with-load-based-pod-auto-scaler/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection-with-load-based-pod-auto-scaler/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql
 
 # Configuration for the Service Protection policy.
 # Type: policies/service-protection/promql:param:policy

--- a/blueprints/policies/service-protection/average-latency/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/service-protection/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/average-latency

--- a/blueprints/policies/service-protection/average-latency/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/average-latency
 
 # Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. It is useful for observing the behavior of load scheduler without disrupting any real traffic.
 # Type: bool

--- a/blueprints/policies/service-protection/average-latency/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/average-latency
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/service-protection/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/average-latency
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/average-latency
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/service-protection/base/config-defaults.libsonnet
+++ b/blueprints/policies/service-protection/base/config-defaults.libsonnet
@@ -45,8 +45,8 @@ local kubernetes_replicas_defaults = {
   max_replicas: '__REQUIRED_FIELD__',
 };
 
-local kube_stat_infra_meter = {
-  kubetstats: {
+local kubeletstats_infra_meter = {
+  kubeletstats: {
     per_agent_group: true,
     pipeline: {
       processors: [
@@ -92,7 +92,7 @@ local kube_stat_infra_meter = {
     },
     receivers: {
       kubeletstats: {
-        collection_interval: '1s',
+        collection_interval: '15s',
         auth_type: 'serviceAccount',
         endpoint: 'https://${NODE_NAME}:10250',
         insecure_skip_verify: true,
@@ -143,5 +143,5 @@ local kube_stat_infra_meter = {
     },
   },
 
-  kube_stat_infra_meter: kube_stat_infra_meter,
+  kubeletstats_infra_meter: kubeletstats_infra_meter,
 }

--- a/blueprints/policies/service-protection/base/config-defaults.libsonnet
+++ b/blueprints/policies/service-protection/base/config-defaults.libsonnet
@@ -45,6 +45,66 @@ local kubernetes_replicas_defaults = {
   max_replicas: '__REQUIRED_FIELD__',
 };
 
+local kube_stat_infra_meter = {
+  kubetstats: {
+    per_agent_group: true,
+    pipeline: {
+      processors: [
+        'k8sattributes',
+      ],
+      receivers: [
+        'kubeletstats',
+      ],
+    },
+    processors: {
+      k8sattributes: {
+        auth_type: 'serviceAccount',
+        passthrough: false,
+        filter: {
+          node_from_env_var: 'NODE_NAME',
+        },
+        extract: {
+          metadata: [
+            'k8s.cronjob.name',
+            'k8s.daemonset.name',
+            'k8s.deployment.name',
+            'k8s.job.name',
+            'k8s.namespace.name',
+            'k8s.node.name',
+            'k8s.pod.name',
+            'k8s.pod.uid',
+            'k8s.replicaset.name',
+            'k8s.statefulset.name',
+            'k8s.container.name',
+          ],
+        },
+        pod_association: [
+          {
+            sources: [
+              {
+                from: 'resource_attribute',
+                name: 'k8s.pod.uid',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    receivers: {
+      kubeletstats: {
+        collection_interval: '1s',
+        auth_type: 'serviceAccount',
+        endpoint: 'https://${NODE_NAME}:10250',
+        insecure_skip_verify: true,
+        metric_groups: [
+          'pod',
+          'container',
+        ],
+      },
+    },
+  },
+};
+
 {
   policy: {
     policy_name: '__REQUIRED_FIELD__',
@@ -82,4 +142,6 @@ local kubernetes_replicas_defaults = {
       kubernetes_replicas: kubernetes_replicas_defaults,
     },
   },
+
+  kube_stat_infra_meter: kube_stat_infra_meter,
 }

--- a/blueprints/policies/service-protection/jmx/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/service-protection/jmx/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/service-protection/jmx blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/jmx
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/jmx

--- a/blueprints/policies/service-protection/jmx/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/service-protection/jmx/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/jmx blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/jmx
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/jmx
 
 # Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. It is useful for observing the behavior of load scheduler without disrupting any real traffic.
 # Type: bool

--- a/blueprints/policies/service-protection/jmx/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/jmx/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/jmx blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/jmx
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/jmx
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/service-protection/jmx/gen/values.yaml
+++ b/blueprints/policies/service-protection/jmx/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/jmx blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/jmx
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/jmx
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/service-protection/postgresql/README.md
+++ b/blueprints/policies/service-protection/postgresql/README.md
@@ -1,0 +1,1 @@
+[Documentation](https://docs.fluxninja.com/reference/blueprints/policies/service-protection/postgresql.md)

--- a/blueprints/policies/service-protection/postgresql/bundle.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/bundle.libsonnet
@@ -1,0 +1,74 @@
+local blueprint = import './postgresql.libsonnet';
+
+local policy = blueprint.policy;
+local dashboard = blueprint.dashboard;
+local config = blueprint.config;
+
+function(params, metadata={}) {
+  // make sure param object contains fields that are in config
+  local extra_keys = std.setDiff(std.objectFields(params), std.objectFields(config)),
+  assert std.length(extra_keys) == 0 : 'Unknown keys in params: ' + extra_keys,
+
+  local c = std.mergePatch(config, params),
+  local agent_group = c.policy.postgresql.agent_group,
+  local postgresql = std.prune(c.policy.postgresql { agent_group: null }),
+
+  local updatedConfig =
+    c {
+      policy+: {
+        resources+: {
+          telemetry_collectors+: [
+            {
+              agent_group: agent_group,
+              infra_meters: config.kube_stat_infra_meter {
+                postgresql: {
+                  receivers: {
+                    postgresql: postgresql,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+
+  local finalConfig =
+    updatedConfig +
+    if c.policy.service_protection_core.cpu_overload_confirmation_threshold != '' || c.policy.service_protection_core.cpu_overload_confirmation_threshold != null then
+      local updatedTelemetryCollectors = std.map(
+        function(c) if c.agent_group == agent_group then
+          c { infra_meters+: config.kube_stat_infra_meter }
+        else c,
+        c.policy.resources.telemetry_collectors,
+      );
+      {
+        policy+: {
+          resources+: {
+            telemetry_collectors: updatedTelemetryCollectors,
+          },
+          service_protection_core+: {
+            overload_confirmations+: [
+              {
+                query_string: 'max(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name="hasura-postgresql"})',
+                threshold: c.policy.service_protection_core.cpu_overload_confirmation_threshold,
+                operator: 'gte',
+              },
+            ],
+          },
+        },
+      }
+    else {},
+
+  local metadataWrapper = metadata { values: std.toString(params) },
+  local p = policy(updatedConfig, metadataWrapper),
+  local d = dashboard(updatedConfig),
+
+  policies: {
+    [std.format('%s-cr.yaml', c.policy.policy_name)]: p.policyResource,
+    [std.format('%s.yaml', c.policy.policy_name)]: p.policyDef { metadata: metadataWrapper },
+  },
+  dashboards: {
+    [std.format('%s.json', c.policy.policy_name)]: d.dashboard,
+  },
+}

--- a/blueprints/policies/service-protection/postgresql/config.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/config.libsonnet
@@ -51,7 +51,7 @@ promqlDefaults {
     * @schema (postgresql.tls.insecure_skip_verify: bool) Whether to validate server name and certificate if client transport security is enabled.
     * @schema (postgresql.tls.cert_file: string) A cerficate used for client authentication, if necessary.
     * @schema (postgresql.tls.key_file: string) An SSL key used for client authentication, if necessary.
-    * @schema (postgresql.tls.ca_file: string) A set of certificate authorities used to validate the database server's SSL certificate.
+    * @schema (postgresql.tls.ca_file: string) A set of certificate authorities used to validate the database server SSL certificate.
     */
     postgresql: {
       username: '__REQUIRED_FIELD__',
@@ -61,7 +61,7 @@ promqlDefaults {
     },
 
     /**
-    * @param (policy.service_protection_core.cpu_overload_confirmation_threshold: float64) Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+    * @param (policy.service_protection_core.cpu_overload_confirmation_threshold: string) Threshold value for CPU utilizatio if it has to be used as overload confirmation.
     */
     service_protection_core+: {
       cpu_overload_confirmation_threshold: '',

--- a/blueprints/policies/service-protection/postgresql/config.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/config.libsonnet
@@ -1,0 +1,94 @@
+local promqlDefaults = import '../promql/config.libsonnet';
+
+/**
+* @param (policy.policy_name: string required) Name of the policy.
+* @param (policy.promql_query: string) PromQL query to detect PostgreSQL overload.
+* @param (policy.components: []aperture.spec.v1.Component) List of additional circuit components.
+* @param (policy.resources: aperture.spec.v1.Resources) Additional resources.
+* @param (policy.evaluation_interval: string) The interval between successive evaluations of the Circuit.
+* @param (policy.service_protection_core.overload_confirmations: []overload_confirmation) List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
+* @schema (overload_confirmation.query_string: string required) The Prometheus query to be run. Must return a scalar or a vector with a single element.
+* @schema (overload_confirmation.threshold: float64) The threshold for the overload confirmation criteria.
+* @schema (overload_confirmation.operator: string) The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`
+* @param (policy.service_protection_core.adaptive_load_scheduler: aperture.spec.v1.AdaptiveLoadSchedulerParameters required) Parameters for Adaptive Load Scheduler.
+* @param (policy.service_protection_core.dry_run: bool) Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.
+* @param (policy.auto_scaling.dry_run: bool) Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
+* @schema (promql_scale_out_controller.query_string: string) The Prometheus query to be run. Must return a scalar or a vector with a single element.
+* @schema (promql_scale_out_controller.threshold: float64) Threshold for the controller.
+* @schema (promql_scale_out_controller.gradient: aperture.spec.v1.IncreasingGradientParameters) Gradient parameters for the controller.
+* @schema (promql_scale_out_controller.alerter: aperture.spec.v1.AlerterParameters) Alerter parameters for the controller.
+* @param (policy.auto_scaling.promql_scale_out_controllers: []promql_scale_out_controller) List of scale out controllers.
+* @schema (promql_scale_in_controller.query_string: string) The Prometheus query to be run. Must return a scalar or a vector with a single element.
+* @schema (promql_scale_in_controller.threshold: float64) Threshold for the controller.
+* @schema (promql_scale_in_controller.gradient: aperture.spec.v1.DecreasingGradientParameters) Gradient parameters for the controller.
+* @schema (promql_scale_in_controller.alerter: aperture.spec.v1.AlerterParameters) Alerter parameters for the controller.
+* @param (policy.auto_scaling.promql_scale_in_controllers: []promql_scale_in_controller) List of scale in controllers.
+* @param (policy.auto_scaling.scaling_parameters: aperture.spec.v1.AutoScalerScalingParameters) Parameters that define the scaling behavior.
+* @param (policy.auto_scaling.scaling_backend: aperture.spec.v1.AutoScalerScalingBackend) Scaling backend for the policy.
+* @param (policy.auto_scaling.periodic_decrease.period: string) Period for periodic scale in.
+* @param (policy.auto_scaling.periodic_decrease.scale_in_percentage: float64) Percentage of replicas to scale in.
+*/
+
+promqlDefaults {
+  policy+: {
+    promql_query: '(sum(postgresql_backends) / sum(postgresql_connection_max)) * 100',
+    /**
+    * @param (policy.setpoint: float64 required) Setpoint.
+    */
+    setpoint: '__REQUIRED_FIELD__',
+
+    /**
+    * @param (policy.postgresql: postgresql required) Configuration for PostgreSQL OpenTelemetry receiver. Refer https://docs.fluxninja.com/integrations/metrics/postgresql for more information.
+    * @schema (postgresql.username: string required) Username of the PostgreSQL.
+    * @schema (postgresql.password: string required) Password of the PostgreSQL.
+    * @schema (postgresql.endpoint: string required) Endpoint of the PostgreSQL.
+    * @schema (postgresql.transport: string) The transport protocol being used to connect to postgresql. Available options are tcp and unix.
+    * @schema (postgresql.database: []string) The list of databases for which the receiver will attempt to collect statistics.
+    * @schema (postgresql.collection_interval: string) This receiver collects metrics on an interval.
+    * @schema (postgresql.initial_delay: string) Defines how long this receiver waits before starting.
+    * @schema (postgresql.agent_group: string) Name of the Aperture Agent group.
+    * @schema (postgresql.tls.insecure: bool) Whether to enable client transport security for the postgresql connection.
+    * @schema (postgresql.tls.insecure_skip_verify: bool) Whether to validate server name and certificate if client transport security is enabled.
+    * @schema (postgresql.tls.cert_file: string) A cerficate used for client authentication, if necessary.
+    * @schema (postgresql.tls.key_file: string) An SSL key used for client authentication, if necessary.
+    * @schema (postgresql.tls.ca_file: string) A set of certificate authorities used to validate the database server's SSL certificate.
+    */
+    postgresql: {
+      username: '__REQUIRED_FIELD__',
+      password: '__REQUIRED_FIELD__',
+      endpoint: '__REQUIRED_FIELD__',
+      agent_group: 'default',
+    },
+
+    /**
+    * @param (policy.service_protection_core.cpu_overload_confirmation_threshold: float64) Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+    */
+    service_protection_core+: {
+      cpu_overload_confirmation_threshold: '',
+    },
+  },
+
+  /**
+  * @param (dashboard.refresh_interval: string) Refresh interval for dashboard panels.
+  * @param (dashboard.time_from: string) Time from of dashboard.
+  * @param (dashboard.time_to: string) Time to of dashboard.
+  * @param (dashboard.extra_filters: map[string]string) Additional filters to pass to each query to Grafana datasource.
+  * @param (dashboard.title: string) Name of the main dashboard.
+  */
+  dashboard: {
+    refresh_interval: '15s',
+    time_from: 'now-15m',
+    time_to: 'now',
+    extra_filters: {},
+    title: 'Aperture Service Protection for PostgreSQL',
+    /**
+    * @param (dashboard.datasource.name: string) Datasource name.
+    * @param (dashboard.datasource.filter_regex: string) Datasource filter regex.
+    */
+    datasource: {
+      name: '$datasource',
+      filter_regex: '',
+    },
+    variant_name: 'PostgreSQL Overload Detection',
+  },
+}

--- a/blueprints/policies/service-protection/postgresql/config.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/config.libsonnet
@@ -61,10 +61,16 @@ promqlDefaults {
     },
 
     /**
-    * @param (policy.service_protection_core.cpu_overload_confirmation_threshold: string) Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+    * @param (policy.service_protection_core.cpu_overload_confirmation.query_string: string) The Prometheus query to be run to get the PostgreSQL CPU utilization. Must return a scalar or a vector with a single element.
+    * @param (policy.service_protection_core.cpu_overload_confirmation.threshold: string) Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+    * @param (policy.service_protection_core.cpu_overload_confirmation.operator: string) The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.
     */
     service_protection_core+: {
-      cpu_overload_confirmation_threshold: '',
+      cpu_overload_confirmation+: {
+        query_string: 'avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name="__REQUIRED_FIELD__"})',
+        threshold: '',
+        operator: 'gte',
+      },
     },
   },
 

--- a/blueprints/policies/service-protection/postgresql/config.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/config.libsonnet
@@ -62,13 +62,13 @@ promqlDefaults {
 
     /**
     * @param (policy.service_protection_core.cpu_overload_confirmation.query_string: string) The Prometheus query to be run to get the PostgreSQL CPU utilization. Must return a scalar or a vector with a single element.
-    * @param (policy.service_protection_core.cpu_overload_confirmation.threshold: string) Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+    * @param (policy.service_protection_core.cpu_overload_confirmation.threshold: float64) Threshold value for CPU utilizatio if it has to be used as overload confirmation.
     * @param (policy.service_protection_core.cpu_overload_confirmation.operator: string) The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.
     */
     service_protection_core+: {
       cpu_overload_confirmation+: {
         query_string: 'avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name="__REQUIRED_FIELD__"})',
-        threshold: '',
+        threshold: null,
         operator: 'gte',
       },
     },

--- a/blueprints/policies/service-protection/postgresql/dashboard.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/dashboard.libsonnet
@@ -1,0 +1,12 @@
+local promqlDashboardFn = import '../promql/dashboard.libsonnet';
+local config = import './config.libsonnet';
+
+function(cfg) {
+  local params = config + cfg,
+  local variantName = params.dashboard.variant_name,
+  local query = params.policy.promql_query,
+
+  local promqlDashboard = promqlDashboardFn(params),
+
+  dashboard: promqlDashboard.dashboard,
+}

--- a/blueprints/policies/service-protection/postgresql/dynamic-config.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/dynamic-config.libsonnet
@@ -1,0 +1,6 @@
+/**
+* @param (dry_run: bool) Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. It is useful for observing the behavior of load scheduler without disrupting any real traffic.
+*/
+{
+  dry_run: '__REQUIRED_FIELD__',
+}

--- a/blueprints/policies/service-protection/postgresql/gen/definitions.json
+++ b/blueprints/policies/service-protection/postgresql/gen/definitions.json
@@ -104,8 +104,9 @@
                 },
                 "threshold": {
                   "description": "Threshold value for CPU utilizatio if it has to be used as overload confirmation.",
-                  "default": "",
-                  "type": "string"
+                  "default": null,
+                  "type": "number",
+                  "format": "double"
                 },
                 "operator": {
                   "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.",

--- a/blueprints/policies/service-protection/postgresql/gen/definitions.json
+++ b/blueprints/policies/service-protection/postgresql/gen/definitions.json
@@ -96,8 +96,7 @@
             "cpu_overload_confirmation_threshold": {
               "description": "Threshold value for CPU utilizatio if it has to be used as overload confirmation.",
               "default": "",
-              "type": "number",
-              "format": "double"
+              "type": "string"
             }
           }
         },
@@ -382,7 +381,7 @@
               "type": "string"
             },
             "ca_file": {
-              "description": "A set of certificate authorities used to validate the database server's SSL certificate.",
+              "description": "A set of certificate authorities used to validate the database server SSL certificate.",
               "default": null,
               "type": "string"
             }

--- a/blueprints/policies/service-protection/postgresql/gen/definitions.json
+++ b/blueprints/policies/service-protection/postgresql/gen/definitions.json
@@ -93,10 +93,26 @@
               "default": false,
               "type": "boolean"
             },
-            "cpu_overload_confirmation_threshold": {
-              "description": "Threshold value for CPU utilizatio if it has to be used as overload confirmation.",
-              "default": "",
-              "type": "string"
+            "cpu_overload_confirmation": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "query_string": {
+                  "description": "The Prometheus query to be run to get the PostgreSQL CPU utilization. Must return a scalar or a vector with a single element.",
+                  "default": "avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name=\"__REQUIRED_FIELD__\"})",
+                  "type": "string"
+                },
+                "threshold": {
+                  "description": "Threshold value for CPU utilizatio if it has to be used as overload confirmation.",
+                  "default": "",
+                  "type": "string"
+                },
+                "operator": {
+                  "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.",
+                  "default": "gte",
+                  "type": "string"
+                }
+              }
             }
           }
         },

--- a/blueprints/policies/service-protection/postgresql/gen/definitions.json
+++ b/blueprints/policies/service-protection/postgresql/gen/definitions.json
@@ -1,0 +1,394 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "policies/service-protection/postgresql blueprint",
+  "additionalProperties": false,
+  "required": ["policy"],
+  "properties": {
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_name",
+        "service_protection_core",
+        "setpoint",
+        "postgresql"
+      ],
+      "properties": {
+        "policy_name": {
+          "description": "Name of the policy.",
+          "default": "__REQUIRED_FIELD__",
+          "type": "string"
+        },
+        "promql_query": {
+          "description": "PromQL query to detect PostgreSQL overload.",
+          "default": "(sum(postgresql_backends) / sum(postgresql_connection_max)) * 100",
+          "type": "string"
+        },
+        "components": {
+          "description": "List of additional circuit components.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/Component"
+          }
+        },
+        "resources": {
+          "description": "Additional resources.",
+          "default": {
+            "flow_control": {
+              "classifiers": []
+            }
+          },
+          "type": "object",
+          "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/Resources"
+        },
+        "evaluation_interval": {
+          "description": "The interval between successive evaluations of the Circuit.",
+          "default": "1s",
+          "type": "string"
+        },
+        "service_protection_core": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["adaptive_load_scheduler"],
+          "properties": {
+            "overload_confirmations": {
+              "description": "List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "$ref": "#/$defs/overload_confirmation"
+              }
+            },
+            "adaptive_load_scheduler": {
+              "description": "Parameters for Adaptive Load Scheduler.",
+              "default": {
+                "alerter": {
+                  "alert_name": "Load Throttling Event"
+                },
+                "gradient": {
+                  "max_gradient": 1,
+                  "min_gradient": 0.1,
+                  "slope": -1
+                },
+                "load_multiplier_linear_increment": 0.0025,
+                "load_scheduler": {
+                  "selectors": [
+                    {
+                      "control_point": "__REQUIRED_FIELD__",
+                      "service": "__REQUIRED_FIELD__"
+                    }
+                  ]
+                },
+                "max_load_multiplier": 2
+              },
+              "type": "object",
+              "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AdaptiveLoadSchedulerParameters"
+            },
+            "dry_run": {
+              "description": "Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.",
+              "default": false,
+              "type": "boolean"
+            },
+            "cpu_overload_confirmation_threshold": {
+              "description": "Threshold value for CPU utilizatio if it has to be used as overload confirmation.",
+              "default": "",
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        "auto_scaling": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dry_run": {
+              "description": "Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.",
+              "default": null,
+              "type": "boolean"
+            },
+            "promql_scale_out_controllers": {
+              "description": "List of scale out controllers.",
+              "default": null,
+              "type": "array",
+              "items": {
+                "type": "object",
+                "$ref": "#/$defs/promql_scale_out_controller"
+              }
+            },
+            "promql_scale_in_controllers": {
+              "description": "List of scale in controllers.",
+              "default": null,
+              "type": "array",
+              "items": {
+                "type": "object",
+                "$ref": "#/$defs/promql_scale_in_controller"
+              }
+            },
+            "scaling_parameters": {
+              "description": "Parameters that define the scaling behavior.",
+              "default": null,
+              "type": "object",
+              "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingParameters"
+            },
+            "scaling_backend": {
+              "description": "Scaling backend for the policy.",
+              "default": null,
+              "type": "object",
+              "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingBackend"
+            },
+            "periodic_decrease": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "period": {
+                  "description": "Period for periodic scale in.",
+                  "default": null,
+                  "type": "string"
+                },
+                "scale_in_percentage": {
+                  "description": "Percentage of replicas to scale in.",
+                  "default": null,
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            }
+          }
+        },
+        "setpoint": {
+          "description": "Setpoint.",
+          "default": "__REQUIRED_FIELD__",
+          "type": "number",
+          "format": "double"
+        },
+        "postgresql": {
+          "description": "Configuration for PostgreSQL OpenTelemetry receiver. Refer https://docs.fluxninja.com/integrations/metrics/postgresql for more information.",
+          "default": {
+            "agent_group": "default",
+            "endpoint": "__REQUIRED_FIELD__",
+            "password": "__REQUIRED_FIELD__",
+            "username": "__REQUIRED_FIELD__"
+          },
+          "type": "object",
+          "$ref": "#/$defs/postgresql"
+        }
+      }
+    },
+    "dashboard": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "refresh_interval": {
+          "description": "Refresh interval for dashboard panels.",
+          "default": "15s",
+          "type": "string"
+        },
+        "time_from": {
+          "description": "Time from of dashboard.",
+          "default": "now-15m",
+          "type": "string"
+        },
+        "time_to": {
+          "description": "Time to of dashboard.",
+          "default": "now",
+          "type": "string"
+        },
+        "extra_filters": {
+          "description": "Additional filters to pass to each query to Grafana datasource.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
+        "title": {
+          "description": "Name of the main dashboard.",
+          "default": "Aperture Service Protection for PostgreSQL",
+          "type": "string"
+        },
+        "datasource": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "description": "Datasource name.",
+              "default": "$datasource",
+              "type": "string"
+            },
+            "filter_regex": {
+              "description": "Datasource filter regex.",
+              "default": "",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "overload_confirmation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query_string"],
+      "properties": {
+        "query_string": {
+          "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
+          "type": "string"
+        },
+        "threshold": {
+          "description": "The threshold for the overload confirmation criteria.",
+          "default": null,
+          "type": "number",
+          "format": "double"
+        },
+        "operator": {
+          "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`",
+          "default": null,
+          "type": "string"
+        }
+      }
+    },
+    "promql_scale_out_controller": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "query_string": {
+          "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
+          "type": "string"
+        },
+        "threshold": {
+          "description": "Threshold for the controller.",
+          "default": null,
+          "type": "number",
+          "format": "double"
+        },
+        "gradient": {
+          "description": "Gradient parameters for the controller.",
+          "default": null,
+          "type": "object",
+          "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/IncreasingGradientParameters"
+        },
+        "alerter": {
+          "description": "Alerter parameters for the controller.",
+          "default": null,
+          "type": "object",
+          "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
+        }
+      }
+    },
+    "promql_scale_in_controller": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "query_string": {
+          "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
+          "type": "string"
+        },
+        "threshold": {
+          "description": "Threshold for the controller.",
+          "default": null,
+          "type": "number",
+          "format": "double"
+        },
+        "gradient": {
+          "description": "Gradient parameters for the controller.",
+          "default": null,
+          "type": "object",
+          "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/DecreasingGradientParameters"
+        },
+        "alerter": {
+          "description": "Alerter parameters for the controller.",
+          "default": null,
+          "type": "object",
+          "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["username", "password", "endpoint"],
+      "properties": {
+        "username": {
+          "description": "Username of the PostgreSQL.",
+          "default": null,
+          "type": "string"
+        },
+        "password": {
+          "description": "Password of the PostgreSQL.",
+          "default": null,
+          "type": "string"
+        },
+        "endpoint": {
+          "description": "Endpoint of the PostgreSQL.",
+          "default": null,
+          "type": "string"
+        },
+        "transport": {
+          "description": "The transport protocol being used to connect to postgresql. Available options are tcp and unix.",
+          "default": null,
+          "type": "string"
+        },
+        "database": {
+          "description": "The list of databases for which the receiver will attempt to collect statistics.",
+          "default": null,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "collection_interval": {
+          "description": "This receiver collects metrics on an interval.",
+          "default": null,
+          "type": "string"
+        },
+        "initial_delay": {
+          "description": "Defines how long this receiver waits before starting.",
+          "default": null,
+          "type": "string"
+        },
+        "agent_group": {
+          "description": "Name of the Aperture Agent group.",
+          "default": null,
+          "type": "string"
+        },
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "insecure": {
+              "description": "Whether to enable client transport security for the postgresql connection.",
+              "default": null,
+              "type": "boolean"
+            },
+            "insecure_skip_verify": {
+              "description": "Whether to validate server name and certificate if client transport security is enabled.",
+              "default": null,
+              "type": "boolean"
+            },
+            "cert_file": {
+              "description": "A cerficate used for client authentication, if necessary.",
+              "default": null,
+              "type": "string"
+            },
+            "key_file": {
+              "description": "An SSL key used for client authentication, if necessary.",
+              "default": null,
+              "type": "string"
+            },
+            "ca_file": {
+              "description": "A set of certificate authorities used to validate the database server's SSL certificate.",
+              "default": null,
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/blueprints/policies/service-protection/postgresql/gen/dynamic-config-definitions.json
+++ b/blueprints/policies/service-protection/postgresql/gen/dynamic-config-definitions.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "policies/service-protection/postgresql blueprint",
+  "additionalProperties": false,
+  "properties": {
+    "dry_run": {
+      "description": "Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. It is useful for observing the behavior of load scheduler without disrupting any real traffic.",
+      "default": "__REQUIRED_FIELD__",
+      "type": "boolean"
+    }
+  },
+  "$defs": null
+}

--- a/blueprints/policies/service-protection/postgresql/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/dynamic-config-values-required.yaml
@@ -1,0 +1,3 @@
+# Generated values file for policies/service-protection/postgresql blueprint
+# Documentation/Reference for objects and parameters can be found at:
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/postgresql

--- a/blueprints/policies/service-protection/postgresql/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/dynamic-config-values.yaml
@@ -1,0 +1,7 @@
+# Generated values file for policies/service-protection/postgresql blueprint
+# Documentation/Reference for objects and parameters can be found at:
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/postgresql
+
+# Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. It is useful for observing the behavior of load scheduler without disrupting any real traffic.
+# Type: bool
+dry_run: __REQUIRED_FIELD__

--- a/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
@@ -45,9 +45,16 @@ policy:
     # Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.
     # Type: bool
     dry_run: false
-    # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
-    # Type: string
-    cpu_overload_confirmation_threshold: ""
+    cpu_overload_confirmation:
+      # The Prometheus query to be run to get the PostgreSQL CPU utilization. Must return a scalar or a vector with a single element.
+      # Type: string
+      query_string: 'avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name="__REQUIRED_FIELD__"})'
+      # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+      # Type: string
+      threshold: ""
+      # The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.
+      # Type: string
+      operator: "gte"
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool

--- a/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
@@ -50,8 +50,8 @@ policy:
       # Type: string
       query_string: 'avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name="__REQUIRED_FIELD__"})'
       # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
-      # Type: string
-      threshold: ""
+      # Type: float64
+      threshold: null
       # The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.
       # Type: string
       operator: "gte"

--- a/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
@@ -46,7 +46,7 @@ policy:
     # Type: bool
     dry_run: false
     # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
-    # Type: float64
+    # Type: string
     cpu_overload_confirmation_threshold: ""
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.

--- a/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
@@ -1,0 +1,85 @@
+# Generated values file for policies/service-protection/postgresql blueprint
+# Documentation/Reference for objects and parameters can be found at:
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/postgresql
+
+policy:
+  # Name of the policy.
+  # Type: string
+  # Required: True
+  policy_name: __REQUIRED_FIELD__
+  # PromQL query to detect PostgreSQL overload.
+  # Type: string
+  promql_query:
+    "(sum(postgresql_backends) / sum(postgresql_connection_max)) * 100"
+  # List of additional circuit components.
+  # Type: []aperture.spec.v1.Component
+  components: []
+  # Additional resources.
+  # Type: aperture.spec.v1.Resources
+  resources:
+    flow_control:
+      classifiers: []
+  # The interval between successive evaluations of the Circuit.
+  # Type: string
+  evaluation_interval: "1s"
+  service_protection_core:
+    # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
+    # Type: []overload_confirmation
+    overload_confirmations: []
+    # Parameters for Adaptive Load Scheduler.
+    # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
+    # Required: True
+    adaptive_load_scheduler:
+      alerter:
+        alert_name: "Load Throttling Event"
+      gradient:
+        max_gradient: 1
+        min_gradient: 0.1
+        slope: -1
+      load_multiplier_linear_increment: 0.0025
+      load_scheduler:
+        selectors:
+          - control_point: __REQUIRED_FIELD__
+            service: __REQUIRED_FIELD__
+      max_load_multiplier: 2
+    # Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.
+    # Type: bool
+    dry_run: false
+    # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+    # Type: float64
+    cpu_overload_confirmation_threshold: ""
+  auto_scaling:
+    # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
+    # Type: bool
+    dry_run: null
+    # List of scale out controllers.
+    # Type: []promql_scale_out_controller
+    promql_scale_out_controllers: null
+    # List of scale in controllers.
+    # Type: []promql_scale_in_controller
+    promql_scale_in_controllers: null
+    # Parameters that define the scaling behavior.
+    # Type: aperture.spec.v1.AutoScalerScalingParameters
+    scaling_parameters: null
+    # Scaling backend for the policy.
+    # Type: aperture.spec.v1.AutoScalerScalingBackend
+    scaling_backend: null
+    periodic_decrease:
+      # Period for periodic scale in.
+      # Type: string
+      period: null
+      # Percentage of replicas to scale in.
+      # Type: float64
+      scale_in_percentage: null
+  # Setpoint.
+  # Type: float64
+  # Required: True
+  setpoint: __REQUIRED_FIELD__
+  # Configuration for PostgreSQL OpenTelemetry receiver. Refer https://docs.fluxninja.com/integrations/metrics/postgresql for more information.
+  # Type: postgresql
+  # Required: True
+  postgresql:
+    agent_group: "default"
+    endpoint: __REQUIRED_FIELD__
+    password: __REQUIRED_FIELD__
+    username: __REQUIRED_FIELD__

--- a/blueprints/policies/service-protection/postgresql/gen/values.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values.yaml
@@ -45,9 +45,16 @@ policy:
     # Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.
     # Type: bool
     dry_run: false
-    # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
-    # Type: string
-    cpu_overload_confirmation_threshold: ""
+    cpu_overload_confirmation:
+      # The Prometheus query to be run to get the PostgreSQL CPU utilization. Must return a scalar or a vector with a single element.
+      # Type: string
+      query_string: 'avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name="__REQUIRED_FIELD__"})'
+      # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+      # Type: string
+      threshold: ""
+      # The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.
+      # Type: string
+      operator: "gte"
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool

--- a/blueprints/policies/service-protection/postgresql/gen/values.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values.yaml
@@ -50,8 +50,8 @@ policy:
       # Type: string
       query_string: 'avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name="__REQUIRED_FIELD__"})'
       # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
-      # Type: string
-      threshold: ""
+      # Type: float64
+      threshold: null
       # The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.
       # Type: string
       operator: "gte"

--- a/blueprints/policies/service-protection/postgresql/gen/values.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values.yaml
@@ -1,0 +1,109 @@
+# Generated values file for policies/service-protection/postgresql blueprint
+# Documentation/Reference for objects and parameters can be found at:
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/postgresql
+
+policy:
+  # Name of the policy.
+  # Type: string
+  # Required: True
+  policy_name: __REQUIRED_FIELD__
+  # PromQL query to detect PostgreSQL overload.
+  # Type: string
+  promql_query:
+    "(sum(postgresql_backends) / sum(postgresql_connection_max)) * 100"
+  # List of additional circuit components.
+  # Type: []aperture.spec.v1.Component
+  components: []
+  # Additional resources.
+  # Type: aperture.spec.v1.Resources
+  resources:
+    flow_control:
+      classifiers: []
+  # The interval between successive evaluations of the Circuit.
+  # Type: string
+  evaluation_interval: "1s"
+  service_protection_core:
+    # List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.
+    # Type: []overload_confirmation
+    overload_confirmations: []
+    # Parameters for Adaptive Load Scheduler.
+    # Type: aperture.spec.v1.AdaptiveLoadSchedulerParameters
+    # Required: True
+    adaptive_load_scheduler:
+      alerter:
+        alert_name: "Load Throttling Event"
+      gradient:
+        max_gradient: 1
+        min_gradient: 0.1
+        slope: -1
+      load_multiplier_linear_increment: 0.0025
+      load_scheduler:
+        selectors:
+          - control_point: __REQUIRED_FIELD__
+            service: __REQUIRED_FIELD__
+      max_load_multiplier: 2
+    # Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.
+    # Type: bool
+    dry_run: false
+    # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
+    # Type: float64
+    cpu_overload_confirmation_threshold: ""
+  auto_scaling:
+    # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
+    # Type: bool
+    dry_run: null
+    # List of scale out controllers.
+    # Type: []promql_scale_out_controller
+    promql_scale_out_controllers: null
+    # List of scale in controllers.
+    # Type: []promql_scale_in_controller
+    promql_scale_in_controllers: null
+    # Parameters that define the scaling behavior.
+    # Type: aperture.spec.v1.AutoScalerScalingParameters
+    scaling_parameters: null
+    # Scaling backend for the policy.
+    # Type: aperture.spec.v1.AutoScalerScalingBackend
+    scaling_backend: null
+    periodic_decrease:
+      # Period for periodic scale in.
+      # Type: string
+      period: null
+      # Percentage of replicas to scale in.
+      # Type: float64
+      scale_in_percentage: null
+  # Setpoint.
+  # Type: float64
+  # Required: True
+  setpoint: __REQUIRED_FIELD__
+  # Configuration for PostgreSQL OpenTelemetry receiver. Refer https://docs.fluxninja.com/integrations/metrics/postgresql for more information.
+  # Type: postgresql
+  # Required: True
+  postgresql:
+    agent_group: "default"
+    endpoint: __REQUIRED_FIELD__
+    password: __REQUIRED_FIELD__
+    username: __REQUIRED_FIELD__
+
+dashboard:
+  # Refresh interval for dashboard panels.
+  # Type: string
+  refresh_interval: "15s"
+  # Time from of dashboard.
+  # Type: string
+  time_from: "now-15m"
+  # Time to of dashboard.
+  # Type: string
+  time_to: "now"
+  # Additional filters to pass to each query to Grafana datasource.
+  # Type: map[string]string
+  extra_filters: {}
+  # Name of the main dashboard.
+  # Type: string
+  title: "Aperture Service Protection for PostgreSQL"
+  datasource:
+    # Datasource name.
+    # Type: string
+    name: "$datasource"
+    # Datasource filter regex.
+    # Type: string
+    filter_regex: ""

--- a/blueprints/policies/service-protection/postgresql/gen/values.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values.yaml
@@ -46,7 +46,7 @@ policy:
     # Type: bool
     dry_run: false
     # Threshold value for CPU utilizatio if it has to be used as overload confirmation.
-    # Type: float64
+    # Type: string
     cpu_overload_confirmation_threshold: ""
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.

--- a/blueprints/policies/service-protection/postgresql/metadata.yaml
+++ b/blueprints/policies/service-protection/postgresql/metadata.yaml
@@ -1,0 +1,4 @@
+blueprint: Service Protection Policy for PostgreSQL.
+sources:
+  dashboard: policies/service-protection/postgresql/dashboard.libsonnet
+  policy: policies/service-protection/postgresql/policy.libsonnet

--- a/blueprints/policies/service-protection/postgresql/policy.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/policy.libsonnet
@@ -1,0 +1,13 @@
+local promqlPolicyFn = import '../promql/policy.libsonnet';
+local config = import './config.libsonnet';
+
+function(cfg, metadata={}) {
+  local params = config + cfg,
+
+  local promqlPolicy = promqlPolicyFn(cfg, metadata),
+
+  policyResource: promqlPolicy.policyResource {
+    spec+: promqlPolicy.policyDef,
+  },
+  policyDef: promqlPolicy.policyDef,
+}

--- a/blueprints/policies/service-protection/postgresql/postgresql.libsonnet
+++ b/blueprints/policies/service-protection/postgresql/postgresql.libsonnet
@@ -1,0 +1,6 @@
+{
+  config: import 'config.libsonnet',
+  policy: import 'policy.libsonnet',
+  dashboard: import 'dashboard.libsonnet',
+  bundle: import 'bundle.libsonnet',
+}

--- a/blueprints/policies/service-protection/promql/gen/dynamic-config-values-required.yaml
+++ b/blueprints/policies/service-protection/promql/gen/dynamic-config-values-required.yaml
@@ -1,3 +1,3 @@
 # Generated values file for policies/service-protection/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/promql

--- a/blueprints/policies/service-protection/promql/gen/dynamic-config-values.yaml
+++ b/blueprints/policies/service-protection/promql/gen/dynamic-config-values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/promql
 
 # Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. It is useful for observing the behavior of load scheduler without disrupting any real traffic.
 # Type: bool

--- a/blueprints/policies/service-protection/promql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/promql/gen/values-required.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/promql
 
 policy:
   # Name of the policy.

--- a/blueprints/policies/service-protection/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection/promql/gen/values.yaml
@@ -1,6 +1,6 @@
 # Generated values file for policies/service-protection/promql blueprint
 # Documentation/Reference for objects and parameters can be found at:
-# https://docs.fluxninja.com/reference/blueprints/ policies/service-protection/promql
+# https://docs.fluxninja.com/reference/blueprints/policies/service-protection/promql
 
 policy:
   # Name of the policy.

--- a/docs/content/reference/blueprints/policies/service-protection/postgresql.md
+++ b/docs/content/reference/blueprints/policies/service-protection/postgresql.md
@@ -209,14 +209,48 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <!-- vale off -->
 
+###### policy.service_protection_core.cpu_overload_confirmation {#policy-service-protection-core-cpu-overload-confirmation}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-service-protection-core-cpu-overload-confirmation-query-string"></a>
+
+<ParameterDescription
+    name='policy.service_protection_core.cpu_overload_confirmation.query_string'
+    description='The Prometheus query to be run to get the PostgreSQL CPU utilization. Must return a scalar or a vector with a single element.'
+    type='string'
+    reference=''
+    value='"avg(k8s_pod_cpu_utilization_ratio{k8s_statefulset_name=\"__REQUIRED_FIELD__\"})"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
 <a id="policy-service-protection-core-cpu-overload-confirmation-threshold"></a>
 
 <ParameterDescription
-    name='policy.service_protection_core.cpu_overload_confirmation_threshold'
+    name='policy.service_protection_core.cpu_overload_confirmation.threshold'
     description='Threshold value for CPU utilizatio if it has to be used as overload confirmation.'
     type='string'
     reference=''
     value='""'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-service-protection-core-cpu-overload-confirmation-operator"></a>
+
+<ParameterDescription
+    name='policy.service_protection_core.cpu_overload_confirmation.operator'
+    description='The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`.'
+    type='string'
+    reference=''
+    value='"gte"'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/blueprints/policies/service-protection/postgresql.md
+++ b/docs/content/reference/blueprints/policies/service-protection/postgresql.md
@@ -1,0 +1,853 @@
+---
+title: Service Protection for PostgreSQL
+keywords:
+  - blueprints
+sidebar_position: 4
+sidebar_label: Service Protection for PostgreSQL
+---
+
+## Introduction
+
+This policy detects traffic overloads and cascading failure build-up on
+PostgreSQL by checking the real-time percentage of PostgreSQL connections
+against the maximum number of connections.
+
+It also uses the CPU utilization ratio of the PostgreSQL pod to confirm traffic
+overloads and cascading failure build-up. The CPU utilization ratio is the
+percentage of CPU used by the PostgreSQL pod divided by the total CPU available
+to the pod.
+
+All the PostgreSQL related metrics are collected by the
+[PostgreSQL OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver)
+so if the system under observation requires using different metrics for the
+overload confirmation, the
+[list of available metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/postgresqlreceiver/metadata.yaml)
+can be used to configure the policy.
+
+A gradient controller calculates a proportional response to limit accepted
+concurrency. The concurrency is reduced by a multiplicative factor when the
+service is overloaded, and increased by an additive factor while the service is
+no longer overloaded.
+
+This policy detects traffic overloads and cascading failure build-up by
+comparing the real-time latency with its exponential moving average. A gradient
+controller calculates a proportional response to limit accepted concurrency. The
+concurrency is reduced by a multiplicative factor when the service is
+overloaded, and increased by an additive factor while the service is no longer
+overloaded.
+
+:::info
+
+Please see reference for the
+[`AdaptiveLoadScheduler`](/reference/configuration/spec.md#adaptive-load-scheduler)
+component that is used within this blueprint.
+
+:::
+
+<!-- Configuration Marker -->
+
+```mdx-code-block
+import {apertureVersion as aver} from '../../../../apertureVersion.js'
+import {ParameterDescription} from '../../../../parameterComponents.js'
+```
+
+## Configuration
+
+<!-- vale off -->
+
+Blueprint name: <a
+href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/service-protection/postgresql`}>policies/service-protection/postgresql</a>
+
+<!-- vale on -->
+
+### Parameters
+
+<!-- vale off -->
+
+#### policy {#policy}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-policy-name"></a>
+
+<ParameterDescription
+    name='policy.policy_name'
+    description='Name of the policy.'
+    type='string'
+    reference=''
+    value='"__REQUIRED_FIELD__"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-promql-query"></a>
+
+<ParameterDescription
+    name='policy.promql_query'
+    description='PromQL query to detect PostgreSQL overload.'
+    type='string'
+    reference=''
+    value='"(sum(postgresql_backends) / sum(postgresql_connection_max)) * 100"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-components"></a>
+
+<ParameterDescription
+    name='policy.components'
+    description='List of additional circuit components.'
+    type='Array of Object (aperture.spec.v1.Component)'
+    reference='../../../spec#component'
+    value='[]'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-resources"></a>
+
+<ParameterDescription
+    name='policy.resources'
+    description='Additional resources.'
+    type='Object (aperture.spec.v1.Resources)'
+    reference='../../../spec#resources'
+    value='{"flow_control": {"classifiers": []}}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-evaluation-interval"></a>
+
+<ParameterDescription
+    name='policy.evaluation_interval'
+    description='The interval between successive evaluations of the Circuit.'
+    type='string'
+    reference=''
+    value='"1s"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-setpoint"></a>
+
+<ParameterDescription
+    name='policy.setpoint'
+    description='Setpoint.'
+    type='Number (double)'
+    reference=''
+    value='"__REQUIRED_FIELD__"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-postgresql"></a>
+
+<ParameterDescription
+    name='policy.postgresql'
+    description='Configuration for PostgreSQL OpenTelemetry receiver. Refer https://docs.fluxninja.com/integrations/metrics/postgresql for more information.'
+    type='Object (postgresql)'
+    reference='#postgresql'
+    value='{"agent_group": "default", "endpoint": "__REQUIRED_FIELD__", "password": "__REQUIRED_FIELD__", "username": "__REQUIRED_FIELD__"}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+##### policy.service_protection_core {#policy-service-protection-core}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-service-protection-core-overload-confirmations"></a>
+
+<ParameterDescription
+    name='policy.service_protection_core.overload_confirmations'
+    description='List of overload confirmation criteria. Load scheduler can throttle flows when all of the specified overload confirmation criteria are met.'
+    type='Array of Object (overload_confirmation)'
+    reference='#overload-confirmation'
+    value='[]'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-service-protection-core-adaptive-load-scheduler"></a>
+
+<ParameterDescription
+    name='policy.service_protection_core.adaptive_load_scheduler'
+    description='Parameters for Adaptive Load Scheduler.'
+    type='Object (aperture.spec.v1.AdaptiveLoadSchedulerParameters)'
+    reference='../../../spec#adaptive-load-scheduler-parameters'
+    value='{"alerter": {"alert_name": "Load Throttling Event"}, "gradient": {"max_gradient": 1, "min_gradient": 0.1, "slope": -1}, "load_multiplier_linear_increment": 0.0025, "load_scheduler": {"selectors": [{"control_point": "__REQUIRED_FIELD__", "service": "__REQUIRED_FIELD__"}]}, "max_load_multiplier": 2}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-service-protection-core-dry-run"></a>
+
+<ParameterDescription
+    name='policy.service_protection_core.dry_run'
+    description='Default configuration for setting dry run mode on Load Scheduler. In dry run mode, the Load Scheduler acts as a passthrough and does not throttle flows. This config can be updated at runtime without restarting the policy.'
+    type='Boolean'
+    reference=''
+    value='false'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-service-protection-core-cpu-overload-confirmation-threshold"></a>
+
+<ParameterDescription
+    name='policy.service_protection_core.cpu_overload_confirmation_threshold'
+    description='Threshold value for CPU utilizatio if it has to be used as overload confirmation.'
+    type='Number (double)'
+    reference=''
+    value='""'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+##### policy.auto_scaling {#policy-auto-scaling}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-auto-scaling-dry-run"></a>
+
+<ParameterDescription
+    name='policy.auto_scaling.dry_run'
+    description='Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.'
+    type='Boolean'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-auto-scaling-promql-scale-out-controllers"></a>
+
+<ParameterDescription
+    name='policy.auto_scaling.promql_scale_out_controllers'
+    description='List of scale out controllers.'
+    type='Array of Object (promql_scale_out_controller)'
+    reference='#promql-scale-out-controller'
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-auto-scaling-promql-scale-in-controllers"></a>
+
+<ParameterDescription
+    name='policy.auto_scaling.promql_scale_in_controllers'
+    description='List of scale in controllers.'
+    type='Array of Object (promql_scale_in_controller)'
+    reference='#promql-scale-in-controller'
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-auto-scaling-scaling-parameters"></a>
+
+<ParameterDescription
+    name='policy.auto_scaling.scaling_parameters'
+    description='Parameters that define the scaling behavior.'
+    type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
+    reference='../../../spec#auto-scaler-scaling-parameters'
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-auto-scaling-scaling-backend"></a>
+
+<ParameterDescription
+    name='policy.auto_scaling.scaling_backend'
+    description='Scaling backend for the policy.'
+    type='Object (aperture.spec.v1.AutoScalerScalingBackend)'
+    reference='../../../spec#auto-scaler-scaling-backend'
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+###### policy.auto_scaling.periodic_decrease {#policy-auto-scaling-periodic-decrease}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-auto-scaling-periodic-decrease-period"></a>
+
+<ParameterDescription
+    name='policy.auto_scaling.periodic_decrease.period'
+    description='Period for periodic scale in.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-auto-scaling-periodic-decrease-scale-in-percentage"></a>
+
+<ParameterDescription
+    name='policy.auto_scaling.periodic_decrease.scale_in_percentage'
+    description='Percentage of replicas to scale in.'
+    type='Number (double)'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+---
+
+<!-- vale off -->
+
+#### dashboard {#dashboard}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-refresh-interval"></a>
+
+<ParameterDescription
+    name='dashboard.refresh_interval'
+    description='Refresh interval for dashboard panels.'
+    type='string'
+    reference=''
+    value='"15s"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-time-from"></a>
+
+<ParameterDescription
+    name='dashboard.time_from'
+    description='Time from of dashboard.'
+    type='string'
+    reference=''
+    value='"now-15m"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-time-to"></a>
+
+<ParameterDescription
+    name='dashboard.time_to'
+    description='Time to of dashboard.'
+    type='string'
+    reference=''
+    value='"now"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-extra-filters"></a>
+
+<ParameterDescription
+    name='dashboard.extra_filters'
+    description='Additional filters to pass to each query to Grafana datasource.'
+    type='Object (map[string]string)'
+    reference='#map-string-string'
+    value='{}'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-title"></a>
+
+<ParameterDescription
+    name='dashboard.title'
+    description='Name of the main dashboard.'
+    type='string'
+    reference=''
+    value='"Aperture Service Protection for PostgreSQL"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+##### dashboard.datasource {#dashboard-datasource}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-datasource-name"></a>
+
+<ParameterDescription
+    name='dashboard.datasource.name'
+    description='Datasource name.'
+    type='string'
+    reference=''
+    value='"$datasource"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="dashboard-datasource-filter-regex"></a>
+
+<ParameterDescription
+    name='dashboard.datasource.filter_regex'
+    description='Datasource filter regex.'
+    type='string'
+    reference=''
+    value='""'
+/>
+
+<!-- vale on -->
+
+---
+
+### Schemas
+
+<!-- vale off -->
+
+#### overload_confirmation {#overload-confirmation}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="overload-confirmation-query-string"></a>
+
+<ParameterDescription
+    name='query_string'
+    description='The Prometheus query to be run. Must return a scalar or a vector with a single element.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="overload-confirmation-threshold"></a>
+
+<ParameterDescription
+    name='threshold'
+    description='The threshold for the overload confirmation criteria.'
+    type='Number (double)'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="overload-confirmation-operator"></a>
+
+<ParameterDescription
+    name='operator'
+    description='The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+---
+
+<!-- vale off -->
+
+#### promql_scale_out_controller {#promql-scale-out-controller}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-out-controller-query-string"></a>
+
+<ParameterDescription
+    name='query_string'
+    description='The Prometheus query to be run. Must return a scalar or a vector with a single element.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-out-controller-threshold"></a>
+
+<ParameterDescription
+    name='threshold'
+    description='Threshold for the controller.'
+    type='Number (double)'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-out-controller-gradient"></a>
+
+<ParameterDescription
+    name='gradient'
+    description='Gradient parameters for the controller.'
+    type='Object (aperture.spec.v1.IncreasingGradientParameters)'
+    reference='../../../spec#increasing-gradient-parameters'
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-out-controller-alerter"></a>
+
+<ParameterDescription
+    name='alerter'
+    description='Alerter parameters for the controller.'
+    type='Object (aperture.spec.v1.AlerterParameters)'
+    reference='../../../spec#alerter-parameters'
+    value='null'
+/>
+
+<!-- vale on -->
+
+---
+
+<!-- vale off -->
+
+#### promql_scale_in_controller {#promql-scale-in-controller}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-in-controller-query-string"></a>
+
+<ParameterDescription
+    name='query_string'
+    description='The Prometheus query to be run. Must return a scalar or a vector with a single element.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-in-controller-threshold"></a>
+
+<ParameterDescription
+    name='threshold'
+    description='Threshold for the controller.'
+    type='Number (double)'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-in-controller-gradient"></a>
+
+<ParameterDescription
+    name='gradient'
+    description='Gradient parameters for the controller.'
+    type='Object (aperture.spec.v1.DecreasingGradientParameters)'
+    reference='../../../spec#decreasing-gradient-parameters'
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="promql-scale-in-controller-alerter"></a>
+
+<ParameterDescription
+    name='alerter'
+    description='Alerter parameters for the controller.'
+    type='Object (aperture.spec.v1.AlerterParameters)'
+    reference='../../../spec#alerter-parameters'
+    value='null'
+/>
+
+<!-- vale on -->
+
+---
+
+<!-- vale off -->
+
+#### postgresql {#postgresql}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-username"></a>
+
+<ParameterDescription
+    name='username'
+    description='Username of the PostgreSQL.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-password"></a>
+
+<ParameterDescription
+    name='password'
+    description='Password of the PostgreSQL.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-endpoint"></a>
+
+<ParameterDescription
+    name='endpoint'
+    description='Endpoint of the PostgreSQL.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-transport"></a>
+
+<ParameterDescription
+    name='transport'
+    description='The transport protocol being used to connect to postgresql. Available options are tcp and unix.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-database"></a>
+
+<ParameterDescription
+    name='database'
+    description='The list of databases for which the receiver will attempt to collect statistics.'
+    type='Array of string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-collection-interval"></a>
+
+<ParameterDescription
+    name='collection_interval'
+    description='This receiver collects metrics on an interval.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-initial-delay"></a>
+
+<ParameterDescription
+    name='initial_delay'
+    description='Defines how long this receiver waits before starting.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-agent-group"></a>
+
+<ParameterDescription
+    name='agent_group'
+    description='Name of the Aperture Agent group.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+##### tls {#postgresql-tls}
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-tls-insecure"></a>
+
+<ParameterDescription
+    name='insecure'
+    description='Whether to enable client transport security for the postgresql connection.'
+    type='Boolean'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-tls-insecure-skip-verify"></a>
+
+<ParameterDescription
+    name='insecure_skip_verify'
+    description='Whether to validate server name and certificate if client transport security is enabled.'
+    type='Boolean'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-tls-cert-file"></a>
+
+<ParameterDescription
+    name='cert_file'
+    description='A cerficate used for client authentication, if necessary.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-tls-key-file"></a>
+
+<ParameterDescription
+    name='key_file'
+    description='An SSL key used for client authentication, if necessary.'
+    type='string'
+    reference=''
+    value='null'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="postgresql-tls-ca-file"></a>
+
+<ParameterDescription name='ca_file' description='A set of certificate
+authorities used to validate the database server's SSL certificate.'
+type='string' reference='' value='null' />
+
+<!-- vale on -->
+
+---
+
+## Dynamic Configuration
+
+:::note
+
+The following configuration parameters can be
+[dynamically configured](/reference/aperturectl/apply/dynamic-config/dynamic-config.md)
+at runtime, without reloading the policy.
+
+:::
+
+### Parameters
+
+<!-- vale off -->
+
+<a id="dry-run"></a>
+
+<ParameterDescription
+    name='dry_run'
+    description='Dynamic configuration for setting dry run mode at runtime without restarting this policy. In dry run mode the scheduler acts as pass through to all flow and does not queue flows. It is useful for observing the behavior of load scheduler without disrupting any real traffic.'
+    type='Boolean'
+    reference=''
+    value='"__REQUIRED_FIELD__"'
+/>
+
+<!-- vale on -->
+
+---

--- a/docs/content/reference/blueprints/policies/service-protection/postgresql.md
+++ b/docs/content/reference/blueprints/policies/service-protection/postgresql.md
@@ -234,9 +234,9 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 <ParameterDescription
     name='policy.service_protection_core.cpu_overload_confirmation.threshold'
     description='Threshold value for CPU utilizatio if it has to be used as overload confirmation.'
-    type='string'
+    type='Number (double)'
     reference=''
-    value='""'
+    value='null'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/blueprints/policies/service-protection/postgresql.md
+++ b/docs/content/reference/blueprints/policies/service-protection/postgresql.md
@@ -29,13 +29,6 @@ concurrency. The concurrency is reduced by a multiplicative factor when the
 service is overloaded, and increased by an additive factor while the service is
 no longer overloaded.
 
-This policy detects traffic overloads and cascading failure build-up by
-comparing the real-time latency with its exponential moving average. A gradient
-controller calculates a proportional response to limit accepted concurrency. The
-concurrency is reduced by a multiplicative factor when the service is
-overloaded, and increased by an additive factor while the service is no longer
-overloaded.
-
 :::info
 
 Please see reference for the
@@ -221,7 +214,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 <ParameterDescription
     name='policy.service_protection_core.cpu_overload_confirmation_threshold'
     description='Threshold value for CPU utilizatio if it has to be used as overload confirmation.'
-    type='Number (double)'
+    type='string'
     reference=''
     value='""'
 />
@@ -816,9 +809,13 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <a id="postgresql-tls-ca-file"></a>
 
-<ParameterDescription name='ca_file' description='A set of certificate
-authorities used to validate the database server's SSL certificate.'
-type='string' reference='' value='null' />
+<ParameterDescription
+    name='ca_file'
+    description='A set of certificate authorities used to validate the database server SSL certificate.'
+    type='string'
+    reference=''
+    value='null'
+/>
 
 <!-- vale on -->
 


### PR DESCRIPTION
![image](https://github.com/fluxninja/aperture/assets/34568645/5f59cc00-0ea7-4b77-9907-013abaaad281)

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Added PostgreSQL service protection blueprint with configuration, policy, and dashboard

Bug fix:
- Fixed broken URL in blueprint-assets-generator.py
- Added condition to check for existence of `params.policy.service_protection_core` object in adaptive-load-scheduler/dashboard.libsonnet
```

> 🎉 A new feature we bring, with care,
> PostgreSQL protection, now there.
> Bug fixes too, we did prepare,
> For smoother sailing, everywhere. 🚀
<!-- end of auto-generated comment: release notes by openai -->