### PR TITLE
Downgrade gcloud cli version to last working one

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 pre-commit 3.3.1
 bats 1.9.0
 python 3.11.4
-gcloud 437.0.0
+gcloud 429.0.0
 golang 1.20.5
 golangci-lint 1.53.3
 grpcurl 1.8.7
@@ -10,7 +10,7 @@ buf 1.17.0
 nodejs 20.1.0
 shellcheck 0.9.0
 yq 4.33.3
-helm 3.11.3
+helm 3.12.1
 kubectl 1.27.1
 kustomize 5.0.1
 kind 0.18.0


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Chore:**
- Added a new package `libffi-dev` to the list of installed packages for Ubuntu 18 in `.circleci/continue-workflows.yml`.
- Rearranged the order of operations in `.circleci/continue-workflows.yml`, moving the GCloud SOPS Auth command to execute before the conditional check for uploading to GCP.
- Modified a log message string in `cmd/aperture-agent/agent.go` from "aperture-agent app created" to "aperture-agent app create".

> 🎉 With every line of code, we strive,
> To make our software come alive.
> A tweak here, an addition there,
> Enhancing quality with utmost care. 🚀
> In this release, we've made some shifts,
> To give your experience uplifting lifts! 🎊
<!-- end of auto-generated comment: release notes by coderabbit.ai -->