### PR TITLE
Handle digest while controller deployment creation

### DIFF
--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -4012,6 +4012,9 @@ spec:
               image:
                 description: Image configuration
                 properties:
+                  digest:
+                    description: The digest (sha) of the image
+                    type: string
                   pullPolicy:
                     description: The ImagePullPolicy of the image
                     type: string

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -3749,6 +3749,9 @@ spec:
               image:
                 description: Image configuration
                 properties:
+                  digest:
+                    description: The digest (sha) of the image
+                    type: string
                   pullPolicy:
                     description: The ImagePullPolicy of the image
                     type: string

--- a/operator/api/common/common_types.go
+++ b/operator/api/common/common_types.go
@@ -50,7 +50,7 @@ type Image struct {
 	//+kubebuilder:validation:Optional
 	Tag string `json:"tag"`
 
-	// The digest (version) of the image
+	// The digest (sha) of the image
 	//+kubebuilder:validation:Optional
 	Digest string `json:"digest"`
 

--- a/operator/api/common/common_types.go
+++ b/operator/api/common/common_types.go
@@ -50,6 +50,10 @@ type Image struct {
 	//+kubebuilder:validation:Optional
 	Tag string `json:"tag" default:"latest"`
 
+	// The digest (version) of the image
+	//+kubebuilder:validation:Optional
+	Digest string `json:"digest,omitempty"`
+
 	// The ImagePullPolicy of the image
 	//+kubebuilder:validation:Optional
 	PullPolicy string `json:"pullPolicy" default:"IfNotPresent" validate:"oneof=Never Always IfNotPresent"`

--- a/operator/api/common/common_types.go
+++ b/operator/api/common/common_types.go
@@ -52,7 +52,7 @@ type Image struct {
 
 	// The digest (version) of the image
 	//+kubebuilder:validation:Optional
-	Digest string `json:"digest,omitempty"`
+	Digest string `json:"digest"`
 
 	// The ImagePullPolicy of the image
 	//+kubebuilder:validation:Optional

--- a/operator/api/common/common_types.go
+++ b/operator/api/common/common_types.go
@@ -48,7 +48,7 @@ type Image struct {
 
 	// The tag (version) of the image
 	//+kubebuilder:validation:Optional
-	Tag string `json:"tag" default:"latest"`
+	Tag string `json:"tag"`
 
 	// The digest (version) of the image
 	//+kubebuilder:validation:Optional

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -4013,7 +4013,7 @@ spec:
                 description: Image configuration
                 properties:
                   digest:
-                    description: The digest (version) of the image
+                    description: The digest (sha) of the image
                     type: string
                   pullPolicy:
                     description: The ImagePullPolicy of the image

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -4012,6 +4012,9 @@ spec:
               image:
                 description: Image configuration
                 properties:
+                  digest:
+                    description: The digest (version) of the image
+                    type: string
                   pullPolicy:
                     description: The ImagePullPolicy of the image
                     type: string

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -3750,7 +3750,7 @@ spec:
                 description: Image configuration
                 properties:
                   digest:
-                    description: The digest (version) of the image
+                    description: The digest (sha) of the image
                     type: string
                   pullPolicy:
                     description: The ImagePullPolicy of the image

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -3749,6 +3749,9 @@ spec:
               image:
                 description: Image configuration
                 properties:
+                  digest:
+                    description: The digest (version) of the image
+                    type: string
                   pullPolicy:
                     description: The ImagePullPolicy of the image
                     type: string

--- a/operator/controllers/agent/hook.go
+++ b/operator/controllers/agent/hook.go
@@ -44,7 +44,7 @@ func (agentHooks *AgentHooks) Handle(ctx context.Context, req admission.Request)
 	}
 
 	if (newAgent.Spec.Image.Digest == "" && newAgent.Spec.Image.Tag == "") || (newAgent.Spec.Image.Digest != "" && newAgent.Spec.Image.Tag != "") {
-		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided , but not both")
+		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided.")
 	}
 
 	if newAgent.Spec.Secrets.FluxNinjaExtension.Create && newAgent.Spec.Secrets.FluxNinjaExtension.Value == "" {

--- a/operator/controllers/agent/hook.go
+++ b/operator/controllers/agent/hook.go
@@ -43,8 +43,8 @@ func (agentHooks *AgentHooks) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if newAgent.Spec.Image.Digest == "" && newAgent.Spec.Image.Tag == "" {
-		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided")
+	if (newAgent.Spec.Image.Digest == "" && newAgent.Spec.Image.Tag == "") || (newAgent.Spec.Image.Digest != "" && newAgent.Spec.Image.Tag != "") {
+		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided , but not both")
 	}
 
 	if newAgent.Spec.Secrets.FluxNinjaExtension.Create && newAgent.Spec.Secrets.FluxNinjaExtension.Value == "" {

--- a/operator/controllers/agent/hook.go
+++ b/operator/controllers/agent/hook.go
@@ -43,6 +43,10 @@ func (agentHooks *AgentHooks) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	if newAgent.Spec.Image.Digest == "" && newAgent.Spec.Image.Tag == "" {
+		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided")
+	}
+
 	if newAgent.Spec.Secrets.FluxNinjaExtension.Create && newAgent.Spec.Secrets.FluxNinjaExtension.Value == "" {
 		return admission.Denied("The value for 'spec.secrets.fluxNinjaExtension.value' can not be empty when 'spec.secrets.fluxNinjaExtension.create' is set to true")
 	}

--- a/operator/controllers/agent/hook_sidecar_test.tpl
+++ b/operator/controllers/agent/hook_sidecar_test.tpl
@@ -5,6 +5,9 @@
     "name": "agent-sample"
   },
   "spec": {
+    "image":{
+      "digest": "sha:432234"
+    },
     "sidecar": {
       "enabled": true
     },

--- a/operator/controllers/agent/hook_test.tpl
+++ b/operator/controllers/agent/hook_test.tpl
@@ -5,6 +5,9 @@
     "name": "agent-sample"
   },
   "spec": {
+    "image":{
+      "digest": "sha:432234"
+    },
     "config": {
       "etcd": {
         "endpoints": [

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -449,6 +449,16 @@ func (r *AgentReconciler) checkDefaults(ctx context.Context, instance *agentv1al
 		return nil
 	}
 
+	if (instance.Spec.Image.Digest == "" && instance.Spec.Image.Tag == "") || (instance.Spec.Image.Digest != "" && instance.Spec.Image.Tag != "") {
+		instance.Status.Resources = controllers.FailedStatus
+		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "ValidationFailed", "Either 'spec.image.digest' or 'spec.image.tag' should be provided.")
+		errUpdate := r.updateStatus(ctx, instance)
+		if errUpdate != nil {
+			return errUpdate
+		}
+		return nil
+	}
+
 	if instance.Status.Resources == controllers.FailedStatus {
 		instance.Status.Resources = ""
 	}

--- a/operator/controllers/agent/reconciler_test.go
+++ b/operator/controllers/agent/reconciler_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			Expect(K8sClient.Create(Ctx, ns)).To(Succeed())
 
 			instance.Namespace = namespace
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			res, err := reconciler.Reconcile(Ctx, reconcile.Request{
@@ -155,6 +156,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			instance.Spec.Sidecar.EnableNamespaceByDefault = []string{namespace1}
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			ns1 := &corev1.Namespace{
@@ -265,6 +267,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			instance.Spec.Sidecar.Enabled = true
 			instance.Spec.Sidecar.EnableNamespaceByDefault = []string{namespace1}
 			instance.Spec.CommonSpec.ServiceAccountSpec.Create = false
+			instance.Spec.Image.Digest = TestDigest
 			encodedString := fmt.Sprintf("enc::%s::enc", base64.StdEncoding.EncodeToString([]byte(Test)))
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
@@ -385,6 +388,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			Expect(K8sClient.Create(Ctx, ns)).To(Succeed())
 
 			instance.Namespace = namespace
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			res, err := reconciler.Reconcile(Ctx, reconcile.Request{
@@ -444,6 +448,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			instance.Spec.CommonSpec.ServiceAccountSpec.Create = false
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
+			instance.Spec.Image.Digest = TestDigest
 
 			ns1 := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -539,6 +544,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			instance.Spec.Sidecar.Enabled = false
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			ns1 := &corev1.Namespace{
@@ -648,6 +654,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			instance.Spec.Sidecar.EnableNamespaceByDefault = []string{namespace1}
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			ns1 := &corev1.Namespace{

--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -130,6 +130,8 @@ var (
 	Test = "test"
 	// TestTwo string.
 	TestTwo = "test2"
+	// TestDigest string.
+	TestDigest = "sha256:1234567890"
 	// TestArray array.
 	TestArray = []string{Test}
 	// TestArrayTwo array.

--- a/operator/controllers/controller/hook.go
+++ b/operator/controllers/controller/hook.go
@@ -42,6 +42,10 @@ func (controllerHooks *ControllerHooks) Handle(ctx context.Context, req admissio
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	if controller.Spec.Image.Digest == "" && controller.Spec.Image.Tag == "" {
+		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided")
+	}
+
 	if controller.Spec.Secrets.FluxNinjaExtension.Create && controller.Spec.Secrets.FluxNinjaExtension.Value == "" {
 		return admission.Denied("The value for 'spec.secrets.fluxNinjaExtension.value' can not be empty when 'spec.secrets.fluxNinjaExtension.create' is set to true")
 	}

--- a/operator/controllers/controller/hook.go
+++ b/operator/controllers/controller/hook.go
@@ -42,8 +42,8 @@ func (controllerHooks *ControllerHooks) Handle(ctx context.Context, req admissio
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if controller.Spec.Image.Digest == "" && controller.Spec.Image.Tag == "" {
-		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided")
+	if (controller.Spec.Image.Digest == "" && controller.Spec.Image.Tag == "") || (controller.Spec.Image.Digest != "" && controller.Spec.Image.Tag != "") {
+		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided,but not both")
 	}
 
 	if controller.Spec.Secrets.FluxNinjaExtension.Create && controller.Spec.Secrets.FluxNinjaExtension.Value == "" {

--- a/operator/controllers/controller/hook.go
+++ b/operator/controllers/controller/hook.go
@@ -43,7 +43,7 @@ func (controllerHooks *ControllerHooks) Handle(ctx context.Context, req admissio
 	}
 
 	if (controller.Spec.Image.Digest == "" && controller.Spec.Image.Tag == "") || (controller.Spec.Image.Digest != "" && controller.Spec.Image.Tag != "") {
-		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided,but not both")
+		return admission.Denied("Either 'spec.image.digest' or 'spec.image.tag' should be provided.")
 	}
 
 	if controller.Spec.Secrets.FluxNinjaExtension.Create && controller.Spec.Secrets.FluxNinjaExtension.Value == "" {

--- a/operator/controllers/controller/hook_test.tpl
+++ b/operator/controllers/controller/hook_test.tpl
@@ -5,6 +5,9 @@
     "name": "controller-sample"
   },
   "spec": {
+    "image":{
+      "digest": "sha:432234"
+    },
     "config": {
       "etcd": {
         "endpoints": [

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -389,6 +389,16 @@ func (r *ControllerReconciler) checkDefaults(ctx context.Context, instance *cont
 		return nil
 	}
 
+	if (instance.Spec.Image.Digest == "" && instance.Spec.Image.Tag == "") || (instance.Spec.Image.Digest != "" && instance.Spec.Image.Tag != "") {
+		instance.Status.Resources = controllers.FailedStatus
+		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "ValidationFailed", "Either 'spec.image.digest' or 'spec.image.tag' should be provided.")
+		errUpdate := r.updateStatus(ctx, instance)
+		if errUpdate != nil {
+			return errUpdate
+		}
+		return nil
+	}
+
 	if instance.Status.Resources == controllers.FailedStatus {
 		instance.Status.Resources = ""
 	}

--- a/operator/controllers/controller/reconciler_test.go
+++ b/operator/controllers/controller/reconciler_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			Expect(K8sClient.Create(Ctx, ns)).To(Succeed())
 
 			instance.Namespace = namespace
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			res, err := reconciler.Reconcile(Ctx, reconcile.Request{
@@ -154,6 +155,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			instance.Namespace = namespace
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			res, err := reconciler.Reconcile(Ctx, reconcile.Request{
@@ -226,6 +228,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			Expect(K8sClient.Create(Ctx, ns)).To(Succeed())
 
 			instance.Namespace = namespace
+			instance.Spec.Image.Digest = TestDigest
 			Expect(K8sClient.Create(Ctx, instance)).To(Succeed())
 
 			res, err := reconciler.Reconcile(Ctx, reconcile.Request{
@@ -274,6 +277,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			instance.Spec.CommonSpec.ServiceAccountSpec.Create = false
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
+			instance.Spec.Image.Digest = TestDigest
 
 			os.Setenv("APERTURE_OPERATOR_CERT_DIR", CertDir)
 			os.Setenv("APERTURE_OPERATOR_CERT_NAME", "tls6.crt")

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -84,6 +84,10 @@ func PodSecurityContext(podSecurityContext common.PodSecurityContext) *corev1.Po
 // ImageString prepares image string from the provided Image struct.
 func ImageString(image common.Image, repository string) string {
 	var imageStr string
+	if image.Digest != "" && image.Registry != "" {
+		imageStr = fmt.Sprintf("%s/%s@%s", image.Registry, repository, image.Digest)
+		return imageStr
+	}
 	if image.Registry != "" {
 		imageStr = fmt.Sprintf("%s/%s:%s", image.Registry, repository, image.Tag)
 	} else {

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -84,8 +84,12 @@ func PodSecurityContext(podSecurityContext common.PodSecurityContext) *corev1.Po
 // ImageString prepares image string from the provided Image struct.
 func ImageString(image common.Image, repository string) string {
 	var imageStr string
-	if image.Digest != "" && image.Registry != "" {
-		imageStr = fmt.Sprintf("%s/%s@%s", image.Registry, repository, image.Digest)
+	if image.Digest != "" {
+		if image.Registry != "" {
+			imageStr = fmt.Sprintf("%s/%s@%s", image.Registry, repository, image.Digest)
+			return imageStr
+		}
+		imageStr = fmt.Sprintf("%s@%s", repository, image.Digest)
 		return imageStr
 	}
 	if image.Registry != "" {

--- a/operator/controllers/utils_test.go
+++ b/operator/controllers/utils_test.go
@@ -160,6 +160,51 @@ var _ = Describe("Tests for imageString", func() {
 		})
 	})
 
+	Context("When image digest is given with registry", func() {
+		It("returns correct image string", func() {
+			instance := &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      AppName,
+					Namespace: AppName,
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Image: common.AgentImage{
+						Image: common.Image{
+							Registry: Test,
+							Digest:   TestDigest,
+						},
+						Repository: Test,
+					},
+				},
+			}
+
+			result := ImageString(instance.Spec.Image.Image, instance.Spec.Image.Repository)
+			Expect(result).To(Equal("test/test@sha256:1234567890"))
+		})
+	})
+
+	Context("When image digest is given without registry", func() {
+		It("returns correct image string", func() {
+			instance := &agentv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      AppName,
+					Namespace: AppName,
+				},
+				Spec: agentv1alpha1.AgentSpec{
+					Image: common.AgentImage{
+						Image: common.Image{
+							Digest: TestDigest,
+						},
+						Repository: Test,
+					},
+				},
+			}
+
+			result := ImageString(instance.Spec.Image.Image, instance.Spec.Image.Repository)
+			Expect(result).To(Equal("test@sha256:1234567890"))
+		})
+	})
+
 	Context("When any image registry is not provided", func() {
 		It("returns correct image string", func() {
 			instance := &agentv1alpha1.Agent{


### PR DESCRIPTION
### Description of change
Adding digest field to image creation when operator create the deployment and digest filed is given in the CR.
##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added support for specifying image version using digest in the deployment creation process.
- Introduced validation checks to ensure either 'spec.image.digest' or 'spec.image.tag' is provided when creating a controller or agent deployment.

**Test:**
- Added test cases to verify the correct formation of image string with and without registry when a digest is provided.

> 🎉 With every line of code, we strive,
> To make our deployments come alive.
> Now with digests, precise and neat,
> Our image versions are complete! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->