### PR TITLE
Handle raw json strings as input to creator

### DIFF
--- a/blueprints/grafana/creator.libsonnet
+++ b/blueprints/grafana/creator.libsonnet
@@ -11,6 +11,8 @@ function(policyFile, cfg) {
   local policyJSON =
     if std.isObject(policyFile)
     then policyFile
+    else if std.startsWith(policyFile, '{')
+    then std.parseJson(policyFile)
     else std.parseYaml(policyFile),
   local componentsJSON =
     if std.objectHas(policyJSON, 'spec')


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### New Feature
- Added support for raw JSON strings as input in `blueprints/grafana/creator.libsonnet`. Now, if the `policyFile` starts with '{', it is parsed as JSON, otherwise, it continues to be parsed as YAML.

> 🎉 Here's to the code that now stands tall,
> Parsing JSON and YAML, it handles them all.
> With a '{' it begins, a new tale to spin,
> A feature so neat, it's sure to win! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->