### PR TITLE
Add default names to servers

### DIFF
--- a/pkg/net/grpc/server.go
+++ b/pkg/net/grpc/server.go
@@ -87,9 +87,9 @@ func (constructor ServerConstructor) Annotate() fx.Option {
 				constructor.provideServer,
 				fx.ParamTags(
 					config.NameTag(constructor.ListenerName),
-					config.GroupTag(constructor.Name)+` optional:"true"`,
-					config.GroupTag(constructor.Name)+` optional:"true"`,
-					config.GroupTag(constructor.Name)+` optional:"true"`,
+					config.GroupTag(constructor.Name),
+					config.GroupTag(constructor.Name),
+					config.GroupTag(constructor.Name),
 				),
 				fx.ResultTags(
 					config.NameTag(constructor.Name),

--- a/pkg/net/grpc/server.go
+++ b/pkg/net/grpc/server.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	defaultServerConfigKey = "server.grpc"
+	defaultServerName      = "main"
 	// Name of gmux based listener.
 	defaultGMuxListener = "grpc-gmux-listener"
 )
@@ -55,7 +56,7 @@ type GRPCServerConfig struct {
 
 // ServerConstructor holds fields to create an annotated gRPC Server.
 type ServerConstructor struct {
-	// Name of grpc server instance -- empty for main server
+	// Name of grpc server instance
 	Name string
 	// Name of listener instance
 	ListenerName string
@@ -73,6 +74,9 @@ type ServerConstructor struct {
 
 // Annotate creates an annotated instance of gRPC Server.
 func (constructor ServerConstructor) Annotate() fx.Option {
+	if constructor.Name == "" {
+		constructor.Name = defaultServerName
+	}
 	if constructor.ConfigKey == "" {
 		constructor.ConfigKey = defaultServerConfigKey
 	}

--- a/pkg/net/http/server.go
+++ b/pkg/net/http/server.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	defaultServerKey   = "server.http"
+	defaultServerName  = "main"
 	defaultHandlerName = "default"
 )
 
@@ -59,7 +60,7 @@ type HTTPServerConfig struct {
 
 // ServerConstructor holds fields to create an annotated HTTP Server.
 type ServerConstructor struct {
-	// Name of http server instance -- empty for main server
+	// Name of http server instance
 	Name string
 	// Name of listener instance
 	ListenerName string
@@ -73,6 +74,9 @@ type ServerConstructor struct {
 
 // Annotate creates an annotated instance of HTTP Server.
 func (constructor ServerConstructor) Annotate() fx.Option {
+	if constructor.Name == "" {
+		constructor.Name = defaultServerName
+	}
 	if constructor.ConfigKey == "" {
 		constructor.ConfigKey = defaultServerKey
 	}


### PR DESCRIPTION
### Description of change
This adds name to the main GRPC and HTTP servers, as empty names didn't work well with group tags.
Also, this removes `optional: true` flag from group annotations, as groups can't be optional in FX. This error was shadowed by having empty group name.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:
- Bug fix: Added a default name to the main server if it is empty.
- Refactor: Removed the `optional: true` flag from group annotations.

> "A bug was squashed, a refactor made,
> The code improved, no bugs displayed.
> With added default names and flags removed,
> The server runs smoothly, its behavior improved."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->