### PR TITLE
Add `api-key` flag to `aperturectl`

### DIFF
--- a/docs/content/reference/aperturectl/agents/agents.md
+++ b/docs/content/reference/aperturectl/agents/agents.md
@@ -23,6 +23,7 @@ aperturectl agents [flags]
 ### Options
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for agents

--- a/docs/content/reference/aperturectl/apply/apply.md
+++ b/docs/content/reference/aperturectl/apply/apply.md
@@ -19,6 +19,7 @@ Use this command to apply the Aperture Policies.
 ### Options
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for apply

--- a/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
+++ b/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
@@ -37,6 +37,7 @@ aperturectl apply dynamic-config --policy=rate-limiting --file=dynamic-config.ya
 ### Options inherited from parent commands
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/apply/policy/policy.md
+++ b/docs/content/reference/aperturectl/apply/policy/policy.md
@@ -39,6 +39,7 @@ aperturectl apply policy --dir=policies
 ### Options inherited from parent commands
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/auto-scale/auto-scale.md
+++ b/docs/content/reference/aperturectl/auto-scale/auto-scale.md
@@ -19,6 +19,7 @@ Use this command to query information about active AutoScale integrations
 ### Options
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for auto-scale

--- a/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
@@ -35,6 +35,7 @@ aperturectl auto-scale control-points
 ### Options inherited from parent commands
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/blueprints/generate/generate.md
+++ b/docs/content/reference/aperturectl/blueprints/generate/generate.md
@@ -31,6 +31,7 @@ aperturectl blueprints generate --name=policies/rate-limiting --values-file=rate
 ### Options
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --apply                  Apply generated policies on the Kubernetes cluster in the namespace where Aperture Controller is installed
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/decisions/decisions.md
+++ b/docs/content/reference/aperturectl/decisions/decisions.md
@@ -32,6 +32,7 @@ aperturectl decisions [flags]
 
 ```
       --all                    Get all decisions
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --decision-type string   Type of the decision to get (load_scheduler, rate_limiter, quota_scheduler, pod_scaler, sampler)

--- a/docs/content/reference/aperturectl/delete/delete.md
+++ b/docs/content/reference/aperturectl/delete/delete.md
@@ -19,6 +19,7 @@ Use this command to delete the Aperture Policies.
 ### Options
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for delete

--- a/docs/content/reference/aperturectl/delete/policy/policy.md
+++ b/docs/content/reference/aperturectl/delete/policy/policy.md
@@ -35,6 +35,7 @@ aperturectl delete policy --policy=rate-limiting
 ### Options inherited from parent commands
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/discovery/discovery.md
+++ b/docs/content/reference/aperturectl/discovery/discovery.md
@@ -19,6 +19,7 @@ Use this command to query information about active Discovery integrations
 ### Options
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for discovery

--- a/docs/content/reference/aperturectl/discovery/entities/entities.md
+++ b/docs/content/reference/aperturectl/discovery/entities/entities.md
@@ -40,6 +40,7 @@ aperturectl discovery entities --find-by=“ip=10.244.1.24”
 ### Options inherited from parent commands
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
@@ -35,6 +35,7 @@ aperturectl flow-control control-points
 ### Options inherited from parent commands
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/flow-control/flow-control.md
+++ b/docs/content/reference/aperturectl/flow-control/flow-control.md
@@ -19,6 +19,7 @@ Use this command to query information about active Flow Control integrations
 ### Options
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for flow-control

--- a/docs/content/reference/aperturectl/flow-control/preview/preview.md
+++ b/docs/content/reference/aperturectl/flow-control/preview/preview.md
@@ -32,6 +32,7 @@ aperturectl flow-control preview [--http] SERVICE CONTROL_POINT [flags]
 ### Options inherited from parent commands
 
 ```
+      --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --controller string      Address of Aperture controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS


### PR DESCRIPTION
### Description of change
This allows to interact with Cloud Controller using `aperturectl`.

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature**
- Added a new `api-key` flag to the `ControllerConn` struct in `controller.go`. This allows for API key inclusion in the metadata of outgoing contexts.
- Introduced a new command-line option `--api-key` to the `aperturectl` tool and its various commands. Users can now specify an API key for interacting with the Cloud Controller via FluxNinja ARC.

> 🎉 With keys in hand, we unlock the cloud, 🌤️
> 
> Through lines of code, speaking clear and loud. 🔊
> 
> The aperturectl tool gains more might, 💪
> 
> In the realm of APIs, it's a shining knight. 🛡️🔑
<!-- end of auto-generated comment: release notes by coderabbit.ai -->