### PR TITLE
Revert "Update helm dependencies in aperture-controller chart (#2163)"

### DIFF
--- a/manifests/charts/aperture-controller/Chart.lock
+++ b/manifests/charts/aperture-controller/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.17.1
 - name: etcd
   repository: https://charts.bitnami.com/bitnami
-  version: 8.12.0
+  version: 8.9.0
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 22.6.4
-digest: sha256:3758f4766d64756a9009590ec02803702179220659e076a46f4ebb3a17a2b27b
-generated: "2023-06-15T10:44:09.55426-07:00"
+  version: 15.18.0
+digest: sha256:c16e0f10234a15181cdde670a1c422e17ae90020598a4e2f0b254ea391898ab3
+generated: "2023-04-21T11:34:56.926829081+05:30"

--- a/manifests/charts/aperture-controller/Chart.yaml
+++ b/manifests/charts/aperture-controller/Chart.yaml
@@ -9,10 +9,10 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: "=1.17.1"
   - name: etcd
-    version: "=8.12.0"
+    version: "=8.9.0"
     repository: https://charts.bitnami.com/bitnami
     condition: etcd.enabled
   - name: prometheus
-    version: "=22.6.4"
+    version: "=15.18.0"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -603,7 +603,7 @@ prometheus:
     image:
       registry: docker.io/linuxserver
       repository: yq
-      tag: 3.2.2
+      tag: 3.1.0
       pullPolicy: IfNotPresent
   server:
     statefulSet:
@@ -611,15 +611,14 @@ prometheus:
     image:
       tag: v2.33.5
     extraFlags:
-      - web.enable-lifecycle
-      - web.enable-remote-write-receiver
+    - web.enable-remote-write-receiver
   alertmanager:
     enabled: false
-  prometheus-node-exporter:
+  nodeExporter:
     enabled: false
-  prometheus-pushgateway:
+  pushgateway:
     enabled: false
-  kube-state-metrics:
+  kubeStateMetrics:
     enabled: false
   serverFiles:
     prometheus.yml:


### PR DESCRIPTION
Reverting the prometheus upgrade as it is just a Helm chart version change and underneath, the Prometheus version is same `v2.33.5`.

This update is breaking the upgrade procedure for Aperture Controller so we can handle this later when the actual prometheus is also updated