### PR TITLE
Use MarshalVT to marshal CheckResponse

### DIFF
--- a/sdks/aperture-go/sdk/flow.go
+++ b/sdks/aperture-go/sdk/flow.go
@@ -8,7 +8,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // Flow is the interface that is returned to the user every time a CheckHTTP call through ApertureClient is made.
@@ -84,7 +83,7 @@ func (f *flow) End() error {
 	}
 	f.ended = true
 
-	checkResponseJSONBytes, err := protojson.Marshal(f.checkResponse)
+	checkResponseJSONBytes, err := f.checkResponse.MarshalVT()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:
- Bug fix: Replaced usage of `protojson.Marshal` with a new method `MarshalVT` to marshal `f.checkResponse` in `sdks/aperture-go/sdk/flow.go`.
- Refactor: Made modifications to the logic and functionality of the code in `sdks/aperture-go/sdk/flow.go`.

> "In the realm of code, changes unfold,
> Bugs are fixed, logic takes hold.
> With careful review, improvements arise,
> Making the code a pleasant surprise. 🎉"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->