### PR TITLE
Revert "Fixes in blueprints generator and auto-scaling defaults in service-protection (#2182)"

### DIFF
--- a/blueprints/blueprint-assets-generator.py
+++ b/blueprints/blueprint-assets-generator.py
@@ -266,7 +266,7 @@ def update_param_defaults(
                 try:
                     return config[part]
                 except KeyError:
-                    # fatal
+                    # fatal exit
                     logger.error(f"Unable to find param {name} in rendered config")
                     raise typer.Exit(1)
             else:
@@ -279,8 +279,8 @@ def update_param_defaults(
                     return None
 
     logger.trace(rendered_config)
-
     # walk nested_parameters and update defaults
+
     def update_nested_param_defaults(node, prefix=""):
         if node.parameter.param_type != "intermediate_node":
             default = get_param_default_from_rendered_config(
@@ -510,9 +510,7 @@ type: "{{ param_type }}"
 {% else %}
 {{ node.parameter.param_name }}:
   description: "{{ node.parameter.description }}"
-  {% if node.parameter.default != None %}
   default: {{ node.parameter.default | quote_value }}
-  {% endif %}
   {{ render_type(node.parameter.param_type, node.parameter.json_schema_link,
                  node.parameter.is_complex_type) | indent(2, true) }}
 {% endif %}

--- a/blueprints/policies/auto-scaling/pod-auto-scaler/gen/definitions.json
+++ b/blueprints/policies/auto-scaling/pod-auto-scaler/gen/definitions.json
@@ -176,20 +176,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/IncreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }
@@ -202,20 +206,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/DecreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/config.libsonnet
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/average-latency/config.libsonnet
@@ -1,8 +1,15 @@
 local averageLatencyServiceProtection = import '../../service-protection/average-latency/config.libsonnet';
 local baseServiceProtectionDefaults = import '../../service-protection/base/config-defaults.libsonnet';
 
-/**
-* @param (policy: policies/service-protection/average-latency:param:policy required) Configuration for the Service Protection policy.
-* @param (dashboard: policies/service-protection/average-latency:param:dashboard) Configuration for the Grafana dashboard accompanying this policy.
-*/
-averageLatencyServiceProtection
+averageLatencyServiceProtection {
+  /**
+  * @param (policy: policies/service-protection/average-latency:param:policy required) Configuration for the Service Protection policy.
+  */
+  policy+: {
+    auto_scaling: baseServiceProtectionDefaults.auto_scaling_pods,
+  },
+  /**
+  * @param (dashboard: policies/service-protection/average-latency:param:dashboard) Configuration for the Grafana dashboard accompanying this policy.
+  */
+  dashboard: averageLatencyServiceProtection.dashboard,
+}

--- a/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/config.libsonnet
+++ b/blueprints/policies/service-protection-with-load-based-pod-auto-scaler/promql/config.libsonnet
@@ -1,8 +1,15 @@
 local baseServiceProtectionDefaults = import '../../service-protection/base/config-defaults.libsonnet';
 local promqlServiceProtection = import '../../service-protection/promql/config.libsonnet';
 
-/**
-* @param (policy: policies/service-protection/promql:param:policy required) Configuration for the Service Protection policy.
-* @param (dashboard: policies/service-protection/promql:param:dashboard) Configuration for the Grafana dashboard accompanying this policy.
-*/
-promqlServiceProtection
+promqlServiceProtection {
+  /**
+  * @param (policy: policies/service-protection/promql:param:policy required) Configuration for the Service Protection policy.
+  */
+  policy+: {
+    auto_scaling: baseServiceProtectionDefaults.auto_scaling_pods,
+  },
+  /**
+  * @param (dashboard: policies/service-protection/promql:param:dashboard) Configuration for the Grafana dashboard accompanying this policy.
+  */
+  dashboard: promqlServiceProtection.dashboard,
+}

--- a/blueprints/policies/service-protection/average-latency/bundle.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/bundle.libsonnet
@@ -11,8 +11,8 @@ function(params, metadata={}) {
 
   local c = std.mergePatch(config, params),
   local metadataWrapper = metadata { values: std.toString(params) },
-  local p = policy(c, params, metadataWrapper),
-  local d = dashboard(c, params),
+  local p = policy(c, metadataWrapper),
+  local d = dashboard(c),
 
   policies: {
     [std.format('%s-cr.yaml', c.policy.policy_name)]: p.policyResource,

--- a/blueprints/policies/service-protection/average-latency/dashboard.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/dashboard.libsonnet
@@ -6,18 +6,18 @@ local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libso
 local graphPanel = grafana.graphPanel;
 local prometheus = grafana.prometheus;
 
-function(cfg, params={}) {
-  local updatedConfig = config + cfg,
-  local policyName = updatedConfig.policy.policy_name,
-  local variantName = updatedConfig.dashboard.variant_name,
-  local filters = utils.dictToPrometheusFilter(updatedConfig.dashboard.extra_filters { flux_meter_name: policyName, flow_status: 'OK' }),
+function(cfg) {
+  local params = config + cfg,
+  local policyName = params.policy.policy_name,
+  local variantName = params.dashboard.variant_name,
+  local filters = utils.dictToPrometheusFilter(params.dashboard.extra_filters { flux_meter_name: policyName, policy_name: policyName, flow_status: 'OK' }),
 
-  local baseDashboard = baseDashboardFn(updatedConfig, params),
+  local baseDashboard = baseDashboardFn(params),
 
   local fluxMeterPanel =
     graphPanel.new(
       title=variantName + ' Query',
-      datasource=updatedConfig.dashboard.datasource.name,
+      datasource=params.dashboard.datasource.name,
       interval='30s',
       labelY1='Latency (ms)',
       formatY1='ms',

--- a/blueprints/policies/service-protection/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection/average-latency/gen/definitions.json
@@ -95,12 +95,12 @@
           "properties": {
             "dry_run": {
               "description": "Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.",
-              "default": false,
+              "default": null,
               "type": "boolean"
             },
             "promql_scale_out_controllers": {
               "description": "List of scale out controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -109,7 +109,7 @@
             },
             "promql_scale_in_controllers": {
               "description": "List of scale in controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -118,28 +118,13 @@
             },
             "scaling_parameters": {
               "description": "Parameters that define the scaling behavior.",
-              "default": {
-                "scale_in_alerter": {
-                  "alert_name": "Auto-scaler is scaling in"
-                },
-                "scale_in_cooldown": "40s",
-                "scale_out_alerter": {
-                  "alert_name": "Auto-scaler is scaling out"
-                },
-                "scale_out_cooldown": "30s"
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingParameters"
             },
             "scaling_backend": {
               "description": "Scaling backend for the policy.",
-              "default": {
-                "kubernetes_replicas": {
-                  "kubernetes_object_selector": "__REQUIRED_FIELD__",
-                  "max_replicas": "__REQUIRED_FIELD__",
-                  "min_replicas": "__REQUIRED_FIELD__"
-                }
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingBackend"
             },
@@ -149,12 +134,12 @@
               "properties": {
                 "period": {
                   "description": "Period for periodic scale in.",
-                  "default": "60s",
+                  "default": null,
                   "type": "string"
                 },
                 "scale_in_percentage": {
                   "description": "Percentage of replicas to scale in.",
-                  "default": 10,
+                  "default": null,
                   "type": "number",
                   "format": "double"
                 }
@@ -263,15 +248,18 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "The threshold for the overload confirmation criteria.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "operator": {
           "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`",
+          "default": null,
           "type": "string"
         }
       }
@@ -282,20 +270,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/IncreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }
@@ -307,20 +299,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/DecreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }

--- a/blueprints/policies/service-protection/average-latency/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values-required.yaml
@@ -44,36 +44,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   latency_baseliner:
     # Flux Meter defines the scope of latency measurements.
     # Type: aperture.spec.v1.FluxMeter

--- a/blueprints/policies/service-protection/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values.yaml
@@ -44,36 +44,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   latency_baseliner:
     # Flux Meter defines the scope of latency measurements.
     # Type: aperture.spec.v1.FluxMeter

--- a/blueprints/policies/service-protection/average-latency/policy.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/policy.libsonnet
@@ -2,10 +2,10 @@ local spec = import '../../../spec.libsonnet';
 local basePolicyFn = import '../base/policy.libsonnet';
 local config = import './config.libsonnet';
 
-function(cfg, params={}, metadata={}) {
-  local updatedConfig = config + cfg,
+function(cfg, metadata={}) {
+  local params = config + cfg,
 
-  local basePolicy = basePolicyFn(cfg, params, metadata),
+  local basePolicy = basePolicyFn(cfg, metadata),
 
   // Add new components to basePolicy
   local policyDef = basePolicy.policyDef {
@@ -14,20 +14,20 @@ function(cfg, params={}, metadata={}) {
         spec.v1.Component.withQuery(
           spec.v1.Query.new()
           + spec.v1.Query.withPromql(
-            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))' % { policy_name: updatedConfig.policy.policy_name };
+            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))' % { policy_name: params.policy.policy_name };
             spec.v1.PromQL.new()
             + spec.v1.PromQL.withQueryString(q)
-            + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.evaluation_interval)
+            + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=params.policy.evaluation_interval)
             + spec.v1.PromQL.withOutPorts({ output: spec.v1.Port.withSignalName('SIGNAL') }),
           ),
         ),
         spec.v1.Component.withArithmeticCombinator(spec.v1.ArithmeticCombinator.mul(
           spec.v1.Port.withSignalName('SIGNAL'),
-          spec.v1.Port.withConstantSignal(updatedConfig.policy.latency_baseliner.latency_ema_limit_multiplier),
+          spec.v1.Port.withConstantSignal(params.policy.latency_baseliner.latency_ema_limit_multiplier),
           output=spec.v1.Port.withSignalName('MAX_EMA')
         )),
         spec.v1.Component.withEma(
-          spec.v1.EMA.withParameters(updatedConfig.policy.latency_baseliner.ema)
+          spec.v1.EMA.withParameters(params.policy.latency_baseliner.ema)
           + spec.v1.EMA.withInPortsMixin(
             spec.v1.EMA.inPorts.withInput(spec.v1.Port.withSignalName('SIGNAL'))
             + spec.v1.EMA.inPorts.withMaxEnvelope(spec.v1.Port.withSignalName('MAX_EMA'))
@@ -36,14 +36,14 @@ function(cfg, params={}, metadata={}) {
         ),
         spec.v1.Component.withArithmeticCombinator(spec.v1.ArithmeticCombinator.mul(
           spec.v1.Port.withSignalName('SIGNAL_EMA'),
-          spec.v1.Port.withConstantSignal(updatedConfig.policy.latency_baseliner.latency_tolerance_multiplier),
+          spec.v1.Port.withConstantSignal(params.policy.latency_baseliner.latency_tolerance_multiplier),
           output=spec.v1.Port.withSignalName('SETPOINT')
         )),
       ],
     },
     resources+: {
       flow_control+: {
-        flux_meters+: { [updatedConfig.policy.policy_name]: updatedConfig.policy.latency_baseliner.flux_meter },
+        flux_meters+: { [params.policy.policy_name]: params.policy.latency_baseliner.flux_meter },
       },
     },
   },

--- a/blueprints/policies/service-protection/base/config-defaults.libsonnet
+++ b/blueprints/policies/service-protection/base/config-defaults.libsonnet
@@ -117,11 +117,6 @@ local kubeletstats_infra_meter = function(agent_group) {
     },
     evaluation_interval: '10s',
     service_protection_core: service_protection_core_defaults,
-    auto_scaling: auto_scaling_defaults {
-      scaling_backend+: {
-        kubernetes_replicas: kubernetes_replicas_defaults,
-      },
-    },
   },
 
   dashboard: {
@@ -136,6 +131,12 @@ local kubeletstats_infra_meter = function(agent_group) {
   },
 
   selectors: selectors_defaults,
+
+  auto_scaling: auto_scaling_defaults {
+    scaling_backend+: {
+      kubernetes_replicas: kubernetes_replicas_defaults,
+    },
+  },
 
   auto_scaling_pods: auto_scaling_defaults {
     scaling_backend+: {

--- a/blueprints/policies/service-protection/base/dashboard.libsonnet
+++ b/blueprints/policies/service-protection/base/dashboard.libsonnet
@@ -2,15 +2,15 @@ local baseAutoScalingDashboardFn = import '../../../../blueprints/dashboards/aut
 local adaptiveLoadSchedulerDashboard = import '../../../../blueprints/dashboards/flow-control/adaptive-load-scheduler/dashboard.libsonnet';
 local config = import './config-defaults.libsonnet';
 
-function(cfg, params={}) {
-  local updatedConfig = config + cfg,
-  local protectionDashboard = adaptiveLoadSchedulerDashboard(updatedConfig).dashboard,
+function(cfg) {
+  local params = config + cfg,
+  local protectionDashboard = adaptiveLoadSchedulerDashboard(params).dashboard,
   local autoScalingParams = {
-    policy+: updatedConfig.policy.auto_scaling {
-      policy_name: updatedConfig.policy.policy_name,
+    policy+: params.policy.auto_scaling {
+      policy_name: params.policy.policy_name,
     },
 
-    dashboard: updatedConfig.dashboard,
+    dashboard: params.dashboard,
   },
 
   local baseAutoScalingDashboard = baseAutoScalingDashboardFn(autoScalingParams).dashboard,
@@ -30,5 +30,5 @@ function(cfg, params={}) {
       ],
     },
 
-  dashboard: if std.objectHas(params, 'policy') && std.objectHas(params.policy, 'auto_scaling') then protectionAndEscalationDashboard else protectionDashboard,
+  dashboard: if std.objectHas(params.policy, 'auto_scaling') then protectionAndEscalationDashboard else protectionDashboard,
 }

--- a/blueprints/policies/service-protection/base/policy.libsonnet
+++ b/blueprints/policies/service-protection/base/policy.libsonnet
@@ -3,15 +3,15 @@ local utils = import '../../../utils/utils.libsonnet';
 local baseAutoScalingPolicyFn = import '../../auto-scaling/base/policy.libsonnet';
 local config = import './config-defaults.libsonnet';
 
-function(cfg, params={}, metadata={}) {
-  local updatedConfig = config + cfg,
+function(cfg, metadata={}) {
+  local params = config + cfg,
 
   local addOverloadConfirmation = function(confirmationAccumulator, confirmation) {
     local promQLSignalName = 'PROMQL_' + std.toString(confirmationAccumulator.overload_confirmation_signals_count),
 
     local promQLComponent = spec.v1.Component.withQuery(spec.v1.Query.withPromql(
       spec.v1.PromQL.withQueryString(confirmation.query_string)
-      + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.evaluation_interval)
+      + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=params.policy.evaluation_interval)
       + spec.v1.PromQL.withOutPorts({
         output: spec.v1.Port.withSignalName(promQLSignalName),
       })
@@ -57,7 +57,7 @@ function(cfg, params={}, metadata={}) {
 
   local confirmationAccumulator = std.foldl(
     addOverloadConfirmation,
-    (if std.objectHas(updatedConfig.policy.service_protection_core, 'overload_confirmations') then updatedConfig.policy.service_protection_core.overload_confirmations else []),
+    (if std.objectHas(params.policy.service_protection_core, 'overload_confirmations') then params.policy.service_protection_core.overload_confirmations else []),
     confirmationAccumulatorInitial
   ),
 
@@ -77,11 +77,11 @@ function(cfg, params={}, metadata={}) {
 
   local adaptiveLoadSchedulerComponent = spec.v1.Component.withFlowControl(
     spec.v1.FlowControl.withAdaptiveLoadScheduler(
-      local adaptiveLoadScheduler = updatedConfig.policy.service_protection_core.adaptive_load_scheduler;
+      local adaptiveLoadScheduler = params.policy.service_protection_core.adaptive_load_scheduler;
       spec.v1.AdaptiveLoadScheduler.new()
       + spec.v1.AdaptiveLoadScheduler.withParameters(adaptiveLoadScheduler)
       + spec.v1.AdaptiveLoadScheduler.withDryRunConfigKey('dry_run')
-      + spec.v1.AdaptiveLoadScheduler.withDryRun(updatedConfig.policy.service_protection_core.dry_run)
+      + spec.v1.AdaptiveLoadScheduler.withDryRun(params.policy.service_protection_core.dry_run)
       + spec.v1.AdaptiveLoadScheduler.withInPorts({
         overload_confirmation: (if isConfirmationCriteria then spec.v1.Port.withSignalName('OVERLOAD_CONFIRMATION') else spec.v1.Port.withConstantSignal(1)),
         signal: spec.v1.Port.withSignalName('SIGNAL'),
@@ -97,9 +97,8 @@ function(cfg, params={}, metadata={}) {
   /** Auto scale escalation **/
 
   local scaleInControllers =
-    (if std.objectHas(params, 'policy') &&
-        std.objectHas(params.policy, 'auto_scaling') &&
-        std.objectHas(updatedConfig.policy.auto_scaling, 'periodic_decrease')
+    (if
+       std.objectHas(params.policy, 'auto_scaling') && std.objectHas(params.policy.auto_scaling, 'periodic_decrease')
      then
        [
          spec.v1.ScaleInController.new()
@@ -109,14 +108,13 @@ function(cfg, params={}, metadata={}) {
          )
          + spec.v1.ScaleInController.withController(
            spec.v1.ScaleInControllerController.new()
-           + spec.v1.ScaleInControllerController.withPeriodic(updatedConfig.policy.auto_scaling.periodic_decrease)
+           + spec.v1.ScaleInControllerController.withPeriodic(params.policy.auto_scaling.periodic_decrease)
          ),
        ]
      else []),
 
   local scaleOutControllers =
-    (if std.objectHas(params, 'policy') &&
-        std.objectHas(params.policy, 'auto_scaling') then [
+    (if std.objectHas(params.policy, 'auto_scaling') then [
        spec.v1.ScaleOutController.new()
        + spec.v1.ScaleOutController.withAlerter(
          spec.v1.AlerterParameters.new()
@@ -141,32 +139,31 @@ function(cfg, params={}, metadata={}) {
 
   local policyDef =
     spec.v1.Policy.new()
-    + spec.v1.Policy.withResources(utils.resources(updatedConfig.policy.resources).updatedResources)
+    + spec.v1.Policy.withResources(params.policy.resources)
     + spec.v1.Policy.withCircuit(
       spec.v1.Circuit.new()
-      + spec.v1.Circuit.withEvaluationInterval(evaluation_interval=updatedConfig.policy.evaluation_interval)
+      + spec.v1.Circuit.withEvaluationInterval(evaluation_interval=params.policy.evaluation_interval)
       + spec.v1.Circuit.withComponents(
         confirmationAccumulator.components
         + (if isConfirmationCriteria then [overloadConfirmationAnd] else [])
         + [
           adaptiveLoadSchedulerComponent,
         ]
-        + updatedConfig.policy.components,
+        + params.policy.components,
       ),
     ) +
     (
-      if std.objectHas(params, 'policy') &&
-         std.objectHas(params.policy, 'auto_scaling') then
-        local autoScalingUpdatedConfig = {
-          policy+: updatedConfig.policy.auto_scaling {
-            policy_name: updatedConfig.policy.policy_name,
+      if std.objectHas(params.policy, 'auto_scaling') then
+        local autoScalingParams = {
+          policy+: params.policy.auto_scaling {
+            policy_name: params.policy.policy_name,
             // Set empty defaults for promql_scale_out_controllers and promql_scale_in_controllers
-            promql_scale_out_controllers: if std.objectHas(updatedConfig.policy.auto_scaling, 'promql_scale_out_controllers') then updatedConfig.policy.auto_scaling.promql_scale_out_controllers else [],
-            promql_scale_in_controllers: if std.objectHas(updatedConfig.policy.auto_scaling, 'promql_scale_in_controllers') then updatedConfig.policy.auto_scaling.promql_scale_in_controllers else [],
+            promql_scale_out_controllers: if std.objectHas(params.policy.auto_scaling, 'promql_scale_out_controllers') then params.policy.auto_scaling.promql_scale_out_controllers else [],
+            promql_scale_in_controllers: if std.objectHas(params.policy.auto_scaling, 'promql_scale_in_controllers') then params.policy.auto_scaling.promql_scale_in_controllers else [],
           },
         };
 
-        local baseAutoScalingPolicy = baseAutoScalingPolicyFn(autoScalingUpdatedConfig).policyDef;
+        local baseAutoScalingPolicy = baseAutoScalingPolicyFn(autoScalingParams).policyDef;
         {
           circuit+: {
             components+: std.map(
@@ -189,7 +186,7 @@ function(cfg, params={}, metadata={}) {
     kind: 'Policy',
     apiVersion: 'fluxninja.com/v1alpha1',
     metadata: {
-      name: updatedConfig.policy.policy_name,
+      name: params.policy.policy_name,
       labels: {
         'fluxninja.com/validate': 'true',
       },

--- a/blueprints/policies/service-protection/jmx/bundle.libsonnet
+++ b/blueprints/policies/service-protection/jmx/bundle.libsonnet
@@ -11,7 +11,7 @@ function(params, metadata={}) {
 
   local c = std.mergePatch(config, params),
   local metadataWrapper = metadata { values: std.toString(params) },
-  local p = policy(c, params, metadataWrapper),
+  local p = policy(c, metadataWrapper),
   local d = dashboard(c),
 
   policies: {

--- a/blueprints/policies/service-protection/jmx/gen/definitions.json
+++ b/blueprints/policies/service-protection/jmx/gen/definitions.json
@@ -95,12 +95,12 @@
           "properties": {
             "dry_run": {
               "description": "Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.",
-              "default": false,
+              "default": null,
               "type": "boolean"
             },
             "promql_scale_out_controllers": {
               "description": "List of scale out controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -109,7 +109,7 @@
             },
             "promql_scale_in_controllers": {
               "description": "List of scale in controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -118,28 +118,13 @@
             },
             "scaling_parameters": {
               "description": "Parameters that define the scaling behavior.",
-              "default": {
-                "scale_in_alerter": {
-                  "alert_name": "Auto-scaler is scaling in"
-                },
-                "scale_in_cooldown": "40s",
-                "scale_out_alerter": {
-                  "alert_name": "Auto-scaler is scaling out"
-                },
-                "scale_out_cooldown": "30s"
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingParameters"
             },
             "scaling_backend": {
               "description": "Scaling backend for the policy.",
-              "default": {
-                "kubernetes_replicas": {
-                  "kubernetes_object_selector": "__REQUIRED_FIELD__",
-                  "max_replicas": "__REQUIRED_FIELD__",
-                  "min_replicas": "__REQUIRED_FIELD__"
-                }
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingBackend"
             },
@@ -149,12 +134,12 @@
               "properties": {
                 "period": {
                   "description": "Period for periodic scale in.",
-                  "default": "60s",
+                  "default": null,
                   "type": "string"
                 },
                 "scale_in_percentage": {
                   "description": "Percentage of replicas to scale in.",
-                  "default": 10,
+                  "default": null,
                   "type": "number",
                   "format": "double"
                 }
@@ -258,15 +243,18 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "The threshold for the overload confirmation criteria.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "operator": {
           "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`",
+          "default": null,
           "type": "string"
         }
       }
@@ -277,20 +265,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/IncreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }
@@ -302,20 +294,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/DecreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }

--- a/blueprints/policies/service-protection/jmx/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/jmx/gen/values-required.yaml
@@ -44,36 +44,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   latency_baseliner:
     # Flux Meter defines the scope of latency measurements.
     # Type: aperture.spec.v1.FluxMeter

--- a/blueprints/policies/service-protection/jmx/gen/values.yaml
+++ b/blueprints/policies/service-protection/jmx/gen/values.yaml
@@ -44,36 +44,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   latency_baseliner:
     # Flux Meter defines the scope of latency measurements.
     # Type: aperture.spec.v1.FluxMeter

--- a/blueprints/policies/service-protection/jmx/policy.libsonnet
+++ b/blueprints/policies/service-protection/jmx/policy.libsonnet
@@ -2,10 +2,10 @@ local spec = import '../../../spec.libsonnet';
 local basePolicyFn = import '../base/policy.libsonnet';
 local config = import './config.libsonnet';
 
-function(cfg, params={}, metadata={}) {
-  local updatedConfig = config + cfg,
+function(cfg, metadata={}) {
+  local params = config + cfg,
 
-  local basePolicy = basePolicyFn(cfg, params, metadata),
+  local basePolicy = basePolicyFn(cfg, metadata),
 
   // Add new components to basePolicy
   local policyDef = basePolicy.policyDef {
@@ -14,20 +14,20 @@ function(cfg, params={}, metadata={}) {
         spec.v1.Component.withQuery(
           spec.v1.Query.new()
           + spec.v1.Query.withPromql(
-            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))' % { policy_name: updatedConfig.policy.policy_name };
+            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))' % { policy_name: params.policy.policy_name };
             spec.v1.PromQL.new()
             + spec.v1.PromQL.withQueryString(q)
-            + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.evaluation_interval)
+            + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=params.policy.evaluation_interval)
             + spec.v1.PromQL.withOutPorts({ output: spec.v1.Port.withSignalName('SIGNAL') }),
           ),
         ),
         spec.v1.Component.withArithmeticCombinator(spec.v1.ArithmeticCombinator.mul(
           spec.v1.Port.withSignalName('SIGNAL'),
-          spec.v1.Port.withConstantSignal(updatedConfig.policy.latency_baseliner.latency_ema_limit_multiplier),
+          spec.v1.Port.withConstantSignal(params.policy.latency_baseliner.latency_ema_limit_multiplier),
           output=spec.v1.Port.withSignalName('MAX_EMA')
         )),
         spec.v1.Component.withEma(
-          spec.v1.EMA.withParameters(updatedConfig.policy.latency_baseliner.ema)
+          spec.v1.EMA.withParameters(params.policy.latency_baseliner.ema)
           + spec.v1.EMA.withInPortsMixin(
             spec.v1.EMA.inPorts.withInput(spec.v1.Port.withSignalName('SIGNAL'))
             + spec.v1.EMA.inPorts.withMaxEnvelope(spec.v1.Port.withSignalName('MAX_EMA'))
@@ -36,14 +36,14 @@ function(cfg, params={}, metadata={}) {
         ),
         spec.v1.Component.withArithmeticCombinator(spec.v1.ArithmeticCombinator.mul(
           spec.v1.Port.withSignalName('SIGNAL_EMA'),
-          spec.v1.Port.withConstantSignal(updatedConfig.policy.latency_baseliner.latency_tolerance_multiplier),
+          spec.v1.Port.withConstantSignal(params.policy.latency_baseliner.latency_tolerance_multiplier),
           output=spec.v1.Port.withSignalName('SETPOINT')
         )),
       ],
     },
     resources+: {
       flow_control+: {
-        flux_meters+: { [updatedConfig.policy.policy_name]: updatedConfig.policy.latency_baseliner.flux_meter },
+        flux_meters+: { [params.policy.policy_name]: params.policy.latency_baseliner.flux_meter },
       },
     },
   },

--- a/blueprints/policies/service-protection/postgresql/gen/definitions.json
+++ b/blueprints/policies/service-protection/postgresql/gen/definitions.json
@@ -104,6 +104,7 @@
                 },
                 "threshold": {
                   "description": "Threshold value for CPU utilizatio if it has to be used as overload confirmation.",
+                  "default": null,
                   "type": "number",
                   "format": "double"
                 },
@@ -122,12 +123,12 @@
           "properties": {
             "dry_run": {
               "description": "Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.",
-              "default": false,
+              "default": null,
               "type": "boolean"
             },
             "promql_scale_out_controllers": {
               "description": "List of scale out controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -136,7 +137,7 @@
             },
             "promql_scale_in_controllers": {
               "description": "List of scale in controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -145,28 +146,13 @@
             },
             "scaling_parameters": {
               "description": "Parameters that define the scaling behavior.",
-              "default": {
-                "scale_in_alerter": {
-                  "alert_name": "Auto-scaler is scaling in"
-                },
-                "scale_in_cooldown": "40s",
-                "scale_out_alerter": {
-                  "alert_name": "Auto-scaler is scaling out"
-                },
-                "scale_out_cooldown": "30s"
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingParameters"
             },
             "scaling_backend": {
               "description": "Scaling backend for the policy.",
-              "default": {
-                "kubernetes_replicas": {
-                  "kubernetes_object_selector": "__REQUIRED_FIELD__",
-                  "max_replicas": "__REQUIRED_FIELD__",
-                  "min_replicas": "__REQUIRED_FIELD__"
-                }
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingBackend"
             },
@@ -176,12 +162,12 @@
               "properties": {
                 "period": {
                   "description": "Period for periodic scale in.",
-                  "default": "60s",
+                  "default": null,
                   "type": "string"
                 },
                 "scale_in_percentage": {
                   "description": "Percentage of replicas to scale in.",
-                  "default": 10,
+                  "default": null,
                   "type": "number",
                   "format": "double"
                 }
@@ -265,15 +251,18 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "The threshold for the overload confirmation criteria.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "operator": {
           "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`",
+          "default": null,
           "type": "string"
         }
       }
@@ -284,20 +273,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/IncreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }
@@ -309,20 +302,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/DecreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }
@@ -335,22 +332,27 @@
       "properties": {
         "username": {
           "description": "Username of the PostgreSQL.",
+          "default": null,
           "type": "string"
         },
         "password": {
           "description": "Password of the PostgreSQL.",
+          "default": null,
           "type": "string"
         },
         "endpoint": {
           "description": "Endpoint of the PostgreSQL.",
+          "default": null,
           "type": "string"
         },
         "transport": {
           "description": "The transport protocol being used to connect to postgresql. Available options are tcp and unix.",
+          "default": null,
           "type": "string"
         },
         "database": {
           "description": "The list of databases for which the receiver will attempt to collect statistics.",
+          "default": null,
           "type": "array",
           "items": {
             "type": "string"
@@ -358,14 +360,17 @@
         },
         "collection_interval": {
           "description": "This receiver collects metrics on an interval.",
+          "default": null,
           "type": "string"
         },
         "initial_delay": {
           "description": "Defines how long this receiver waits before starting.",
+          "default": null,
           "type": "string"
         },
         "agent_group": {
           "description": "Name of the Aperture Agent group.",
+          "default": null,
           "type": "string"
         },
         "tls": {
@@ -374,22 +379,27 @@
           "properties": {
             "insecure": {
               "description": "Whether to enable client transport security for the postgresql connection.",
+              "default": null,
               "type": "boolean"
             },
             "insecure_skip_verify": {
               "description": "Whether to validate server name and certificate if client transport security is enabled.",
+              "default": null,
               "type": "boolean"
             },
             "cert_file": {
               "description": "A cerficate used for client authentication, if necessary.",
+              "default": null,
               "type": "string"
             },
             "key_file": {
               "description": "An SSL key used for client authentication, if necessary.",
+              "default": null,
               "type": "string"
             },
             "ca_file": {
               "description": "A set of certificate authorities used to validate the database server SSL certificate.",
+              "default": null,
               "type": "string"
             }
           }

--- a/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values-required.yaml
@@ -58,36 +58,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   # Setpoint.
   # Type: float64
   # Required: True

--- a/blueprints/policies/service-protection/postgresql/gen/values.yaml
+++ b/blueprints/policies/service-protection/postgresql/gen/values.yaml
@@ -58,36 +58,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   # Setpoint.
   # Type: float64
   # Required: True

--- a/blueprints/policies/service-protection/promql/bundle.libsonnet
+++ b/blueprints/policies/service-protection/promql/bundle.libsonnet
@@ -11,8 +11,8 @@ function(params, metadata={}) {
 
   local c = std.mergePatch(config, params),
   local metadataWrapper = metadata { values: std.toString(params) },
-  local p = policy(c, params, metadataWrapper),
-  local d = dashboard(c, params),
+  local p = policy(c, metadataWrapper),
+  local d = dashboard(c),
 
   policies: {
     [std.format('%s-cr.yaml', c.policy.policy_name)]: p.policyResource,

--- a/blueprints/policies/service-protection/promql/dashboard.libsonnet
+++ b/blueprints/policies/service-protection/promql/dashboard.libsonnet
@@ -5,17 +5,17 @@ local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libso
 local graphPanel = grafana.graphPanel;
 local prometheus = grafana.prometheus;
 
-function(cfg, params={}) {
-  local updatedConfig = config + cfg,
-  local variantName = updatedConfig.dashboard.variant_name,
-  local query = updatedConfig.policy.promql_query,
+function(cfg) {
+  local params = config + cfg,
+  local variantName = params.dashboard.variant_name,
+  local query = params.policy.promql_query,
 
-  local baseDashboard = baseDashboardFn(updatedConfig, params),
+  local baseDashboard = baseDashboardFn(params),
 
   local queryPanel =
     graphPanel.new(
       title=variantName + ' Query',
-      datasource=updatedConfig.dashboard.datasource.name,
+      datasource=params.dashboard.datasource.name,
       interval='30s',
       labelY1='Messages',
     ).addTarget(

--- a/blueprints/policies/service-protection/promql/gen/definitions.json
+++ b/blueprints/policies/service-protection/promql/gen/definitions.json
@@ -101,12 +101,12 @@
           "properties": {
             "dry_run": {
               "description": "Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.",
-              "default": false,
+              "default": null,
               "type": "boolean"
             },
             "promql_scale_out_controllers": {
               "description": "List of scale out controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -115,7 +115,7 @@
             },
             "promql_scale_in_controllers": {
               "description": "List of scale in controllers.",
-              "default": [],
+              "default": null,
               "type": "array",
               "items": {
                 "type": "object",
@@ -124,28 +124,13 @@
             },
             "scaling_parameters": {
               "description": "Parameters that define the scaling behavior.",
-              "default": {
-                "scale_in_alerter": {
-                  "alert_name": "Auto-scaler is scaling in"
-                },
-                "scale_in_cooldown": "40s",
-                "scale_out_alerter": {
-                  "alert_name": "Auto-scaler is scaling out"
-                },
-                "scale_out_cooldown": "30s"
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingParameters"
             },
             "scaling_backend": {
               "description": "Scaling backend for the policy.",
-              "default": {
-                "kubernetes_replicas": {
-                  "kubernetes_object_selector": "__REQUIRED_FIELD__",
-                  "max_replicas": "__REQUIRED_FIELD__",
-                  "min_replicas": "__REQUIRED_FIELD__"
-                }
-              },
+              "default": null,
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AutoScalerScalingBackend"
             },
@@ -155,12 +140,12 @@
               "properties": {
                 "period": {
                   "description": "Period for periodic scale in.",
-                  "default": "60s",
+                  "default": null,
                   "type": "string"
                 },
                 "scale_in_percentage": {
                   "description": "Percentage of replicas to scale in.",
-                  "default": 10,
+                  "default": null,
                   "type": "number",
                   "format": "double"
                 }
@@ -233,15 +218,18 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "The threshold for the overload confirmation criteria.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "operator": {
           "description": "The operator for the overload confirmation criteria. oneof: `gt | lt | gte | lte | eq | neq`",
+          "default": null,
           "type": "string"
         }
       }
@@ -252,20 +240,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/IncreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }
@@ -277,20 +269,24 @@
       "properties": {
         "query_string": {
           "description": "The Prometheus query to be run. Must return a scalar or a vector with a single element.",
+          "default": null,
           "type": "string"
         },
         "threshold": {
           "description": "Threshold for the controller.",
+          "default": null,
           "type": "number",
           "format": "double"
         },
         "gradient": {
           "description": "Gradient parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/DecreasingGradientParameters"
         },
         "alerter": {
           "description": "Alerter parameters for the controller.",
+          "default": null,
           "type": "object",
           "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/AlerterParameters"
         }

--- a/blueprints/policies/service-protection/promql/gen/values-required.yaml
+++ b/blueprints/policies/service-protection/promql/gen/values-required.yaml
@@ -48,36 +48,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   # Setpoint.
   # Type: float64
   # Required: True

--- a/blueprints/policies/service-protection/promql/gen/values.yaml
+++ b/blueprints/policies/service-protection/promql/gen/values.yaml
@@ -48,36 +48,26 @@ policy:
   auto_scaling:
     # Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.
     # Type: bool
-    dry_run: false
+    dry_run: null
     # List of scale out controllers.
     # Type: []promql_scale_out_controller
-    promql_scale_out_controllers: []
+    promql_scale_out_controllers: null
     # List of scale in controllers.
     # Type: []promql_scale_in_controller
-    promql_scale_in_controllers: []
+    promql_scale_in_controllers: null
     # Parameters that define the scaling behavior.
     # Type: aperture.spec.v1.AutoScalerScalingParameters
-    scaling_parameters:
-      scale_in_alerter:
-        alert_name: "Auto-scaler is scaling in"
-      scale_in_cooldown: "40s"
-      scale_out_alerter:
-        alert_name: "Auto-scaler is scaling out"
-      scale_out_cooldown: "30s"
+    scaling_parameters: null
     # Scaling backend for the policy.
     # Type: aperture.spec.v1.AutoScalerScalingBackend
-    scaling_backend:
-      kubernetes_replicas:
-        kubernetes_object_selector: __REQUIRED_FIELD__
-        max_replicas: __REQUIRED_FIELD__
-        min_replicas: __REQUIRED_FIELD__
+    scaling_backend: null
     periodic_decrease:
       # Period for periodic scale in.
       # Type: string
-      period: "60s"
+      period: null
       # Percentage of replicas to scale in.
       # Type: float64
-      scale_in_percentage: 10
+      scale_in_percentage: null
   # Setpoint.
   # Type: float64
   # Required: True

--- a/blueprints/policies/service-protection/promql/policy.libsonnet
+++ b/blueprints/policies/service-protection/promql/policy.libsonnet
@@ -2,10 +2,10 @@ local spec = import '../../../spec.libsonnet';
 local basePolicyFn = import '../base/policy.libsonnet';
 local config = import './config.libsonnet';
 
-function(cfg, params={}, metadata={}) {
-  local updatedConfig = config + cfg,
+function(cfg, metadata={}) {
+  local params = config + cfg,
 
-  local basePolicy = basePolicyFn(cfg, params, metadata),
+  local basePolicy = basePolicyFn(cfg, metadata),
 
   // Add new components to basePolicy
   local policyDef = basePolicy.policyDef {
@@ -14,17 +14,17 @@ function(cfg, params={}, metadata={}) {
         spec.v1.Component.withQuery(
           spec.v1.Query.new()
           + spec.v1.Query.withPromql(
-            local q = updatedConfig.policy.promql_query;
+            local q = params.policy.promql_query;
             spec.v1.PromQL.new()
             + spec.v1.PromQL.withQueryString(q)
-            + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.evaluation_interval)
+            + spec.v1.PromQL.withEvaluationInterval(params.policy.evaluation_interval)
             + spec.v1.PromQL.withOutPorts({ output: spec.v1.Port.withSignalName('SIGNAL') }),
           ),
         ),
         spec.v1.Component.withVariable(
           spec.v1.Variable.new()
           + spec.v1.Variable.withConstantOutput(
-            local s = updatedConfig.policy.setpoint;
+            local s = params.policy.setpoint;
             spec.v1.ConstantSignal.new()
             + spec.v1.ConstantSignal.withValue(s)
           )

--- a/docs/content/reference/blueprints/policies/service-protection/average-latency.md
+++ b/docs/content/reference/blueprints/policies/service-protection/average-latency.md
@@ -197,7 +197,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.'
     type='Boolean'
     reference=''
-    value='false'
+    value='null'
 />
 
 <!-- vale on -->
@@ -211,7 +211,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale out controllers.'
     type='Array of Object (promql_scale_out_controller)'
     reference='#promql-scale-out-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -225,7 +225,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale in controllers.'
     type='Array of Object (promql_scale_in_controller)'
     reference='#promql-scale-in-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -239,7 +239,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Parameters that define the scaling behavior.'
     type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
     reference='../../../spec#auto-scaler-scaling-parameters'
-    value='{"scale_in_alerter": {"alert_name": "Auto-scaler is scaling in"}, "scale_in_cooldown": "40s", "scale_out_alerter": {"alert_name": "Auto-scaler is scaling out"}, "scale_out_cooldown": "30s"}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -253,7 +253,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Scaling backend for the policy.'
     type='Object (aperture.spec.v1.AutoScalerScalingBackend)'
     reference='../../../spec#auto-scaler-scaling-backend'
-    value='{"kubernetes_replicas": {"kubernetes_object_selector": "__REQUIRED_FIELD__", "max_replicas": "__REQUIRED_FIELD__", "min_replicas": "__REQUIRED_FIELD__"}}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -273,7 +273,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Period for periodic scale in.'
     type='string'
     reference=''
-    value='"60s"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -287,7 +287,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Percentage of replicas to scale in.'
     type='Number (double)'
     reference=''
-    value='10'
+    value='null'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/blueprints/policies/service-protection/jmx.md
+++ b/docs/content/reference/blueprints/policies/service-protection/jmx.md
@@ -150,7 +150,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.'
     type='Boolean'
     reference=''
-    value='false'
+    value='null'
 />
 
 <!-- vale on -->
@@ -164,7 +164,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale out controllers.'
     type='Array of Object (promql_scale_out_controller)'
     reference='#promql-scale-out-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -178,7 +178,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale in controllers.'
     type='Array of Object (promql_scale_in_controller)'
     reference='#promql-scale-in-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -192,7 +192,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Parameters that define the scaling behavior.'
     type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
     reference='../../../spec#auto-scaler-scaling-parameters'
-    value='{"scale_in_alerter": {"alert_name": "Auto-scaler is scaling in"}, "scale_in_cooldown": "40s", "scale_out_alerter": {"alert_name": "Auto-scaler is scaling out"}, "scale_out_cooldown": "30s"}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -206,7 +206,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Scaling backend for the policy.'
     type='Object (aperture.spec.v1.AutoScalerScalingBackend)'
     reference='../../../spec#auto-scaler-scaling-backend'
-    value='{"kubernetes_replicas": {"kubernetes_object_selector": "__REQUIRED_FIELD__", "max_replicas": "__REQUIRED_FIELD__", "min_replicas": "__REQUIRED_FIELD__"}}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -226,7 +226,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Period for periodic scale in.'
     type='string'
     reference=''
-    value='"60s"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -240,7 +240,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Percentage of replicas to scale in.'
     type='Number (double)'
     reference=''
-    value='10'
+    value='null'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/blueprints/policies/service-protection/postgresql.md
+++ b/docs/content/reference/blueprints/policies/service-protection/postgresql.md
@@ -270,7 +270,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.'
     type='Boolean'
     reference=''
-    value='false'
+    value='null'
 />
 
 <!-- vale on -->
@@ -284,7 +284,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale out controllers.'
     type='Array of Object (promql_scale_out_controller)'
     reference='#promql-scale-out-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -298,7 +298,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale in controllers.'
     type='Array of Object (promql_scale_in_controller)'
     reference='#promql-scale-in-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -312,7 +312,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Parameters that define the scaling behavior.'
     type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
     reference='../../../spec#auto-scaler-scaling-parameters'
-    value='{"scale_in_alerter": {"alert_name": "Auto-scaler is scaling in"}, "scale_in_cooldown": "40s", "scale_out_alerter": {"alert_name": "Auto-scaler is scaling out"}, "scale_out_cooldown": "30s"}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -326,7 +326,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Scaling backend for the policy.'
     type='Object (aperture.spec.v1.AutoScalerScalingBackend)'
     reference='../../../spec#auto-scaler-scaling-backend'
-    value='{"kubernetes_replicas": {"kubernetes_object_selector": "__REQUIRED_FIELD__", "max_replicas": "__REQUIRED_FIELD__", "min_replicas": "__REQUIRED_FIELD__"}}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -346,7 +346,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Period for periodic scale in.'
     type='string'
     reference=''
-    value='"60s"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -360,7 +360,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Percentage of replicas to scale in.'
     type='Number (double)'
     reference=''
-    value='10'
+    value='null'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/blueprints/policies/service-protection/promql.md
+++ b/docs/content/reference/blueprints/policies/service-protection/promql.md
@@ -177,7 +177,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Dry run mode ensures that no scaling is invoked by the auto scaler escalation. This config can be updated at runtime without restarting the policy.'
     type='Boolean'
     reference=''
-    value='false'
+    value='null'
 />
 
 <!-- vale on -->
@@ -191,7 +191,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale out controllers.'
     type='Array of Object (promql_scale_out_controller)'
     reference='#promql-scale-out-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -205,7 +205,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='List of scale in controllers.'
     type='Array of Object (promql_scale_in_controller)'
     reference='#promql-scale-in-controller'
-    value='[]'
+    value='null'
 />
 
 <!-- vale on -->
@@ -219,7 +219,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Parameters that define the scaling behavior.'
     type='Object (aperture.spec.v1.AutoScalerScalingParameters)'
     reference='../../../spec#auto-scaler-scaling-parameters'
-    value='{"scale_in_alerter": {"alert_name": "Auto-scaler is scaling in"}, "scale_in_cooldown": "40s", "scale_out_alerter": {"alert_name": "Auto-scaler is scaling out"}, "scale_out_cooldown": "30s"}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -233,7 +233,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Scaling backend for the policy.'
     type='Object (aperture.spec.v1.AutoScalerScalingBackend)'
     reference='../../../spec#auto-scaler-scaling-backend'
-    value='{"kubernetes_replicas": {"kubernetes_object_selector": "__REQUIRED_FIELD__", "max_replicas": "__REQUIRED_FIELD__", "min_replicas": "__REQUIRED_FIELD__"}}'
+    value='null'
 />
 
 <!-- vale on -->
@@ -253,7 +253,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Period for periodic scale in.'
     type='string'
     reference=''
-    value='"60s"'
+    value='null'
 />
 
 <!-- vale on -->
@@ -267,7 +267,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
     description='Percentage of replicas to scale in.'
     type='Number (double)'
     reference=''
-    value='10'
+    value='null'
 />
 
 <!-- vale on -->


### PR DESCRIPTION
### Description of change

This reverts commit 9994e60bd5a95821c8ca6fe17637abe592431efa.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**Revert:**
- Reverted changes to service-protection auto-scaling policies and blueprints generator
- Restored previous functionality and configurations in average-latency, JMX, and PromQL service protection

**Bug fix:**
- Fixed issues with default values in documentation for service-protection blueprints

> 🎉 Rejoice, for we've restored the past,
> To make our scaling policies last.
> With wisdom gained, we forge ahead,
> And celebrate this PR's thread. 🚀
<!-- end of auto-generated comment: release notes by openai -->