### PR TITLE
Fix path filters for aperture build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ workflows:
           config-path: .circleci/continue-workflows.yml
           mapping: |
             .dockerignore updated-aperture true
-            (cmd|pkg|plugins|api|test)/.* updated-aperture true
+            (cmd|pkg|extensions|api|test)/.* updated-aperture true
             packaging/agent/.* updated-aperture-agent-packaging true
             packaging/cli/.* updated-aperturectl-packaging true
             operator/(api|config|controllers|hack)/.*|operator/main.go updated-aperture-operator true


### PR DESCRIPTION
### Description of change
Fix path filtering in CI, so Aperture is build/tested also when extensions are changed.

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Chore:**
- Update CI path filtering to include `extensions` directory

> 🎉 Extensions now in sight,
> CI builds them day and night.
> With every change, we test,
> Ensuring Aperture's at its best! 🚀
<!-- end of auto-generated comment: release notes by openai -->