### PR TITLE
Update aperturectl docs

### DIFF
--- a/cmd/aperturectl/cmd/blueprints/dynamic-values.go
+++ b/cmd/aperturectl/cmd/blueprints/dynamic-values.go
@@ -23,7 +23,7 @@ var dynamicValuesCmd = &cobra.Command{
 	Long: `
 Provides a dynamic values file for a given Aperture Blueprint that can be then used to generate policies after customization`,
 	SilenceErrors: true,
-	Example:       `aperturectl blueprints dynamic-values --name=policies/rate-limiting --output-file=values.yaml`,
+	Example:       `aperturectl blueprints dynamic-values --name=rate-limiting/base --output-file=values.yaml`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if blueprintName == "" {
 			return fmt.Errorf("--name must be provided")

--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -43,9 +43,9 @@ var generateCmd = &cobra.Command{
 	Long: `
 Use this command to generate Aperture Policy related resources like Kubernetes Custom Resource, Grafana Dashboards and graphs in DOT and Mermaid format.`,
 	SilenceErrors: true,
-	Example: `aperturectl blueprints generate --name=policies/rate-limiting --values-file=rate-limiting.yaml
+	Example: `aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-limiting.yaml
 
-aperturectl blueprints generate --name=policies/rate-limiting --values-file=rate-limiting.yaml --apply`,
+aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-limiting.yaml --apply`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := utils.ReaderLock(blueprintsURIRoot)
 		if err != nil {

--- a/cmd/aperturectl/cmd/blueprints/values.go
+++ b/cmd/aperturectl/cmd/blueprints/values.go
@@ -46,7 +46,7 @@ var valuesCmd = &cobra.Command{
 	Long: `
 Provides a values file for a given Aperture Blueprint that can be then used to generate policies after customization`,
 	SilenceErrors: true,
-	Example:       `aperturectl blueprints values --name=policies/rate-limiting --output-file=values.yaml`,
+	Example:       `aperturectl blueprints values --name=rate-limiting/base --output-file=values.yaml`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if blueprintName == "" {
 			return fmt.Errorf("--name must be provided")

--- a/docs/content/get-started/policies/policies.md
+++ b/docs/content/get-started/policies/policies.md
@@ -73,7 +73,7 @@ For example, to generate a `policies/rate-limiting` policy, you can first
 generate a `values.yaml` file using the following command:
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints values --name=policies/rate-limiting --version={apertureVersion} --output-file=values.yaml</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints values --name=rate-limiting/base --version={apertureVersion} --output-file=values.yaml</CodeBlock>
 ```
 
 You can then edit the `values.yaml` to provide the required fields
@@ -104,7 +104,7 @@ Once the `values.yaml` file is ready, you can generate the blueprint using the
 following command:
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=policies/rate-limiting
+<CodeBlock language="bash">aperturectl blueprints generate --name=rate-limiting/base
 --values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
 ```
 
@@ -136,7 +136,7 @@ generated policies on a Kubernetes cluster in the namespace where the Aperture
 Controller is installed.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=policies/rate-limiting
+<CodeBlock language="bash">aperturectl blueprints generate --name=rate-limiting/base
 --values-file=values.yaml --apply --version={apertureVersion}</CodeBlock>
 ```
 
@@ -144,7 +144,7 @@ It uses the default configuration for Kubernetes cluster under `~/.kube/config`.
 You can pass the `--kube-config` flag to pass any other path.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=policies/rate-limiting
+<CodeBlock language="bash">aperturectl blueprints generate --name=rate-limiting/base
 --values-file=values.yaml --kube-config=/path/to/config --apply --version={apertureVersion}</CodeBlock>
 ```
 

--- a/docs/content/reference/aperturectl/blueprints/dynamic-values/dynamic-values.md
+++ b/docs/content/reference/aperturectl/blueprints/dynamic-values/dynamic-values.md
@@ -23,7 +23,7 @@ aperturectl blueprints dynamic-values [flags]
 ### Examples
 
 ```
-aperturectl blueprints dynamic-values --name=policies/rate-limiting --output-file=values.yaml
+aperturectl blueprints dynamic-values --name=rate-limiting/base --output-file=values.yaml
 ```
 
 ### Options

--- a/docs/content/reference/aperturectl/blueprints/generate/generate.md
+++ b/docs/content/reference/aperturectl/blueprints/generate/generate.md
@@ -23,9 +23,9 @@ aperturectl blueprints generate [flags]
 ### Examples
 
 ```
-aperturectl blueprints generate --name=policies/rate-limiting --values-file=rate-limiting.yaml
+aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-limiting.yaml
 
-aperturectl blueprints generate --name=policies/rate-limiting --values-file=rate-limiting.yaml --apply
+aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-limiting.yaml --apply
 ```
 
 ### Options

--- a/docs/content/reference/aperturectl/blueprints/values/values.md
+++ b/docs/content/reference/aperturectl/blueprints/values/values.md
@@ -23,7 +23,7 @@ aperturectl blueprints values [flags]
 ### Examples
 
 ```
-aperturectl blueprints values --name=policies/rate-limiting --output-file=values.yaml
+aperturectl blueprints values --name=rate-limiting/base --output-file=values.yaml
 ```
 
 ### Options


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Documentation:**
- Updated the `aperturectl` command usage examples in both the source code and documentation. The `--name` parameter value has been changed from `policies/rate-limiting` to `rate-limiting/base`.

> 🎉 With a tweak here, and a tweak there, 🛠️
> Our docs now have a brand new flair! 🌟
> No more confusion, no more despair, 🚫🤯
> Just clear commands floating in the air. 💻🌈
<!-- end of auto-generated comment: release notes by coderabbit.ai -->