### PR TITLE
Operator name and unit test fixes

### DIFF
--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -41,8 +41,10 @@ const (
 	AppName = "aperture"
 	// OperatorName defines operator name.
 	OperatorName = AppName + "-operator"
+	// ControllerName defines controller name.
+	ControllerName = "controller"
 	// ControllerServiceName defines controller service name.
-	ControllerServiceName = AppName + "-aperture"
+	ControllerServiceName = AppName + "-controller"
 	// AgentServiceName defines agent service name.
 	AgentServiceName = AppName + "-agent"
 	// PodMutatingWebhookName defines agent service name.

--- a/operator/controllers/controller/clusterrole_test.go
+++ b/operator/controllers/controller/clusterrole_test.go
@@ -38,7 +38,7 @@ var _ = Describe("clusterRoleForController", func() {
 					APIVersion: "fluxninja.com/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{},
@@ -49,13 +49,13 @@ var _ = Describe("clusterRoleForController", func() {
 					Name: ControllerServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  OperatorName,
 					},
 					Annotations: map[string]string{
 						"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
-						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, AppName),
+						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, ControllerName),
 					},
 				},
 				Rules: []rbacv1.PolicyRule{
@@ -95,7 +95,7 @@ var _ = Describe("clusterRoleForController", func() {
 					APIVersion: "fluxninja.com/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -111,14 +111,14 @@ var _ = Describe("clusterRoleForController", func() {
 					Name: ControllerServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  OperatorName,
 						Test:                           Test,
 					},
 					Annotations: map[string]string{
 						"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
-						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, AppName),
+						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, ControllerName),
 						Test:                                  Test,
 					},
 				},
@@ -160,7 +160,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 				APIVersion: "fluxninja.com/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      AppName,
+				Name:      ControllerName,
 				Namespace: AppName,
 			},
 			Spec: controllerv1alpha1.ControllerSpec{
@@ -176,14 +176,14 @@ var _ = Describe("clusterRoleBindingForController", func() {
 				Name: ControllerServiceName,
 				Labels: map[string]string{
 					"app.kubernetes.io/name":       AppName,
-					"app.kubernetes.io/instance":   AppName,
+					"app.kubernetes.io/instance":   ControllerName,
 					"app.kubernetes.io/managed-by": OperatorName,
 					"app.kubernetes.io/component":  ControllerServiceName,
 					Test:                           Test,
 				},
 				Annotations: map[string]string{
 					"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
-					"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, AppName),
+					"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, ControllerName),
 					Test:                                  Test,
 				},
 			},

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -51,7 +51,7 @@ var _ = Describe("ConfigMap for Controller", func() {
 		It("returns correct ConfigMap", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -116,7 +116,7 @@ var _ = Describe("ConfigMap for Controller", func() {
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},

--- a/operator/controllers/controller/controller_suite_test.go
+++ b/operator/controllers/controller/controller_suite_test.go
@@ -113,7 +113,7 @@ var _ = BeforeSuite(func() {
 
 	DefaultControllerInstance = &controllerv1alpha1.Controller{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      AppName,
+			Name:      ControllerName,
 			Namespace: AppName,
 		},
 		Spec: controllerv1alpha1.ControllerSpec{

--- a/operator/controllers/controller/deployment_test.go
+++ b/operator/controllers/controller/deployment_test.go
@@ -96,14 +96,14 @@ var _ = Describe("Controller Deployment", func() {
 		It("returns correct deployment for Controller", func() {
 			selectorLabels := map[string]string{
 				"app.kubernetes.io/name":       AppName,
-				"app.kubernetes.io/instance":   AppName,
+				"app.kubernetes.io/instance":   ControllerName,
 				"app.kubernetes.io/managed-by": OperatorName,
 				"app.kubernetes.io/component":  ControllerServiceName,
 			}
 
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -293,14 +293,14 @@ var _ = Describe("Controller Deployment", func() {
 		It("returns correct deployment for Controller", func() {
 			selectorLabels := map[string]string{
 				"app.kubernetes.io/name":       AppName,
-				"app.kubernetes.io/instance":   AppName,
+				"app.kubernetes.io/instance":   ControllerName,
 				"app.kubernetes.io/managed-by": OperatorName,
 				"app.kubernetes.io/component":  ControllerServiceName,
 			}
 
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{

--- a/operator/controllers/controller/secrets_test.go
+++ b/operator/controllers/controller/secrets_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Secret for Controller", func() {
 		It("returns correct Secret", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -53,11 +53,11 @@ var _ = Describe("Secret for Controller", func() {
 
 			expected := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-aperture-controller-apikey", AppName),
+					Name:      fmt.Sprintf("%s-%s-controller-apikey", AppName, ControllerName),
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
@@ -88,7 +88,7 @@ var _ = Describe("Secret for Controller", func() {
 		It("returns correct Secret", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -113,7 +113,7 @@ var _ = Describe("Secret for Controller", func() {
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
@@ -146,7 +146,7 @@ var _ = Describe("Secret for Controller Cert", func() {
 		It("returns correct Secret", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{},
@@ -154,11 +154,11 @@ var _ = Describe("Secret for Controller Cert", func() {
 
 			expected := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-controller-cert", AppName),
+					Name:      fmt.Sprintf("%s-controller-cert", ControllerName),
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  AppName,
 					},
@@ -181,7 +181,7 @@ var _ = Describe("Secret for Controller Cert", func() {
 		It("returns correct Secret", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -193,11 +193,11 @@ var _ = Describe("Secret for Controller Cert", func() {
 
 			expected := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-controller-cert", AppName),
+					Name:      fmt.Sprintf("%s-controller-cert", ControllerName),
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  AppName,
 					},

--- a/operator/controllers/controller/serviceaccount_test.go
+++ b/operator/controllers/controller/serviceaccount_test.go
@@ -34,7 +34,7 @@ var _ = Describe("ServiceAccount for Controller", func() {
 		It("returns correct ServiceAccount", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -53,7 +53,7 @@ var _ = Describe("ServiceAccount for Controller", func() {
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
@@ -72,7 +72,7 @@ var _ = Describe("ServiceAccount for Controller", func() {
 		It("returns correct ServiceAccount", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -94,7 +94,7 @@ var _ = Describe("ServiceAccount for Controller", func() {
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 						Test:                           Test,

--- a/operator/controllers/controller/services_test.go
+++ b/operator/controllers/controller/services_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Service for Controller", func() {
 		It("returns correct Service", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -61,7 +61,7 @@ var _ = Describe("Service for Controller", func() {
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
@@ -87,7 +87,7 @@ var _ = Describe("Service for Controller", func() {
 					},
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
@@ -105,7 +105,7 @@ var _ = Describe("Service for Controller", func() {
 		It("returns correct Service", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -135,7 +135,7 @@ var _ = Describe("Service for Controller", func() {
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 						Test:                           Test,
@@ -165,7 +165,7 @@ var _ = Describe("Service for Controller", func() {
 					},
 					Selector: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},

--- a/operator/controllers/controller/validating_webhook_configuration_test.go
+++ b/operator/controllers/controller/validating_webhook_configuration_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ValidatingWebhookConfiguration for Controller", func() {
 					APIVersion: "fluxninja.com/v1alpha1",
 				},
 				ObjectMeta: v1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -61,13 +61,13 @@ var _ = Describe("ValidatingWebhookConfiguration for Controller", func() {
 					Name: ControllerServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
 					Annotations: map[string]string{
 						"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
-						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, AppName),
+						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, ControllerName),
 					},
 				},
 				Webhooks: []admissionregistrationv1.ValidatingWebhook{
@@ -119,7 +119,7 @@ var _ = Describe("ValidatingWebhookConfiguration for Controller", func() {
 					APIVersion: "fluxninja.com/v1alpha1",
 				},
 				ObjectMeta: v1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -144,14 +144,14 @@ var _ = Describe("ValidatingWebhookConfiguration for Controller", func() {
 					Name: ControllerServiceName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
-						"app.kubernetes.io/instance":   AppName,
+						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 						Test:                           Test,
 					},
 					Annotations: map[string]string{
 						"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
-						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, AppName),
+						"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, ControllerName),
 						Test:                                  Test,
 						TestTwo:                               TestTwo,
 					},

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 
 	DefaultControllerInstance = &controllerv1alpha1.Controller{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      AppName,
+			Name:      ControllerName,
 			Namespace: AppName,
 		},
 		Spec: controllerv1alpha1.ControllerSpec{

--- a/operator/controllers/utils_test.go
+++ b/operator/controllers/utils_test.go
@@ -800,7 +800,7 @@ var _ = Describe("Tests for controllerEnv", func() {
 		It("returns correct EnvVarSource", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -855,7 +855,7 @@ var _ = Describe("Tests for controllerEnv", func() {
 		It("returns correct EnvVarSource", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -901,7 +901,7 @@ var _ = Describe("Tests for controllerVolumeMounts", func() {
 		It("returns correct VolumeMount", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{},
@@ -928,7 +928,7 @@ var _ = Describe("Tests for controllerVolumeMounts", func() {
 		It("returns correct VolumeMount", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -970,7 +970,7 @@ var _ = Describe("Tests for controllerVolumes", func() {
 		It("returns correct Volume", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{},
@@ -1008,7 +1008,7 @@ var _ = Describe("Tests for controllerVolumes", func() {
 		It("returns correct Volume", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{
@@ -1065,7 +1065,7 @@ var _ = Describe("Tests for commonLabels", func() {
 		It("returns correct labels", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{},
@@ -1087,7 +1087,7 @@ var _ = Describe("Tests for commonLabels", func() {
 		It("returns correct labels", func() {
 			instance := &controllerv1alpha1.Controller{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      AppName,
+					Name:      ControllerName,
 					Namespace: AppName,
 				},
 				Spec: controllerv1alpha1.ControllerSpec{


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Introduced a new constant `ControllerName` and modified the value of `ControllerServiceName` to use this new constant.
- Replaced the usage of `AppName` with `ControllerName` in various fields across Kubernetes object metadata, deployment configuration, secret creation process, service account configuration, service configuration, and validating webhook configuration.

> 🎉 A name change, simple yet profound, 🔄
> From `AppName` to `ControllerName`, all around. 🌐
> Like a conductor leading an orchestra's sound, 🎵
> Our code now dances to a rhythm more sound. 💃🕺
<!-- end of auto-generated comment: release notes by coderabbit.ai -->