### PR TITLE
Read controller ID from config

### DIFF
--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1517,6 +1517,18 @@ FluxNinjaExtensionConfig is the configuration for FluxNinja ARC integration.
 API Key for this agent. If this key is not set, the extension won't be enabled.
 
 </dd>
+<dt>controller_id</dt>
+<dd>
+
+<!-- vale off -->
+
+(string)
+
+<!-- vale on -->
+
+Controller ID.
+
+</dd>
 <dt>disable_local_otel_pipeline</dt>
 <dd>
 

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -938,6 +938,18 @@ FluxNinjaExtensionConfig is the configuration for FluxNinja ARC integration.
 API Key for this agent. If this key is not set, the extension won't be enabled.
 
 </dd>
+<dt>controller_id</dt>
+<dd>
+
+<!-- vale off -->
+
+(string)
+
+<!-- vale on -->
+
+Controller ID.
+
+</dd>
 <dt>disable_local_otel_pipeline</dt>
 <dd>
 

--- a/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
+++ b/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
@@ -98,6 +98,11 @@ definitions:
                 $ref: '#/definitions/ClientConfig'
                 description: Client configuration.
                 x-go-tag-json: client
+            controller_id:
+                description: Controller ID.
+                type: string
+                x-go-name: ControllerID
+                x-go-tag-json: controller_id,omitempty
             disable_local_otel_pipeline:
                 default: false
                 description: Whether to configure local Prometheus OTel pipeline for metrics

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -30,6 +30,8 @@ type FluxNinjaExtensionConfig struct {
 	InstallationMode string `json:"installation_mode" validate:"oneof=KUBERNETES_SIDECAR KUBERNETES_DAEMONSET LINUX_BARE_METAL" default:"LINUX_BARE_METAL"`
 	// Whether to configure local Prometheus OTel pipeline for metrics
 	DisableLocalOTelPipeline bool `json:"disable_local_otel_pipeline" default:"false"`
+	// Controller ID.
+	ControllerID string `json:"controller_id,omitempty"`
 }
 
 // ClientConfig is the client configuration.

--- a/extensions/fluxninja/heartbeats/heartbeats.go
+++ b/extensions/fluxninja/heartbeats/heartbeats.go
@@ -3,13 +3,9 @@ package heartbeats
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
-	guuid "github.com/google/uuid"
-	"github.com/technosophos/moniker"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -122,13 +118,8 @@ func (h *Heartbeats) start(ctx context.Context, in *ConstructorIn) error {
 	return nil
 }
 
-func (h *Heartbeats) setupControllerInfo(ctx context.Context, etcdClient *etcdclient.Client) error {
+func (h *Heartbeats) setupControllerInfo(ctx context.Context, etcdClient *etcdclient.Client, controllerID string) error {
 	etcdPath := "/fluxninja/controllerid"
-	newID := guuid.NewString()
-	parts := strings.Split(newID, "-")
-	moniker := strings.Replace(moniker.New().Name(), " ", "-", 1)
-	controllerID := fmt.Sprintf("%s-%s", moniker, parts[0])
-
 	txn := etcdClient.Client.Txn(etcdClient.Client.Ctx())
 	resp, err := txn.If(clientv3.Compare(clientv3.CreateRevision(etcdPath), "=", 0)).
 		Then(clientv3.OpPut(etcdPath, controllerID)).

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1291,6 +1291,9 @@ spec:
                                 type: integer
                             type: object
                         type: object
+                      controller_id:
+                        description: Controller ID.
+                        type: string
                       disable_local_otel_pipeline:
                         description: Whether to configure local Prometheus OTel pipeline
                           for metrics

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -1175,6 +1175,9 @@ spec:
                                 type: integer
                             type: object
                         type: object
+                      controller_id:
+                        description: Controller ID.
+                        type: string
                       disable_local_otel_pipeline:
                         description: Whether to configure local Prometheus OTel pipeline
                           for metrics

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1291,6 +1291,9 @@ spec:
                                 type: integer
                             type: object
                         type: object
+                      controller_id:
+                        description: Controller ID.
+                        type: string
                       disable_local_otel_pipeline:
                         description: Whether to configure local Prometheus OTel pipeline
                           for metrics

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1175,6 +1175,9 @@ spec:
                                 type: integer
                             type: object
                         type: object
+                      controller_id:
+                        description: Controller ID.
+                        type: string
                       disable_local_otel_pipeline:
                         description: Whether to configure local Prometheus OTel pipeline
                           for metrics

--- a/operator/controllers/agent/secrets_test.go
+++ b/operator/controllers/agent/secrets_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Secret for Agent", func() {
 
 			expected := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-agent-apikey", AppName),
+					Name:      fmt.Sprintf("%s-aperture-agent-apikey", AppName),
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,

--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -42,7 +42,7 @@ const (
 	// OperatorName defines operator name.
 	OperatorName = AppName + "-operator"
 	// ControllerServiceName defines controller service name.
-	ControllerServiceName = AppName + "-controller"
+	ControllerServiceName = AppName + "-aperture"
 	// AgentServiceName defines agent service name.
 	AgentServiceName = AppName + "-agent"
 	// PodMutatingWebhookName defines agent service name.

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
 
 	controller "github.com/fluxninja/aperture/v2/cmd/aperture-controller/config"
 	"github.com/fluxninja/aperture/v2/operator/api/common"
@@ -120,16 +119,6 @@ var _ = Describe("ConfigMap for Controller", func() {
 						"app.kubernetes.io/instance":   AppName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
-					},
-					Annotations: nil,
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "fluxninja.com/v1alpha1",
-							Name:               instance.GetName(),
-							Kind:               "Controller",
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
-						},
 					},
 				},
 				Data: map[string]string{

--- a/operator/controllers/controller/deployment_test.go
+++ b/operator/controllers/controller/deployment_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Controller Deployment", func() {
 				},
 			}
 
-			result, err := deploymentForController(instance.DeepCopy(), logr.Logger{}, scheme.Scheme)
+			result, err := deploymentForController(instance.DeepCopy(), true, logr.Logger{}, scheme.Scheme)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Spec.Template.Spec.Containers).To(Equal(expected.Spec.Template.Spec.Containers))
@@ -618,7 +618,7 @@ var _ = Describe("Controller Deployment", func() {
 				},
 			}
 
-			result, err := deploymentForController(instance.DeepCopy(), logr.Logger{}, scheme.Scheme)
+			result, err := deploymentForController(instance.DeepCopy(), true, logr.Logger{}, scheme.Scheme)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Spec.Template.Spec.ImagePullSecrets).To(Equal(expected.Spec.Template.Spec.ImagePullSecrets))

--- a/operator/controllers/controller/reconciler_test.go
+++ b/operator/controllers/controller/reconciler_test.go
@@ -24,7 +24,9 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/fluxninja/aperture/v2/operator/controllers"
 	. "github.com/fluxninja/aperture/v2/operator/controllers"
+	"github.com/fluxninja/aperture/v2/pkg/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -89,12 +91,11 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 					Namespace: namespace,
 				},
 			})
-
 			createdControllerConfigMap := &corev1.ConfigMap{}
-			controllerConfigKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerConfigKey := types.NamespacedName{Name: controllers.ConfigMapName(instance), Namespace: namespace}
 
 			createdControllerService := &corev1.Service{}
-			controllerServiceKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerServiceKey := types.NamespacedName{Name: controllers.ServiceName(instance), Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
 			clusterRoleKey := types.NamespacedName{Name: ControllerServiceName}
@@ -103,16 +104,16 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			clusterRoleBindingKey := types.NamespacedName{Name: ControllerServiceName}
 
 			createdControllerServiceAccount := &corev1.ServiceAccount{}
-			controllerServiceAccountKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerServiceAccountKey := types.NamespacedName{Name: controllers.ServiceAccountName(instance), Namespace: namespace}
 
 			createdControllerDeployment := &appsv1.Deployment{}
-			controllerDeploymentKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerDeploymentKey := types.NamespacedName{Name: controllers.DeploymentName(instance), Namespace: namespace}
 
 			createdVWC := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 			vwcKey := types.NamespacedName{Name: ControllerServiceName}
 
 			createdControllerSecret := &corev1.Secret{}
-			controllerSecretKey := types.NamespacedName{Name: SecretName(Test, "controller", &instance.Spec.Secrets.FluxNinjaExtension), Namespace: namespace}
+			controllerSecretKey := types.NamespacedName{Name: Test, Namespace: namespace}
 
 			createdControllerCertSecret := &corev1.Secret{}
 			controllerCertSecretKey := types.NamespacedName{Name: fmt.Sprintf("%s-controller-cert", instance.GetName()), Namespace: namespace}
@@ -130,6 +131,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 				err7 := K8sClient.Get(Ctx, vwcKey, createdVWC)
 				err8 := K8sClient.Get(Ctx, controllerSecretKey, createdControllerSecret)
 				err9 := K8sClient.Get(Ctx, controllerCertSecretKey, createdControllerCertSecret)
+				log.Error().Msgf("err1: %v, err2: %v, err3: %v, err4: %v, err5: %v, err6: %v, err7: %v, err8: %v, err9: %v", err1, err2, err3, err4, err5, err6, err7, err8, err9)
 				return err1 == nil && err2 == nil && err3 == nil && err4 == nil &&
 					err5 == nil && err6 == nil && err7 == nil && err8 != nil && err9 == nil
 			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
@@ -162,10 +164,10 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			})
 
 			createdControllerConfigMap := &corev1.ConfigMap{}
-			controllerConfigKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerConfigKey := types.NamespacedName{Name: controllers.ConfigMapName(instance), Namespace: namespace}
 
 			createdControllerService := &corev1.Service{}
-			controllerServiceKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerServiceKey := types.NamespacedName{Name: controllers.ServiceName(instance), Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
 			clusterRoleKey := types.NamespacedName{Name: ControllerServiceName}
@@ -174,16 +176,16 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			clusterRoleBindingKey := types.NamespacedName{Name: ControllerServiceName}
 
 			createdControllerServiceAccount := &corev1.ServiceAccount{}
-			controllerServiceAccountKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerServiceAccountKey := types.NamespacedName{Name: controllers.ServiceAccountName(instance), Namespace: namespace}
 
 			createdControllerDeployment := &appsv1.Deployment{}
-			controllerDeploymentKey := types.NamespacedName{Name: ControllerServiceName, Namespace: namespace}
+			controllerDeploymentKey := types.NamespacedName{Name: controllers.DeploymentName(instance), Namespace: namespace}
 
 			createdVWC := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 			vwcKey := types.NamespacedName{Name: ControllerServiceName}
 
 			createdControllerSecret := &corev1.Secret{}
-			controllerSecretKey := types.NamespacedName{Name: SecretName(Test, "controller", &instance.Spec.Secrets.FluxNinjaExtension), Namespace: namespace}
+			controllerSecretKey := types.NamespacedName{Name: "aperture-test-controller-apikey", Namespace: namespace}
 
 			createdControllerCertSecret := &corev1.Secret{}
 			controllerCertSecretKey := types.NamespacedName{Name: fmt.Sprintf("%s-controller-cert", instance.GetName()), Namespace: namespace}

--- a/operator/controllers/controller/secrets_test.go
+++ b/operator/controllers/controller/secrets_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Secret for Controller", func() {
 
 			expected := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-controller-apikey", AppName),
+					Name:      fmt.Sprintf("%s-aperture-controller-apikey", AppName),
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,

--- a/operator/controllers/controller/serviceaccount_test.go
+++ b/operator/controllers/controller/serviceaccount_test.go
@@ -57,16 +57,6 @@ var _ = Describe("ServiceAccount for Controller", func() {
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
-					Annotations: nil,
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "fluxninja.com/v1alpha1",
-							Name:               instance.GetName(),
-							Kind:               "Controller",
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
-						},
-					},
 				},
 				AutomountServiceAccountToken: pointer.Bool(true),
 			}
@@ -112,15 +102,6 @@ var _ = Describe("ServiceAccount for Controller", func() {
 					Annotations: map[string]string{
 						Test:    Test,
 						TestTwo: TestTwo,
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "fluxninja.com/v1alpha1",
-							Name:               instance.GetName(),
-							Kind:               "Controller",
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
-						},
 					},
 				},
 				AutomountServiceAccountToken: pointer.Bool(false),

--- a/operator/controllers/utils_test.go
+++ b/operator/controllers/utils_test.go
@@ -1155,7 +1155,7 @@ var _ = Describe("Tests for secretName", func() {
 				},
 			}
 
-			expected := fmt.Sprintf("%s-agent-apikey", AppName)
+			expected := fmt.Sprintf("%s-aperture-agent-apikey", AppName)
 
 			result := SecretName(AppName, "agent", &instance.Spec.Secrets.FluxNinjaExtension)
 			Expect(result).To(Equal(expected))
@@ -1180,7 +1180,7 @@ var _ = Describe("Tests for secretName", func() {
 				},
 			}
 
-			expected := fmt.Sprintf("%s-controller-apikey", AppName)
+			expected := fmt.Sprintf("%s-aperture-controller-apikey", AppName)
 
 			result := SecretName(AppName, "controller", &instance.Spec.Secrets.FluxNinjaExtension)
 			Expect(result).To(Equal(expected))

--- a/operator/controllers/utils_test.go
+++ b/operator/controllers/utils_test.go
@@ -999,7 +999,7 @@ var _ = Describe("Tests for controllerVolumes", func() {
 				},
 			}
 
-			result := ControllerVolumes(instance.DeepCopy())
+			result := ControllerVolumes(true, instance.DeepCopy())
 			Expect(result).To(Equal(expected))
 		})
 	})
@@ -1054,7 +1054,7 @@ var _ = Describe("Tests for controllerVolumes", func() {
 				},
 			}
 
-			result := ControllerVolumes(instance.DeepCopy())
+			result := ControllerVolumes(true, instance.DeepCopy())
 			Expect(result).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Added a new configuration parameter `controller_id` to the FluxNinjaExtensionConfig.
- Modified the `setupControllerInfo` function in the `Heartbeats` package to accept controller ID as an argument.
- Changed the names of Kubernetes Secret objects and removed `OwnerReferences` and `Annotations` fields from several Kubernetes objects.
- Adjusted the secret key name and modified how controller names are generated.
- Changed the `ControllerServiceName` constant and added a boolean argument to the `ControllerVolumes` function.

> 🎉 With every line of code, we stride,
> Refactoring with pride, no place to hide.
> Secrets renamed, constants re-framed,
> Controller IDs tamed, our goals aimed. 🚀
> In the heart of the beats, where the controller meets,
> A new tale repeats, as the old one retreats. 🔄
<!-- end of auto-generated comment: release notes by coderabbit.ai -->