### PR TITLE
Decrease scrape interval for FN plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ workflows:
           config-path: .circleci/continue-workflows.yml
           mapping: |
             .dockerignore updated-aperture true
-            (cmd|pkg|plugins|api|test)/.* updated-aperture true
+            (cmd|pkg|extensions|api|test)/.* updated-aperture true
             packaging/agent/.* updated-aperture-agent-packaging true
             packaging/cli/.* updated-aperturectl-packaging true
             operator/(api|config|controllers|hack)/.*|operator/main.go updated-aperture-operator true

--- a/extensions/fluxninja/otel/otel_test.go
+++ b/extensions/fluxninja/otel/otel_test.go
@@ -123,7 +123,7 @@ func (b configBuilder) withMetrics(pipelineName string) configBuilder {
 		"config": map[string]any{
 			"global": map[string]any{
 				// Here is different scrape interval than in the base otel config.
-				"scrape_interval": "10s",
+				"scrape_interval": "5s",
 			},
 			"scrape_configs": []string{"foo", "bar"},
 		},
@@ -131,7 +131,7 @@ func (b configBuilder) withMetrics(pipelineName string) configBuilder {
 	b.cfg.AddProcessor("batch/metrics-slow", map[string]any{
 		"send_batch_size":     uint32(10000),
 		"send_batch_max_size": uint32(10000),
-		"timeout":             5 * time.Second,
+		"timeout":             4 * time.Second,
 	})
 	processors := []string{
 		"batch/metrics-slow",

--- a/extensions/fluxninja/otel/provide.go
+++ b/extensions/fluxninja/otel/provide.go
@@ -32,6 +32,13 @@ const (
 	processorResourceAttributes = "transform/fluxninja"
 
 	exporterFluxNinja = "otlp/fluxninja"
+
+	scrapeInterval = "5s"
+	// BatchTimeout needs to be less than `scrapeInterval` no there is only
+	// one data point for given metrics in each batch.
+	batchTimeout     = 4 * time.Second
+	sendBatchSize    = 10000
+	sendBatchSizeMax = 10000
 )
 
 // Module provides the OTel configuration for FluxNinja.
@@ -136,7 +143,7 @@ func addFNToPipeline(
 func addMetricsSlowPipeline(config *otelconfig.Config) {
 	log.Info().Msg("Adding metrics/slow pipeline")
 	addFluxNinjaPrometheusReceiver(config)
-	config.AddBatchProcessor(processorBatchMetricsSlow, 5*time.Second, 10000, 10000)
+	config.AddBatchProcessor(processorBatchMetricsSlow, batchTimeout, sendBatchSize, sendBatchSizeMax)
 	config.Service.AddPipeline("metrics/slow", otelconfig.Pipeline{
 		Receivers: []string{receiverPrometheus},
 		Processors: []string{
@@ -150,7 +157,7 @@ func addMetricsSlowPipeline(config *otelconfig.Config) {
 func addMetricsControllerSlowPipeline(config *otelconfig.Config) {
 	log.Info().Msg("Adding metrics/controller-slow pipeline")
 	addFluxNinjaPrometheusReceiver(config)
-	config.AddBatchProcessor(processorBatchMetricsSlow, 5*time.Second, 10000, 10000)
+	config.AddBatchProcessor(processorBatchMetricsSlow, batchTimeout, sendBatchSize, sendBatchSizeMax)
 	config.Service.AddPipeline("metrics/controller-slow", otelconfig.Pipeline{
 		Receivers: []string{receiverPrometheus},
 		Processors: []string{
@@ -171,7 +178,7 @@ func addFluxNinjaPrometheusReceiver(config *otelconfig.Config) {
 	configPatch := map[string]any{
 		"config": map[string]any{
 			"global": map[string]any{
-				"scrape_interval": "10s",
+				"scrape_interval": scrapeInterval,
 			},
 		},
 	}


### PR DESCRIPTION
### Description of change
Scrape interval for metrics sent to FN ARC is now `5s`. This is a step to unify metrics collected in Controller's Prometheus and those sent to FN ARC.

##### Checklist

- [ ] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Tests and/or benchmarks are included

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Decreased scrape interval for metrics sent to FN ARC from 10s to 5s
- Changed timeout for batch/metrics-slow processor from 5s to 4s
- Added constants for batch timeout, send batch size, and send batch size max
- Updated CircleCI configuration to include `extensions` directory
- Removed `BuildOTelScrapeConfig` function call
- Unified metrics collected in Controller's Prometheus and those sent to FN ARC

> 🎉 A faster pace we now embrace,
> Metrics flow with newfound grace.
> Constants set, configs refined,
> CircleCI's watchful eye aligned.
> Unifying metrics, we proceed,
> To fulfill our users' every need. 🚀
<!-- end of auto-generated comment: release notes by openai -->