### PR TITLE
Create jsons for all the dashboards per policy in blueprint

### DIFF
--- a/blueprints/grafana/dashboard_group.libsonnet
+++ b/blueprints/grafana/dashboard_group.libsonnet
@@ -1,0 +1,18 @@
+local creator = import 'creator.libsonnet';
+local signals = import 'signals_dashboard.libsonnet';
+
+function(policyJSON, cfg) {
+  local policyName = cfg.policy.policy_name,
+  local mainDashboard = creator(policyJSON, cfg).dashboard,
+  local signalsDashboard = signals({
+    policy+: {
+      policy_name: policyName,
+    },
+    dashboard+: {
+      title: 'Aperture Signals - %s' % policyName,
+    },
+  }),
+
+  mainDashboard: mainDashboard,
+  signalsDashboard: signalsDashboard,
+}

--- a/blueprints/load-ramping/base/bundle.libsonnet
+++ b/blueprints/load-ramping/base/bundle.libsonnet
@@ -1,4 +1,4 @@
-local creator = import '../../grafana/creator.libsonnet';
+local creator = import '../../grafana/dashboard_group.libsonnet';
 local blueprint = import './load-ramping.libsonnet';
 
 local policy = blueprint.policy;
@@ -19,6 +19,7 @@ function(params, metadata={}) {
     [std.format('%s.yaml', c.policy.policy_name)]: p.policyDef { metadata: metadataWrapper },
   },
   dashboards: {
-    [std.format('%s.json', c.policy.policy_name)]: d.dashboard,
+    [std.format('%s.json', c.policy.policy_name)]: d.mainDashboard,
+    [std.format('signals-%s.json', c.policy.policy_name)]: d.signalsDashboard,
   },
 }

--- a/blueprints/load-scheduling/average-latency/bundle.libsonnet
+++ b/blueprints/load-scheduling/average-latency/bundle.libsonnet
@@ -1,4 +1,4 @@
-local creator = import '../../grafana/creator.libsonnet';
+local creator = import '../../grafana/dashboard_group.libsonnet';
 local blueprint = import './average-latency.libsonnet';
 
 local policy = blueprint.policy;
@@ -19,6 +19,7 @@ function(params, metadata={}) {
     [std.format('%s.yaml', c.policy.policy_name)]: p.policyDef { metadata: metadataWrapper },
   },
   dashboards: {
-    [std.format('%s.json', c.policy.policy_name)]: d.dashboard,
+    [std.format('%s.json', c.policy.policy_name)]: d.mainDashboard,
+    [std.format('signals-%s.json', c.policy.policy_name)]: d.signalsDashboard,
   },
 }

--- a/blueprints/load-scheduling/postgresql/bundle.libsonnet
+++ b/blueprints/load-scheduling/postgresql/bundle.libsonnet
@@ -1,4 +1,4 @@
-local creator = import '../../grafana/creator.libsonnet';
+local creator = import '../../grafana/dashboard_group.libsonnet';
 local blueprint = import './postgresql.libsonnet';
 
 local policy = blueprint.policy;
@@ -111,6 +111,7 @@ function(params, metadata={}) {
     [std.format('%s.yaml', c.policy.policy_name)]: p.policyDef { metadata: metadataWrapper },
   },
   dashboards: {
-    [std.format('%s.json', c.policy.policy_name)]: d.dashboard,
+    [std.format('%s.json', c.policy.policy_name)]: d.mainDashboard,
+    [std.format('signals-%s.json', c.policy.policy_name)]: d.signalsDashboard,
   },
 }

--- a/blueprints/load-scheduling/promql/bundle.libsonnet
+++ b/blueprints/load-scheduling/promql/bundle.libsonnet
@@ -1,4 +1,4 @@
-local creator = import '../../grafana/creator.libsonnet';
+local creator = import '../../grafana/dashboard_group.libsonnet';
 local blueprint = import './promql.libsonnet';
 
 local policy = blueprint.policy;
@@ -19,6 +19,7 @@ function(params, metadata={}) {
     [std.format('%s.yaml', c.policy.policy_name)]: p.policyDef { metadata: metadataWrapper },
   },
   dashboards: {
-    [std.format('%s.json', c.policy.policy_name)]: d.dashboard,
+    [std.format('%s.json', c.policy.policy_name)]: d.mainDashboard,
+    [std.format('signals-%s.json', c.policy.policy_name)]: d.signalsDashboard,
   },
 }

--- a/blueprints/quota-scheduling/base/bundle.libsonnet
+++ b/blueprints/quota-scheduling/base/bundle.libsonnet
@@ -1,4 +1,4 @@
-local creator = import '../../grafana/creator.libsonnet';
+local creator = import '../../grafana/dashboard_group.libsonnet';
 local blueprint = import './quota-scheduling.libsonnet';
 
 local policy = blueprint.policy;
@@ -16,7 +16,8 @@ function(params, metadata={}) {
   local d = creator(p.policyResource, c),
 
   dashboards: {
-    [std.format('%s.json', c.policy.policy_name)]: d.dashboard,
+    [std.format('%s.json', c.policy.policy_name)]: d.mainDashboard,
+    [std.format('signals-%s.json', c.policy.policy_name)]: d.signalsDashboard,
   },
   policies: {
     [std.format('%s-cr.yaml', c.policy.policy_name)]: p.policyResource,

--- a/blueprints/rate-limiting/base/bundle.libsonnet
+++ b/blueprints/rate-limiting/base/bundle.libsonnet
@@ -1,4 +1,4 @@
-local creator = import '../../grafana/creator.libsonnet';
+local creator = import '../../grafana/dashboard_group.libsonnet';
 local blueprint = import './rate-limiting.libsonnet';
 
 local policy = blueprint.policy;
@@ -16,7 +16,8 @@ function(params, metadata={}) {
   local d = creator(p.policyResource, c),
 
   dashboards: {
-    [std.format('%s.json', c.policy.policy_name)]: d.dashboard,
+    [std.format('%s.json', c.policy.policy_name)]: d.mainDashboard,
+    [std.format('signals-%s.json', c.policy.policy_name)]: d.signalsDashboard,
   },
   policies: {
     [std.format('%s-cr.yaml', c.policy.policy_name)]: p.policyResource,


### PR DESCRIPTION
### Description of change
Closes: GH-2214
##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:
- New Feature: Added a new function to create main and signals dashboards in Grafana.
- Bug fix: Modified code to generate two JSON files for each policy in load ramping, load scheduling, quota scheduling, and rate limiting blueprints.
- Refactor: Updated import statements and dashboard assignments in load scheduling, quota scheduling, and rate limiting blueprints.
- Documentation: None
- Style: None
- Test: None
- Chore: None
- Revert: None

> "Code changes dance,
> Dashboards come alive,
> Bugs take no chance,
> Release notes thrive."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->