### PR TITLE
Replace ema with long term latency in average-latency blueprint

### DIFF
--- a/blueprints/jsonnetfile.lock.json
+++ b/blueprints/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "grafonnet"
         }
       },
-      "version": "30280196507e0fe6fa978a3e0eaca3a62844f817",
+      "version": "a1d61cce1da59c71409b99b5c7568511fec661ea",
       "sum": "342u++/7rViR/zj2jeJOjshzglkZ1SY+hFNuyCBFMdc="
     },
     {
@@ -28,7 +28,7 @@
           "subdir": "gen/grafonnet-v9.4.0"
         }
       },
-      "version": "d69eca143c137a72d6a55f078dc0eef1a47cf61c",
+      "version": "bf8e76582d494f3c68e99a26a4a80c519896de8a",
       "sum": "ZpLDXjPjdY1BXZqNrFZ6sApXKALmN3m9j6pp/2xxkxY="
     },
     {
@@ -38,8 +38,8 @@
           "subdir": "grafonnet-base"
         }
       },
-      "version": "d69eca143c137a72d6a55f078dc0eef1a47cf61c",
-      "sum": "dnl+USRFJPZ/f+whbqA0X+qXg6xYzx3chl1rX1wgxYc="
+      "version": "bf8e76582d494f3c68e99a26a4a80c519896de8a",
+      "sum": "0GrcZOf33zjkbaOe7V58008KuciSHamOSjGQ/7LsYz4="
     },
     {
       "source": {
@@ -48,7 +48,7 @@
           "subdir": "jsonnet/v9.4.0"
         }
       },
-      "version": "f6c0c4cd6fc1902eb4f920d82315767cd61deea4",
+      "version": "5ff7cfd1f478de867a25c62a7a0106ce27a72a97",
       "sum": "b6KSW0/Z45K0W2dF+8ZPLV32uv0ApjIsShTjk/zHEbg="
     },
     {
@@ -58,8 +58,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "351bfae3eee23db305597f272ef29ec16f99ee49",
-      "sum": "tDR6yT2GVfw0wTU12iZH+m01HrbIr6g/xN+/8nzNkU0="
+      "version": "2f10b97239412c22a84d580d5c1499b8b6f564ef",
+      "sum": "wp/L/9smcsHIiy24DH5WWMv2fcSckN2Lw/m7qDszaWU="
     },
     {
       "source": {
@@ -78,8 +78,8 @@
           "subdir": "1.24"
         }
       },
-      "version": "610803705e9ec295ef2e4eeaa6b2f8fc1419e5b1",
-      "sum": "OcNQsWgCXnMSoWZNS7u9P9yn6d7HZk6/d/7++sgIc6Q="
+      "version": "44a9f3d21c089a01f62b22e25bdf553f488a74e8",
+      "sum": "ecHj4f4rxFPcqcu6rSdypniF5xMVRG9A8k+HwD87BTg="
     },
     {
       "source": {

--- a/blueprints/policies/service-protection/average-latency/config.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/config.libsonnet
@@ -23,17 +23,13 @@ serviceProtectionDefaults {
         selectors: serviceProtectionDefaults.selectors,
       },
       /**
-      * @param (policy.latency_baseliner.ema: aperture.spec.v1.EMAParameters) EMA parameters.
-      * @param (policy.latency_baseliner.latency_tolerance_multiplier: float64) Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if EMA of latency is 50ms and if Tolerance is 1.1, then service is considered to be in overloaded state if current latency is more than 55ms.
-      * @param (policy.latency_baseliner.latency_ema_limit_multiplier: float64) Current latency value is multiplied with this factor to calculate maximum envelope of Latency EMA.
+      * @param (policy.latency_baseliner.long_term_query_interval: string) Interval for long-term latency query, i.e. how far back in time the query is run.
+      * @param (policy.latency_baseliner.long_term_query_periodic_interval: string) Periodic interval for long-term latency query, i.e. how often the query is run.
+      * @param (policy.latency_baseliner.latency_tolerance_multiplier: float64) Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.
       */
-      ema: {
-        ema_window: '1500s',
-        warmup_window: '60s',
-        correction_factor_on_max_envelope_violation: 0.95,
-      },
-      latency_tolerance_multiplier: '__REQUIRED_FIELD__',
-      latency_ema_limit_multiplier: 2.0,
+      long_term_query_interval: '1800s',
+      long_term_query_periodic_interval: '30s',
+      latency_tolerance_multiplier: 1.25,
     },
   },
 

--- a/blueprints/policies/service-protection/average-latency/config.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/config.libsonnet
@@ -23,9 +23,9 @@ serviceProtectionDefaults {
         selectors: serviceProtectionDefaults.selectors,
       },
       /**
-      * @param (policy.latency_baseliner.long_term_query_interval: string) Interval for long-term latency query, i.e. how far back in time the query is run.
-      * @param (policy.latency_baseliner.long_term_query_periodic_interval: string) Periodic interval for long-term latency query, i.e. how often the query is run.
-      * @param (policy.latency_baseliner.latency_tolerance_multiplier: float64) Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.
+      * @param (policy.latency_baseliner.long_term_query_interval: string) Interval for long-term latency query, i.e., how far back in time the query is run. The value should be a string representing the duration in seconds.
+      * @param (policy.latency_baseliner.long_term_query_periodic_interval: string) Periodic interval for long-term latency query, i.e., how often the query is run. The value should be a string representing the duration in seconds.
+      * @param (policy.latency_baseliner.latency_tolerance_multiplier: float64) Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if the long-term average of latency is L and if the tolerance is T, then the service is considered to be in an overloaded state if the short-term average of latency is more than L*T.
       */
       long_term_query_interval: '1800s',
       long_term_query_periodic_interval: '30s',

--- a/blueprints/policies/service-protection/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection/average-latency/gen/definitions.json
@@ -108,18 +108,18 @@
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/FluxMeter"
             },
             "latency_tolerance_multiplier": {
-              "description": "Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.",
+              "description": "Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if the long-term average of latency is L and if the tolerance is T, then the service is considered to be in an overloaded state if the short-term average of latency is more than L*T.",
               "default": 1.25,
               "type": "number",
               "format": "double"
             },
             "long_term_query_interval": {
-              "description": "Interval for long-term latency query, i.e. how far back in time the query is run.",
+              "description": "Interval for long-term latency query, i.e., how far back in time the query is run. The value should be a string representing the duration in seconds.",
               "default": "1800s",
               "type": "string"
             },
             "long_term_query_periodic_interval": {
-              "description": "Periodic interval for long-term latency query, i.e. how often the query is run.",
+              "description": "Periodic interval for long-term latency query, i.e., how often the query is run. The value should be a string representing the duration in seconds.",
               "default": "30s",
               "type": "string"
             }

--- a/blueprints/policies/service-protection/average-latency/gen/definitions.json
+++ b/blueprints/policies/service-protection/average-latency/gen/definitions.json
@@ -92,7 +92,7 @@
         "latency_baseliner": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["flux_meter", "latency_tolerance_multiplier"],
+          "required": ["flux_meter"],
           "properties": {
             "flux_meter": {
               "description": "Flux Meter defines the scope of latency measurements.",
@@ -107,27 +107,21 @@
               "type": "object",
               "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/FluxMeter"
             },
-            "ema": {
-              "description": "EMA parameters.",
-              "default": {
-                "correction_factor_on_max_envelope_violation": 0.95,
-                "ema_window": "1500s",
-                "warmup_window": "60s"
-              },
-              "type": "object",
-              "$ref": "../../../../gen/jsonschema/_definitions.json#/definitions/EMAParameters"
-            },
-            "latency_ema_limit_multiplier": {
-              "description": "Current latency value is multiplied with this factor to calculate maximum envelope of Latency EMA.",
-              "default": 2,
-              "type": "number",
-              "format": "double"
-            },
             "latency_tolerance_multiplier": {
-              "description": "Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if EMA of latency is 50ms and if Tolerance is 1.1, then service is considered to be in overloaded state if current latency is more than 55ms.",
-              "default": "__REQUIRED_FIELD__",
+              "description": "Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.",
+              "default": 1.25,
               "type": "number",
               "format": "double"
+            },
+            "long_term_query_interval": {
+              "description": "Interval for long-term latency query, i.e. how far back in time the query is run.",
+              "default": "1800s",
+              "type": "string"
+            },
+            "long_term_query_periodic_interval": {
+              "description": "Periodic interval for long-term latency query, i.e. how often the query is run.",
+              "default": "30s",
+              "type": "string"
             }
           }
         }

--- a/blueprints/policies/service-protection/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values.yaml
@@ -49,19 +49,15 @@ policy:
       selectors:
         - control_point: __REQUIRED_FIELD__
           service: __REQUIRED_FIELD__
-    # EMA parameters.
-    # Type: aperture.spec.v1.EMAParameters
-    ema:
-      correction_factor_on_max_envelope_violation: 0.95
-      ema_window: "1500s"
-      warmup_window: "60s"
-    # Current latency value is multiplied with this factor to calculate maximum envelope of Latency EMA.
+    # Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.
     # Type: float64
-    latency_ema_limit_multiplier: 2
-    # Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if EMA of latency is 50ms and if Tolerance is 1.1, then service is considered to be in overloaded state if current latency is more than 55ms.
-    # Type: float64
-    # Required: True
-    latency_tolerance_multiplier: __REQUIRED_FIELD__
+    latency_tolerance_multiplier: 1.25
+    # Interval for long-term latency query, i.e. how far back in time the query is run.
+    # Type: string
+    long_term_query_interval: "1800s"
+    # Periodic interval for long-term latency query, i.e. how often the query is run.
+    # Type: string
+    long_term_query_periodic_interval: "30s"
 
 dashboard:
   # Additional filters to pass to each query to Grafana datasource.

--- a/blueprints/policies/service-protection/average-latency/gen/values.yaml
+++ b/blueprints/policies/service-protection/average-latency/gen/values.yaml
@@ -49,13 +49,13 @@ policy:
       selectors:
         - control_point: __REQUIRED_FIELD__
           service: __REQUIRED_FIELD__
-    # Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.
+    # Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if the long-term average of latency is L and if the tolerance is T, then the service is considered to be in an overloaded state if the short-term average of latency is more than L*T.
     # Type: float64
     latency_tolerance_multiplier: 1.25
-    # Interval for long-term latency query, i.e. how far back in time the query is run.
+    # Interval for long-term latency query, i.e., how far back in time the query is run. The value should be a string representing the duration in seconds.
     # Type: string
     long_term_query_interval: "1800s"
-    # Periodic interval for long-term latency query, i.e. how often the query is run.
+    # Periodic interval for long-term latency query, i.e., how often the query is run. The value should be a string representing the duration in seconds.
     # Type: string
     long_term_query_periodic_interval: "30s"
 

--- a/blueprints/policies/service-protection/average-latency/policy.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/policy.libsonnet
@@ -7,6 +7,8 @@ function(cfg, params={}, metadata={}) {
 
   local basePolicy = basePolicyFn(cfg, params, metadata),
 
+  local createQuery = function(policy_name, interval) 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))' % { policy_name: policy_name, interval: interval },
+
   // Add new components to basePolicy
   local policyDef = basePolicy.policyDef {
     circuit+: {
@@ -14,7 +16,7 @@ function(cfg, params={}, metadata={}) {
         spec.v1.Component.withQuery(
           spec.v1.Query.new()
           + spec.v1.Query.withPromql(
-            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))' % { policy_name: updatedConfig.policy.policy_name, interval: '30s' };
+            local q = createQuery(updatedConfig.policy.policy_name, '30s');
             spec.v1.PromQL.new()
             + spec.v1.PromQL.withQueryString(q)
             + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.evaluation_interval)
@@ -24,7 +26,7 @@ function(cfg, params={}, metadata={}) {
         spec.v1.Component.withQuery(
           spec.v1.Query.new()
           + spec.v1.Query.withPromql(
-            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))' % { policy_name: updatedConfig.policy.policy_name, interval: updatedConfig.policy.latency_baseliner.long_term_query_interval };
+            local q = createQuery(updatedConfig.policy.policy_name, updatedConfig.policy.latency_baseliner.long_term_query_interval);
             spec.v1.PromQL.new()
             + spec.v1.PromQL.withQueryString(q)
             + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.latency_baseliner.long_term_query_periodic_interval)

--- a/blueprints/policies/service-protection/average-latency/policy.libsonnet
+++ b/blueprints/policies/service-protection/average-latency/policy.libsonnet
@@ -14,28 +14,25 @@ function(cfg, params={}, metadata={}) {
         spec.v1.Component.withQuery(
           spec.v1.Query.new()
           + spec.v1.Query.withPromql(
-            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[30s]))' % { policy_name: updatedConfig.policy.policy_name };
+            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))' % { policy_name: updatedConfig.policy.policy_name, interval: '30s' };
             spec.v1.PromQL.new()
             + spec.v1.PromQL.withQueryString(q)
             + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.evaluation_interval)
             + spec.v1.PromQL.withOutPorts({ output: spec.v1.Port.withSignalName('SIGNAL') }),
           ),
         ),
-        spec.v1.Component.withArithmeticCombinator(spec.v1.ArithmeticCombinator.mul(
-          spec.v1.Port.withSignalName('SIGNAL'),
-          spec.v1.Port.withConstantSignal(updatedConfig.policy.latency_baseliner.latency_ema_limit_multiplier),
-          output=spec.v1.Port.withSignalName('MAX_EMA')
-        )),
-        spec.v1.Component.withEma(
-          spec.v1.EMA.withParameters(updatedConfig.policy.latency_baseliner.ema)
-          + spec.v1.EMA.withInPortsMixin(
-            spec.v1.EMA.inPorts.withInput(spec.v1.Port.withSignalName('SIGNAL'))
-            + spec.v1.EMA.inPorts.withMaxEnvelope(spec.v1.Port.withSignalName('MAX_EMA'))
-          )
-          + spec.v1.EMA.withOutPortsMixin(spec.v1.EMA.outPorts.withOutput(spec.v1.Port.withSignalName('SIGNAL_EMA')))
+        spec.v1.Component.withQuery(
+          spec.v1.Query.new()
+          + spec.v1.Query.withPromql(
+            local q = 'sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))/sum(increase(flux_meter_count{flow_status="OK", flux_meter_name="%(policy_name)s", policy_name="%(policy_name)s"}[%(interval)s]))' % { policy_name: updatedConfig.policy.policy_name, interval: updatedConfig.policy.latency_baseliner.long_term_query_interval };
+            spec.v1.PromQL.new()
+            + spec.v1.PromQL.withQueryString(q)
+            + spec.v1.PromQL.withEvaluationInterval(evaluation_interval=updatedConfig.policy.latency_baseliner.long_term_query_periodic_interval)
+            + spec.v1.PromQL.withOutPorts({ output: spec.v1.Port.withSignalName('SIGNAL_LONG_TERM') }),
+          ),
         ),
         spec.v1.Component.withArithmeticCombinator(spec.v1.ArithmeticCombinator.mul(
-          spec.v1.Port.withSignalName('SIGNAL_EMA'),
+          spec.v1.Port.withSignalName('SIGNAL_LONG_TERM'),
           spec.v1.Port.withConstantSignal(updatedConfig.policy.latency_baseliner.latency_tolerance_multiplier),
           output=spec.v1.Port.withSignalName('SETPOINT')
         )),

--- a/docs/content/reference/blueprints/policies/service-protection/average-latency.md
+++ b/docs/content/reference/blueprints/policies/service-protection/average-latency.md
@@ -204,42 +204,42 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <!-- vale off -->
 
-<a id="policy-latency-baseliner-ema"></a>
-
-<ParameterDescription
-    name='policy.latency_baseliner.ema'
-    description='EMA parameters.'
-    type='Object (aperture.spec.v1.EMAParameters)'
-    reference='../../../spec#e-m-a-parameters'
-    value='{"correction_factor_on_max_envelope_violation": 0.95, "ema_window": "1500s", "warmup_window": "60s"}'
-/>
-
-<!-- vale on -->
-
-<!-- vale off -->
-
-<a id="policy-latency-baseliner-latency-ema-limit-multiplier"></a>
-
-<ParameterDescription
-    name='policy.latency_baseliner.latency_ema_limit_multiplier'
-    description='Current latency value is multiplied with this factor to calculate maximum envelope of Latency EMA.'
-    type='Number (double)'
-    reference=''
-    value='2'
-/>
-
-<!-- vale on -->
-
-<!-- vale off -->
-
 <a id="policy-latency-baseliner-latency-tolerance-multiplier"></a>
 
 <ParameterDescription
     name='policy.latency_baseliner.latency_tolerance_multiplier'
-    description='Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if EMA of latency is 50ms and if Tolerance is 1.1, then service is considered to be in overloaded state if current latency is more than 55ms.'
+    description='Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.'
     type='Number (double)'
     reference=''
-    value='"__REQUIRED_FIELD__"'
+    value='1.25'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-latency-baseliner-long-term-query-interval"></a>
+
+<ParameterDescription
+    name='policy.latency_baseliner.long_term_query_interval'
+    description='Interval for long-term latency query, i.e. how far back in time the query is run.'
+    type='string'
+    reference=''
+    value='"1800s"'
+/>
+
+<!-- vale on -->
+
+<!-- vale off -->
+
+<a id="policy-latency-baseliner-long-term-query-periodic-interval"></a>
+
+<ParameterDescription
+    name='policy.latency_baseliner.long_term_query_periodic_interval'
+    description='Periodic interval for long-term latency query, i.e. how often the query is run.'
+    type='string'
+    reference=''
+    value='"30s"'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/blueprints/policies/service-protection/average-latency.md
+++ b/docs/content/reference/blueprints/policies/service-protection/average-latency.md
@@ -208,7 +208,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <ParameterDescription
     name='policy.latency_baseliner.latency_tolerance_multiplier'
-    description='Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if long-term average of latency is 50ms and if the tolerance is 1.1, then the service is considered to be in an overloaded state if short-term average of latency is more than 55ms.'
+    description='Tolerance factor beyond which the service is considered to be in overloaded state. E.g. if the long-term average of latency is L and if the tolerance is T, then the service is considered to be in an overloaded state if the short-term average of latency is more than L*T.'
     type='Number (double)'
     reference=''
     value='1.25'
@@ -222,7 +222,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <ParameterDescription
     name='policy.latency_baseliner.long_term_query_interval'
-    description='Interval for long-term latency query, i.e. how far back in time the query is run.'
+    description='Interval for long-term latency query, i.e., how far back in time the query is run. The value should be a string representing the duration in seconds.'
     type='string'
     reference=''
     value='"1800s"'
@@ -236,7 +236,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/policies/se
 
 <ParameterDescription
     name='policy.latency_baseliner.long_term_query_periodic_interval'
-    description='Periodic interval for long-term latency query, i.e. how often the query is run.'
+    description='Periodic interval for long-term latency query, i.e., how often the query is run. The value should be a string representing the duration in seconds.'
     type='string'
     reference=''
     value='"30s"'

--- a/playground/scenarios/basic-service-protection/load-generator/test.js
+++ b/playground/scenarios/basic-service-protection/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/basic-service-protection/policies/basic-service-protection-cr.yaml
+++ b/playground/scenarios/basic-service-protection/policies/basic-service-protection-cr.yaml
@@ -54,34 +54,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="basic-service-protection",
             policy_name="basic-service-protection"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="basic-service-protection", policy_name="basic-service-protection"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="basic-service-protection",
+            policy_name="basic-service-protection"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="basic-service-protection", policy_name="basic-service-protection"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/demo-app-fan-in/load-generator/test.js
+++ b/playground/scenarios/demo-app-fan-in/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
@@ -90,34 +90,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="weighted-service-protection",
             policy_name="weighted-service-protection"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="weighted-service-protection", policy_name="weighted-service-protection"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="weighted-service-protection",
+            policy_name="weighted-service-protection"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="weighted-service-protection", policy_name="weighted-service-protection"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/demo-app-with-no-policy/load-generator/test.js
+++ b/playground/scenarios/demo-app-with-no-policy/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import encoding from "k6/encoding";
 import { vu } from "k6/execution";

--- a/playground/scenarios/feature-rollout/load-generator/test.js
+++ b/playground/scenarios/feature-rollout/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/graphql-rate-limiting/load-generator/test.js
+++ b/playground/scenarios/graphql-rate-limiting/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import crypto from "k6/crypto";
 import encoding from "k6/encoding";

--- a/playground/scenarios/java-service-protection/load-generator/test.js
+++ b/playground/scenarios/java-service-protection/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
@@ -124,34 +124,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service-protection",
             policy_name="service-protection"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="service-protection", policy_name="service-protection"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service-protection",
+            policy_name="service-protection"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="service-protection", policy_name="service-protection"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/prometheus-workload-prioritization/load-generator/test.js
+++ b/playground/scenarios/prometheus-workload-prioritization/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization-cr.yaml
+++ b/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization-cr.yaml
@@ -83,34 +83,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="prometheus-workload-prioritization",
             policy_name="prometheus-workload-prioritization"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="prometheus-workload-prioritization", policy_name="prometheus-workload-prioritization"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="prometheus-workload-prioritization",
+            policy_name="prometheus-workload-prioritization"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="prometheus-workload-prioritization", policy_name="prometheus-workload-prioritization"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/quota-scheduler/load-generator/test.js
+++ b/playground/scenarios/quota-scheduler/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/rabbitmq-queue-buildup/load-generator/test.js
+++ b/playground/scenarios/rabbitmq-queue-buildup/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import encoding from "k6/encoding";
 import { vu } from "k6/execution";

--- a/playground/scenarios/rate-limiting/load-generator/test.js
+++ b/playground/scenarios/rate-limiting/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/service-protection-auto-scale-escalation/load-generator/test.js
+++ b/playground/scenarios/service-protection-auto-scale-escalation/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale-cr.yaml
+++ b/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale-cr.yaml
@@ -107,34 +107,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="load-based-auto-scale",
             policy_name="load-based-auto-scale"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="load-based-auto-scale", policy_name="load-based-auto-scale"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="load-based-auto-scale",
+            policy_name="load-based-auto-scale"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="load-based-auto-scale", policy_name="load-based-auto-scale"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/service-protection-rl-escalation-kong/load-generator/test.js
+++ b/playground/scenarios/service-protection-rl-escalation-kong/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app-cr.yaml
@@ -130,34 +130,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service1-demo-app",
             policy_name="service1-demo-app"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="service1-demo-app", policy_name="service1-demo-app"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service1-demo-app",
+            policy_name="service1-demo-app"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="service1-demo-app", policy_name="service1-demo-app"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/service-protection-rl-escalation-nginx/load-generator/test.js
+++ b/playground/scenarios/service-protection-rl-escalation-nginx/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app-cr.yaml
@@ -130,34 +130,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service1-demo-app",
             policy_name="service1-demo-app"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="service1-demo-app", policy_name="service1-demo-app"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service1-demo-app",
+            policy_name="service1-demo-app"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="service1-demo-app", policy_name="service1-demo-app"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/service-protection-rl-escalation/load-generator/test.js
+++ b/playground/scenarios/service-protection-rl-escalation/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app-cr.yaml
@@ -130,34 +130,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service1-demo-app",
             policy_name="service1-demo-app"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="service1-demo-app", policy_name="service1-demo-app"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="service1-demo-app",
+            policy_name="service1-demo-app"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="service1-demo-app", policy_name="service1-demo-app"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/scenarios/workload-prioritization/load-generator/test.js
+++ b/playground/scenarios/workload-prioritization/load-generator/test.js
@@ -1,4 +1,4 @@
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import { check, sleep } from "k6";
 import { vu } from "k6/execution";
 import http from "k6/http";

--- a/playground/scenarios/workload-prioritization/policies/workload-prioritization-cr.yaml
+++ b/playground/scenarios/workload-prioritization/policies/workload-prioritization-cr.yaml
@@ -74,34 +74,19 @@ spec:
           query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="workload-prioritization",
             policy_name="workload-prioritization"}[30s]))/sum(increase(flux_meter_count{flow_status="OK",
             flux_meter_name="workload-prioritization", policy_name="workload-prioritization"}[30s]))
+    - query:
+        promql:
+          evaluation_interval: 30s
+          out_ports:
+            output:
+              signal_name: SIGNAL_LONG_TERM
+          query_string: sum(increase(flux_meter_sum{flow_status="OK", flux_meter_name="workload-prioritization",
+            policy_name="workload-prioritization"}[1800s]))/sum(increase(flux_meter_count{flow_status="OK",
+            flux_meter_name="workload-prioritization", policy_name="workload-prioritization"}[1800s]))
     - arithmetic_combinator:
         in_ports:
           lhs:
-            signal_name: SIGNAL
-          rhs:
-            constant_signal:
-              value: 2
-        operator: mul
-        out_ports:
-          output:
-            signal_name: MAX_EMA
-    - ema:
-        in_ports:
-          input:
-            signal_name: SIGNAL
-          max_envelope:
-            signal_name: MAX_EMA
-        out_ports:
-          output:
-            signal_name: SIGNAL_EMA
-        parameters:
-          correction_factor_on_max_envelope_violation: 0.95
-          ema_window: 1500s
-          warmup_window: 60s
-    - arithmetic_combinator:
-        in_ports:
-          lhs:
-            signal_name: SIGNAL_EMA
+            signal_name: SIGNAL_LONG_TERM
           rhs:
             constant_signal:
               value: 1.1

--- a/playground/tanka/jsonnetfile.lock.json
+++ b/playground/tanka/jsonnetfile.lock.json
@@ -26,7 +26,7 @@
           "subdir": "grafonnet"
         }
       },
-      "version": "30280196507e0fe6fa978a3e0eaca3a62844f817",
+      "version": "a1d61cce1da59c71409b99b5c7568511fec661ea",
       "sum": "342u++/7rViR/zj2jeJOjshzglkZ1SY+hFNuyCBFMdc="
     },
     {
@@ -36,7 +36,7 @@
           "subdir": "gen/grafonnet-v9.4.0"
         }
       },
-      "version": "d69eca143c137a72d6a55f078dc0eef1a47cf61c",
+      "version": "bf8e76582d494f3c68e99a26a4a80c519896de8a",
       "sum": "ZpLDXjPjdY1BXZqNrFZ6sApXKALmN3m9j6pp/2xxkxY="
     },
     {
@@ -46,8 +46,8 @@
           "subdir": "grafonnet-base"
         }
       },
-      "version": "d69eca143c137a72d6a55f078dc0eef1a47cf61c",
-      "sum": "dnl+USRFJPZ/f+whbqA0X+qXg6xYzx3chl1rX1wgxYc="
+      "version": "bf8e76582d494f3c68e99a26a4a80c519896de8a",
+      "sum": "0GrcZOf33zjkbaOe7V58008KuciSHamOSjGQ/7LsYz4="
     },
     {
       "source": {
@@ -56,7 +56,7 @@
           "subdir": "jsonnet/v9.4.0"
         }
       },
-      "version": "f6c0c4cd6fc1902eb4f920d82315767cd61deea4",
+      "version": "5ff7cfd1f478de867a25c62a7a0106ce27a72a97",
       "sum": "b6KSW0/Z45K0W2dF+8ZPLV32uv0ApjIsShTjk/zHEbg="
     },
     {
@@ -66,8 +66,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "351bfae3eee23db305597f272ef29ec16f99ee49",
-      "sum": "tDR6yT2GVfw0wTU12iZH+m01HrbIr6g/xN+/8nzNkU0="
+      "version": "2f10b97239412c22a84d580d5c1499b8b6f564ef",
+      "sum": "wp/L/9smcsHIiy24DH5WWMv2fcSckN2Lw/m7qDszaWU="
     },
     {
       "source": {
@@ -76,8 +76,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "351bfae3eee23db305597f272ef29ec16f99ee49",
-      "sum": "2++XoPslyz02LRgsxREWxjLgYgiCIqhAtXCyVSvYcoE="
+      "version": "2f10b97239412c22a84d580d5c1499b8b6f564ef",
+      "sum": "0y3AFX9LQSpfWTxWKSwoLgbt0Wc9nnCwhMH2szKzHv0="
     },
     {
       "source": {
@@ -86,7 +86,7 @@
           "subdir": "tanka-util"
         }
       },
-      "version": "351bfae3eee23db305597f272ef29ec16f99ee49",
+      "version": "2f10b97239412c22a84d580d5c1499b8b6f564ef",
       "sum": "ShSIissXdvCy1izTCDZX6tY7qxCoepE5L+WJ52Hw7ZQ="
     },
     {
@@ -96,8 +96,8 @@
           "subdir": "doc-util"
         }
       },
-      "version": "be066653f33fcaa8467231f6334f6878b92fd8f9",
-      "sum": "fzESn29CRKzLap9jTpcUNSNBy7MzvzOxZo1LYWyIrGs="
+      "version": "ff76f6d8edde6366c6dcf81a356481b0e344566b",
+      "sum": "OxjkWDF0oHmwV52hhyoFW3bwtwgke8s/EOPNRiICPTI="
     },
     {
       "source": {
@@ -106,8 +106,8 @@
           "subdir": ""
         }
       },
-      "version": "90f2a60a37433d12cd913793b65479b5830b532f",
-      "sum": "53cZqeDhE5Oik8pxXUNT3tjMzUoRKf3uHJjk4F37gAI="
+      "version": "f6661c067c63d5f7472b0f4b1823ce7e08e1492f",
+      "sum": "YjBV4glGE30l4I0uY7nrVZmHWmrX2lqqy7YOTKDxch4="
     },
     {
       "source": {
@@ -116,8 +116,8 @@
           "subdir": "1.22"
         }
       },
-      "version": "610803705e9ec295ef2e4eeaa6b2f8fc1419e5b1",
-      "sum": "QKsc62wl5Wc+uxxP4NJCF1NidiPi9zjngbzIszFvesc="
+      "version": "44a9f3d21c089a01f62b22e25bdf553f488a74e8",
+      "sum": "+pMhSLOcwfOC74Snh1B2Dx32nmzx51PqsoEJBphmXqM="
     },
     {
       "source": {
@@ -126,8 +126,8 @@
           "subdir": "1.24"
         }
       },
-      "version": "2ff9e542231fce1ba6d880d1157c81724f176bc6",
-      "sum": "qJK1nFZIYKv/ttM1bZxqXJJ7AIp9UA7ytVZpC6yQYoA="
+      "version": "44a9f3d21c089a01f62b22e25bdf553f488a74e8",
+      "sum": "ecHj4f4rxFPcqcu6rSdypniF5xMVRG9A8k+HwD87BTg="
     },
     {
       "source": {
@@ -146,8 +146,8 @@
           "subdir": ""
         }
       },
-      "version": "5e44626d70c2bf2d35c37f3fee5a6261a5335cc6",
-      "sum": "F0lSJ5J+DUU7Y5u+j783bFLTHNd8Ir1IEkbXuK59RaA="
+      "version": "003ba5eadfbd69817d1215952133d3ecf99fbd92",
+      "sum": "2ZvQR3ld4JuX0PC3IYMri/jbeW7ko3ni2Ukrz2QnG3M="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
### Description of change

![screencapture-localhost-3000-d-1cafa24eadc87e0eeb9217b9179e31473bcfa21d-aperture-service-protection-2023-06-27-13_28_33](https://github.com/fluxninja/aperture/assets/1553055/c8381477-8019-424f-82d5-039c974fe8ea)

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

**New Feature:**
- Replaced EMA latency calculation with a long-term average latency calculation in the `average-latency` blueprint.
- Added two new parameters for the long-term query interval and periodic interval.
- Changed the tolerance factor from 2.0 to 1.25.

**Chore:**
- Updated the version of a dependency across multiple scenarios in the playground.

> 🎉 With every tick and tock of the clock,  
> Our code evolves, solid as a rock.  
> Latency measured with a new trick,  
> And dependencies updated quick.  
> Celebrate this change, let's pop the cork,  
> For this is how we shape our work! 🥂🚀
<!-- end of auto-generated comment: release notes by openai -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

New Feature: The `average-latency` blueprint of service-protection policies has been updated to use a long-term average latency calculation, with new parameters for query interval and periodic interval. The tolerance factor has also been changed from 2.0 to 1.25. This PR also includes an update to the `k6-utils` library version in some load-generator tests.

> "Latency calculations refined,
> Load generators now aligned.
> CodeRabbit's review so fine,
> Quality improved, line by line."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->