### PR TITLE
Make oauth in Prom client optional

### DIFF
--- a/pkg/prometheus/client.go
+++ b/pkg/prometheus/client.go
@@ -47,8 +47,8 @@ func Module() fx.Option {
 // ClientIn holds fields, parameters, to provide Prometheus Client.
 type ClientIn struct {
 	fx.In
-	HTTPClient   *http.Client `name:"prometheus.http-client"`
-	TokenSource  oauth2.TokenSource
+	HTTPClient   *http.Client       `name:"prometheus.http-client"`
+	TokenSource  oauth2.TokenSource `optional:"true"`
 	Unmarshaller config.Unmarshaller
 }
 


### PR DESCRIPTION
### Description of change
This fixes regression introduced in one of the previous PRs.

##### Checklist

- [ ] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Made `TokenSource` field optional in `ClientIn` struct of Prometheus client setup.

This change provides flexibility in the authentication process when interacting with the Prometheus API, allowing for configurations where a token source may not be necessary or available.

> 🎉 Here's to code that's lean and mean,
> 
> To the refactor that's been seen.
> 
> With `TokenSource` now optional, 🛠️
> 
> Our Prometheus client is more operational! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->