### PR TITLE
Added migration support from the older name to new names in controller operator

### DIFF
--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -5695,7 +5695,6 @@ spec:
                     type: string
                 required:
                 - create
-                - name
                 type: object
               sidecar:
                 description: Sidecar defines the desired state of Sidecar setup for

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -5432,7 +5432,6 @@ spec:
                     type: string
                 required:
                 - create
-                - name
                 type: object
               sidecars:
                 description: Add additional sidecar containers
@@ -6751,6 +6750,8 @@ spec:
           status:
             description: ControllerStatus defines the observed state of Controller.
             properties:
+              isMigrationCompleted:
+                type: boolean
               resources:
                 type: string
             type: object

--- a/manifests/charts/aperture-controller/templates/controller-cr.yaml
+++ b/manifests/charts/aperture-controller/templates/controller-cr.yaml
@@ -139,6 +139,8 @@ spec:
             echo "Waiting for Etcd to be Healthy";
           done;
           echo "Etcd is healthy."
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
       volumeMounts:
         - mountPath: /etc/aperture/aperture-controller/config
           name: aperture-controller-config
@@ -155,6 +157,8 @@ spec:
             echo "Waiting for Prometheus to be Ready"; sleep 2;
           done;
           echo "Prometheus is ready."
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
       volumeMounts:
         - mountPath: /etc/aperture/aperture-controller/config
           name: aperture-controller-config

--- a/operator/api/common/security_types.go
+++ b/operator/api/common/security_types.go
@@ -22,6 +22,7 @@ type ServiceAccountSpec struct {
 	Create bool `json:"create" default:"true"`
 
 	// Existing ServiceAccount name to be used
+	//+kubebuilder:validation:Optional
 	Name string `json:"name" default:""`
 
 	// Additional Service Account annotations

--- a/operator/api/controller/v1alpha1/controller_types.go
+++ b/operator/api/controller/v1alpha1/controller_types.go
@@ -75,7 +75,8 @@ type PoliciesConfig struct {
 
 // ControllerStatus defines the observed state of Controller.
 type ControllerStatus struct {
-	Resources string `json:"resources,omitempty"`
+	Resources            string `json:"resources,omitempty"`
+	IsMigrationCompleted bool   `json:"isMigrationCompleted,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -5695,7 +5695,6 @@ spec:
                     type: string
                 required:
                 - create
-                - name
                 type: object
               sidecar:
                 description: Sidecar defines the desired state of Sidecar setup for

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -5432,7 +5432,6 @@ spec:
                     type: string
                 required:
                 - create
-                - name
                 type: object
               sidecars:
                 description: Add additional sidecar containers
@@ -6751,6 +6750,8 @@ spec:
           status:
             description: ControllerStatus defines the observed state of Controller.
             properties:
+              isMigrationCompleted:
+                type: boolean
               resources:
                 type: string
             type: object

--- a/operator/controllers/agent/secrets_test.go
+++ b/operator/controllers/agent/secrets_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Secret for Agent", func() {
 
 			expected := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-aperture-agent-apikey", AppName),
+					Name:      fmt.Sprintf("%s-agent-apikey", AppName),
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,

--- a/operator/controllers/controller/clusterrole_test.go
+++ b/operator/controllers/controller/clusterrole_test.go
@@ -51,7 +51,7 @@ var _ = Describe("clusterRoleForController", func() {
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
-						"app.kubernetes.io/component":  OperatorName,
+						"app.kubernetes.io/component":  ControllerServiceName,
 					},
 					Annotations: map[string]string{
 						"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
@@ -113,7 +113,7 @@ var _ = Describe("clusterRoleForController", func() {
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
-						"app.kubernetes.io/component":  OperatorName,
+						"app.kubernetes.io/component":  ControllerServiceName,
 						Test:                           Test,
 					},
 					Annotations: map[string]string{
@@ -153,7 +153,7 @@ var _ = Describe("clusterRoleForController", func() {
 })
 
 var _ = Describe("clusterRoleBindingForController", func() {
-	It("returns correct ClusterRoleBinding", func() {
+	It("returns correct ClusterRoleBinding when spec.ServiceAccountSpec.Create is false", func() {
 		instance := &controllerv1alpha1.Controller{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Controller",
@@ -195,7 +195,118 @@ var _ = Describe("clusterRoleBindingForController", func() {
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
+					Name:      "",
+					Namespace: instance.GetNamespace(),
+				},
+			},
+		}
+
+		result := clusterRoleBindingForController(instance.DeepCopy())
+		Expect(result).To(Equal(expected))
+	})
+
+	It("returns correct ClusterRoleBinding when spec.ServiceAccountSpec.Create is true and spec.ServiceAccountSpec.Name is not provided", func() {
+		instance := &controllerv1alpha1.Controller{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Controller",
+				APIVersion: "fluxninja.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ControllerName,
+				Namespace: AppName,
+			},
+			Spec: controllerv1alpha1.ControllerSpec{
+				CommonSpec: common.CommonSpec{
+					Labels:      TestMap,
+					Annotations: TestMap,
+					ServiceAccountSpec: common.ServiceAccountSpec{
+						Create: true,
+					},
+				},
+			},
+		}
+
+		expected := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ControllerServiceName,
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       AppName,
+					"app.kubernetes.io/instance":   ControllerName,
+					"app.kubernetes.io/managed-by": OperatorName,
+					"app.kubernetes.io/component":  ControllerServiceName,
+					Test:                           Test,
+				},
+				Annotations: map[string]string{
+					"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
+					"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, ControllerName),
+					Test:                                  Test,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     ControllerServiceName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
 					Name:      ControllerServiceName,
+					Namespace: instance.GetNamespace(),
+				},
+			},
+		}
+
+		result := clusterRoleBindingForController(instance.DeepCopy())
+		Expect(result).To(Equal(expected))
+	})
+
+	It("returns correct ClusterRoleBinding when spec.ServiceAccountSpec.Create is true and spec.ServiceAccountSpec.Name is provided", func() {
+		instance := &controllerv1alpha1.Controller{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Controller",
+				APIVersion: "fluxninja.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ControllerName,
+				Namespace: AppName,
+			},
+			Spec: controllerv1alpha1.ControllerSpec{
+				CommonSpec: common.CommonSpec{
+					Labels:      TestMap,
+					Annotations: TestMap,
+					ServiceAccountSpec: common.ServiceAccountSpec{
+						Create: true,
+						Name:   Test,
+					},
+				},
+			},
+		}
+
+		expected := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ControllerServiceName,
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       AppName,
+					"app.kubernetes.io/instance":   ControllerName,
+					"app.kubernetes.io/managed-by": OperatorName,
+					"app.kubernetes.io/component":  ControllerServiceName,
+					Test:                           Test,
+				},
+				Annotations: map[string]string{
+					"fluxninja.com/primary-resource-type": "Controller.fluxninja.com",
+					"fluxninja.com/primary-resource":      fmt.Sprintf("%s/%s", AppName, ControllerName),
+					Test:                                  Test,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     ControllerServiceName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      Test,
 					Namespace: instance.GetNamespace(),
 				},
 			},

--- a/operator/controllers/controller/configmaps.go
+++ b/operator/controllers/controller/configmaps.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
@@ -51,7 +52,7 @@ func configMapForControllerConfig(instance *controllerv1alpha1.Controller, schem
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.ConfigMapName(instance),
+			Name:        controllers.ControllerResourcesName(instance),
 			Namespace:   instance.GetNamespace(),
 			Labels:      controllers.CommonLabels(instance.Spec.Labels, instance.GetName(), controllers.ControllerServiceName),
 			Annotations: instance.Spec.Annotations,
@@ -59,6 +60,10 @@ func configMapForControllerConfig(instance *controllerv1alpha1.Controller, schem
 		Data: map[string]string{
 			"aperture-controller.yaml": string(config),
 		},
+	}
+
+	if err := ctrl.SetControllerReference(instance, cm, scheme); err != nil {
+		return nil, err
 	}
 
 	return cm, nil

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
 
 	controller "github.com/fluxninja/aperture/v2/cmd/aperture-controller/config"
 	"github.com/fluxninja/aperture/v2/operator/api/common"
@@ -119,6 +120,15 @@ var _ = Describe("ConfigMap for Controller", func() {
 						"app.kubernetes.io/instance":   ControllerName,
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "fluxninja.com/v1alpha1",
+							Name:               instance.GetName(),
+							Kind:               "Controller",
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
+						},
 					},
 				},
 				Data: map[string]string{

--- a/operator/controllers/controller/controller_suite_test.go
+++ b/operator/controllers/controller/controller_suite_test.go
@@ -152,6 +152,8 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
+	MinimumKubernetesVersionBool = true
+
 	err = config.UnmarshalYAML([]byte{}, &DefaultControllerInstance.Spec)
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/operator/controllers/controller/deployment.go
+++ b/operator/controllers/controller/deployment.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	controllerv1alpha1 "github.com/fluxninja/aperture/v2/operator/api/controller/v1alpha1"
@@ -65,7 +66,7 @@ func deploymentForController(instance *controllerv1alpha1.Controller, tlsEnabled
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.DeploymentName(instance),
+			Name:        controllers.ControllerResourcesName(instance),
 			Namespace:   instance.GetNamespace(),
 			Labels:      controllers.CommonLabels(spec.Labels, instance.GetName(), controllers.ControllerServiceName),
 			Annotations: spec.Annotations,
@@ -147,6 +148,10 @@ func deploymentForController(instance *controllerv1alpha1.Controller, tlsEnabled
 
 	if spec.Sidecars != nil {
 		dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, spec.Sidecars...)
+	}
+
+	if err := ctrl.SetControllerReference(instance, dep, scheme); err != nil {
+		return nil, err
 	}
 
 	return dep, nil

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -123,8 +123,8 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	instance := &controllerv1alpha1.Controller{}
 	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil && errors.IsNotFound(err) {
-		defer r.mutex.RUnlock()
 		r.mutex.RLock()
+		defer r.mutex.RUnlock()
 		if deleted, ok := r.ResourcesDeleted[req.NamespacedName.String()]; !ok || !deleted {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
@@ -161,8 +161,8 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 		}
 
-		defer r.mutex.Unlock()
 		r.mutex.Lock()
+		defer r.mutex.Unlock()
 		r.ResourcesDeleted[req.NamespacedName.String()] = true
 		return ctrl.Result{}, nil
 	}
@@ -199,9 +199,9 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.defaultsExecuted = true
 	}
 
-	defer r.mutex.Unlock()
 	r.mutex.Lock()
 	r.ResourcesDeleted[req.NamespacedName.String()] = false
+	r.mutex.Unlock()
 	if err = r.manageResources(ctx, logger, instance); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/operator/controllers/controller/reconciler_test.go
+++ b/operator/controllers/controller/reconciler_test.go
@@ -55,10 +55,11 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			instance.Name = Test
 			instance.Namespace = Test
 			reconciler = &ControllerReconciler{
-				Client:        K8sClient,
-				DynamicClient: K8sDynamicClient,
-				Scheme:        scheme.Scheme,
-				Recorder:      K8sManager.GetEventRecorderFor(AppName),
+				Client:           K8sClient,
+				DynamicClient:    K8sDynamicClient,
+				Scheme:           scheme.Scheme,
+				Recorder:         K8sManager.GetEventRecorderFor(AppName),
+				ResourcesDeleted: map[string]bool{},
 			}
 		})
 
@@ -93,25 +94,25 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 				},
 			})
 			createdControllerConfigMap := &corev1.ConfigMap{}
-			controllerConfigKey := types.NamespacedName{Name: controllers.ConfigMapName(instance), Namespace: namespace}
+			controllerConfigKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdControllerService := &corev1.Service{}
-			controllerServiceKey := types.NamespacedName{Name: controllers.ServiceName(instance), Namespace: namespace}
+			controllerServiceKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: ControllerServiceName}
+			clusterRoleKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			clusterRoleBindingKey := types.NamespacedName{Name: ControllerServiceName}
+			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
 
 			createdControllerServiceAccount := &corev1.ServiceAccount{}
 			controllerServiceAccountKey := types.NamespacedName{Name: controllers.ServiceAccountName(instance), Namespace: namespace}
 
 			createdControllerDeployment := &appsv1.Deployment{}
-			controllerDeploymentKey := types.NamespacedName{Name: controllers.DeploymentName(instance), Namespace: namespace}
+			controllerDeploymentKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdVWC := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-			vwcKey := types.NamespacedName{Name: ControllerServiceName}
+			vwcKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
 
 			createdControllerSecret := &corev1.Secret{}
 			controllerSecretKey := types.NamespacedName{Name: Test, Namespace: namespace}
@@ -166,28 +167,28 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			})
 
 			createdControllerConfigMap := &corev1.ConfigMap{}
-			controllerConfigKey := types.NamespacedName{Name: controllers.ConfigMapName(instance), Namespace: namespace}
+			controllerConfigKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdControllerService := &corev1.Service{}
-			controllerServiceKey := types.NamespacedName{Name: controllers.ServiceName(instance), Namespace: namespace}
+			controllerServiceKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: ControllerServiceName}
+			clusterRoleKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			clusterRoleBindingKey := types.NamespacedName{Name: ControllerServiceName}
+			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
 
 			createdControllerServiceAccount := &corev1.ServiceAccount{}
 			controllerServiceAccountKey := types.NamespacedName{Name: controllers.ServiceAccountName(instance), Namespace: namespace}
 
 			createdControllerDeployment := &appsv1.Deployment{}
-			controllerDeploymentKey := types.NamespacedName{Name: controllers.DeploymentName(instance), Namespace: namespace}
+			controllerDeploymentKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdVWC := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-			vwcKey := types.NamespacedName{Name: ControllerServiceName}
+			vwcKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
 
 			createdControllerSecret := &corev1.Secret{}
-			controllerSecretKey := types.NamespacedName{Name: "aperture-test-controller-apikey", Namespace: namespace}
+			controllerSecretKey := types.NamespacedName{Name: fmt.Sprintf("%s-controller-apikey", instance.GetName()), Namespace: namespace}
 
 			createdControllerCertSecret := &corev1.Secret{}
 			controllerCertSecretKey := types.NamespacedName{Name: fmt.Sprintf("%s-controller-cert", instance.GetName()), Namespace: namespace}
@@ -305,7 +306,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			clusterRoleBindingKey := types.NamespacedName{Name: ControllerServiceName}
+			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
 
 			Eventually(func() bool {
 				return K8sClient.Get(Ctx, clusterRoleBindingKey, createdClusterRoleBinding) == nil

--- a/operator/controllers/controller/secrets_test.go
+++ b/operator/controllers/controller/secrets_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Secret for Controller", func() {
 
 			expected := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-%s-controller-apikey", AppName, ControllerName),
+					Name:      fmt.Sprintf("%s-controller-apikey", ControllerName),
 					Namespace: AppName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,

--- a/operator/controllers/controller/serviceaccount.go
+++ b/operator/controllers/controller/serviceaccount.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	controllerv1alpha1 "github.com/fluxninja/aperture/v2/operator/api/controller/v1alpha1"
@@ -53,6 +54,10 @@ func serviceAccountForController(instance *controllerv1alpha1.Controller, scheme
 			Annotations: annotations,
 		},
 		AutomountServiceAccountToken: &saSpec.AutomountServiceAccountToken,
+	}
+
+	if err := ctrl.SetControllerReference(instance, sa, scheme); err != nil {
+		return nil, err
 	}
 
 	return sa, nil

--- a/operator/controllers/controller/serviceaccount_test.go
+++ b/operator/controllers/controller/serviceaccount_test.go
@@ -57,6 +57,15 @@ var _ = Describe("ServiceAccount for Controller", func() {
 						"app.kubernetes.io/managed-by": OperatorName,
 						"app.kubernetes.io/component":  ControllerServiceName,
 					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "fluxninja.com/v1alpha1",
+							Name:               instance.GetName(),
+							Kind:               "Controller",
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
+						},
+					},
 				},
 				AutomountServiceAccountToken: pointer.Bool(true),
 			}
@@ -102,6 +111,15 @@ var _ = Describe("ServiceAccount for Controller", func() {
 					Annotations: map[string]string{
 						Test:    Test,
 						TestTwo: TestTwo,
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "fluxninja.com/v1alpha1",
+							Name:               instance.GetName(),
+							Kind:               "Controller",
+							Controller:         pointer.Bool(true),
+							BlockOwnerDeletion: pointer.Bool(true),
+						},
 					},
 				},
 				AutomountServiceAccountToken: pointer.Bool(false),

--- a/operator/controllers/controller/services.go
+++ b/operator/controllers/controller/services.go
@@ -56,7 +56,7 @@ func serviceForController(instance *controllerv1alpha1.Controller, log logr.Logg
 
 	svc := &corev1.Service{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.ServiceName(instance),
+			Name:        controllers.ControllerResourcesName(instance),
 			Namespace:   instance.GetNamespace(),
 			Labels:      controllers.CommonLabels(spec.Labels, instance.GetName(), controllers.ControllerServiceName),
 			Annotations: spec.Annotations,

--- a/operator/controllers/controller/validating_webhook_configuration.go
+++ b/operator/controllers/controller/validating_webhook_configuration.go
@@ -31,7 +31,7 @@ func validatingWebhookConfiguration(instance *controllerv1alpha1.Controller, cer
 
 	validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.ControllerServiceName,
+			Name:        controllers.ControllerResourcesName(instance),
 			Labels:      controllers.CommonLabels(instance.Spec.Labels, instance.GetName(), controllers.ControllerServiceName),
 			Annotations: controllers.ControllerAnnotationsWithOwnerRef(instance),
 		},
@@ -40,7 +40,7 @@ func validatingWebhookConfiguration(instance *controllerv1alpha1.Controller, cer
 				Name: controllers.PolicyValidatingWebhookName,
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service: &admissionregistrationv1.ServiceReference{
-						Name:      controllers.ControllerServiceName,
+						Name:      controllers.ControllerResourcesName(instance),
 						Namespace: instance.GetNamespace(),
 						Path:      pointer.String(controllers.PolicyValidatingWebhookURI),
 						Port:      pointer.Int32(serverPort),

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -30,6 +30,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -379,7 +380,7 @@ func ControllerVolumes(tlsEnabled bool, instance *controllerv1alpha1.Controller)
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					DefaultMode: pointer.Int32(420),
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: ConfigMapName(instance),
+						Name: ControllerResourcesName(instance),
 					},
 				},
 			},
@@ -462,30 +463,20 @@ func SecretName(instance, component string, spec *common.APIKeySecret) string {
 		return name
 	}
 
-	return fmt.Sprintf("%s-%s-%s-apikey", AppName, instance, component)
+	return fmt.Sprintf("%s-%s-apikey", instance, component)
 }
 
-// DeploymentName generates a name for the controller deployment.
-func DeploymentName(instance *controllerv1alpha1.Controller) string {
-	return fmt.Sprintf("%s-%s", AppName, instance.GetName())
-}
-
-// ConfigMapName generates a name for the controller config map.
-func ConfigMapName(instance *controllerv1alpha1.Controller) string {
+// ControllerResourcesName generates a name for the controller related resources.
+func ControllerResourcesName(instance *controllerv1alpha1.Controller) string {
 	return fmt.Sprintf("%s-%s", AppName, instance.GetName())
 }
 
 // ServiceAccountName generate a name for the controller service account.
 func ServiceAccountName(instance *controllerv1alpha1.Controller) string {
-	if instance.Spec.ServiceAccountSpec.Create {
-		return fmt.Sprintf("%s-%s", AppName, instance.GetName())
+	if instance.Spec.ServiceAccountSpec.Create && instance.Spec.ServiceAccountSpec.Name == "" {
+		return ControllerResourcesName(instance)
 	}
 	return instance.Spec.ServiceAccountSpec.Name
-}
-
-// ServiceName generates a name for the service used to connect to the controller.
-func ServiceName(instance *controllerv1alpha1.Controller) string {
-	return fmt.Sprintf("%s-%s", AppName, instance.GetName())
 }
 
 // SecretDataKey fetches Key for ApiKey secret from config or generates the Key if not present in config.
@@ -524,6 +515,16 @@ func CheckCertificate() bool {
 	return err == nil
 }
 
+// GetCertificateDNSNames generates DNS names for the certificate.
+func GetCertificateDNSNames(dnsPrefix, namespace string) []string {
+	return []string{
+		dnsPrefix,
+		fmt.Sprintf("%s.%s", dnsPrefix, namespace),
+		fmt.Sprintf("%s.%s.svc", dnsPrefix, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", dnsPrefix, namespace),
+	}
+}
+
 // GenerateCertificate generates certificate and stores it in the desired location.
 func GenerateCertificate(dnsPrefix, namespace string) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 	var caPEM, serverCertPEM, serverPrivKeyPEM *bytes.Buffer
@@ -560,12 +561,7 @@ func GenerateCertificate(dnsPrefix, namespace string) (*bytes.Buffer, *bytes.Buf
 		Bytes: caBytes,
 	})
 
-	dnsNames := []string{
-		dnsPrefix,
-		fmt.Sprintf("%s.%s", dnsPrefix, namespace),
-		fmt.Sprintf("%s.%s.svc", dnsPrefix, namespace),
-		fmt.Sprintf("%s.%s.svc.cluster.local", dnsPrefix, namespace),
-	}
+	dnsNames := GetCertificateDNSNames(dnsPrefix, namespace)
 
 	commonName := fmt.Sprintf("%s.%s.svc", dnsPrefix, namespace)
 
@@ -678,7 +674,7 @@ func CheckAndGenerateCertForOperator(config *rest.Config) error {
 			block, _ := pem.Decode(certBytes)
 			var cert *x509.Certificate
 			cert, err = x509.ParseCertificate(block.Bytes)
-			if err == nil && cert.NotAfter.After(time.Now()) {
+			if err == nil && cert.NotAfter.After(time.Now()) && reflect.DeepEqual(cert.DNSNames, GetCertificateDNSNames(serviceName, namespace)) {
 				serverCertPEM = bytes.NewBuffer(secret.Data[OperatorCertName])
 				serverPrivKeyPEM = bytes.NewBuffer(secret.Data[OperatorCertKeyName])
 				caPEM = bytes.NewBuffer(secret.Data[OperatorCAName])
@@ -730,7 +726,7 @@ func GetOrGenerateCertificate(client client.Client, instance *controllerv1alpha1
 
 	generateCert := func() (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 		// generate certificates
-		serverCertPEM, serverPrivKeyPEM, caPEM, err := GenerateCertificate(ControllerServiceName, instance.GetNamespace())
+		serverCertPEM, serverPrivKeyPEM, caPEM, err := GenerateCertificate(ControllerResourcesName(instance), instance.GetNamespace())
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -761,7 +757,7 @@ func GetOrGenerateCertificate(client client.Client, instance *controllerv1alpha1
 	}
 
 	// regenerate certificate if it is expired
-	if time.Now().After(cert.NotAfter) {
+	if time.Now().After(cert.NotAfter) || reflect.DeepEqual(cert.DNSNames, GetCertificateDNSNames(ControllerResourcesName(instance), instance.GetNamespace())) {
 		return generateCert()
 	}
 

--- a/operator/controllers/utils_test.go
+++ b/operator/controllers/utils_test.go
@@ -1200,7 +1200,7 @@ var _ = Describe("Tests for secretName", func() {
 				},
 			}
 
-			expected := fmt.Sprintf("%s-aperture-agent-apikey", AppName)
+			expected := fmt.Sprintf("%s-agent-apikey", AppName)
 
 			result := SecretName(AppName, "agent", &instance.Spec.Secrets.FluxNinjaExtension)
 			Expect(result).To(Equal(expected))
@@ -1225,7 +1225,7 @@ var _ = Describe("Tests for secretName", func() {
 				},
 			}
 
-			expected := fmt.Sprintf("%s-aperture-controller-apikey", AppName)
+			expected := fmt.Sprintf("%s-controller-apikey", AppName)
 
 			result := SecretName(AppName, "controller", &instance.Spec.Secrets.FluxNinjaExtension)
 			Expect(result).To(Equal(expected))

--- a/operator/main.go
+++ b/operator/main.go
@@ -203,6 +203,7 @@ func main() {
 			Scheme:              mgr.GetScheme(),
 			Recorder:            mgr.GetEventRecorderFor("aperture-controller"),
 			MultipleControllers: multipleControllersEnabled,
+			ResourcesDeleted:    map[string]bool{},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Controller")
 			os.Exit(1)


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Updated naming conventions for Kubernetes resources in the operator controller, including Secret, ClusterRole, ConfigMap, Deployment, ServiceAccount, and others.
- Added migration support from old names to new ones in the controller operator.
- Introduced thread-safety for resource deletion tracking in the reconciler.
- Improved error handling in the reconciler.

**New Feature:**
- Added `IsMigrationCompleted` field to the `ControllerStatus` struct to track migration status.
- Modified URL of 'controller-prometheus' data source in the 'aperture-grafana' application.

> 🎉 Here's to the code that's ever evolving,  
> To the old names we're no longer involving.  
> With each refactor, we're problem-solving,  
> In the dance of progress, we're revolving! 🔄🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->