### PR TITLE
Fix load-scheduling use-case doc

### DIFF
--- a/docs/content/use-cases/load-scheduling/prioritization.md
+++ b/docs/content/use-cases/load-scheduling/prioritization.md
@@ -3,7 +3,7 @@ title: Prioritization
 keywords:
   - policies
   - scheduler
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ```mdx-code-block

--- a/docs/content/use-cases/load-scheduling/protection.md
+++ b/docs/content/use-cases/load-scheduling/protection.md
@@ -4,7 +4,7 @@ keywords:
   - policies
   - concurrency
   - service-protection
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 ```mdx-code-block


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Documentation:**
- Adjusted the sidebar positioning for two documentation pages. The `prioritization.md` page will now appear third in the sidebar (previously second), and the `protection.md` page will appear second (previously first). This change enhances the logical flow of the documentation.

> 📚 With a shift, a tweak, a slight reposition,
> 
> Our docs find a new, improved disposition.
> 
> Prioritization now takes a step back,
> 
> While Protection moves up the stack. 🎉
> 
> A toast to clarity, to order restored,
> 
> In our docs, wisdom is stored. 🥂
<!-- end of auto-generated comment: release notes by coderabbit.ai -->