### PR TITLE
Fixed certificate and cluster level resources names in operator for controller

### DIFF
--- a/operator/controllers/controller/clusterrole.go
+++ b/operator/controllers/controller/clusterrole.go
@@ -52,7 +52,7 @@ var rules = []rbacv1.PolicyRule{
 func clusterRoleForController(instance *controllerv1alpha1.Controller) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.ControllerResourcesName(instance),
+			Name:        controllers.ControllerResourcesNamespacedName(instance),
 			Labels:      controllers.CommonLabels(instance.Spec.Labels, instance.GetName(), controllers.ControllerServiceName),
 			Annotations: controllers.ControllerAnnotationsWithOwnerRef(instance),
 		},
@@ -66,14 +66,14 @@ func clusterRoleForController(instance *controllerv1alpha1.Controller) *rbacv1.C
 func clusterRoleBindingForController(instance *controllerv1alpha1.Controller) *rbacv1.ClusterRoleBinding {
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.ControllerResourcesName(instance),
+			Name:        controllers.ControllerResourcesNamespacedName(instance),
 			Labels:      controllers.CommonLabels(instance.Spec.Labels, instance.GetName(), controllers.ControllerServiceName),
 			Annotations: controllers.ControllerAnnotationsWithOwnerRef(instance),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     controllers.ControllerResourcesName(instance),
+			Name:     controllers.ControllerResourcesNamespacedName(instance),
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/operator/controllers/controller/clusterrole_test.go
+++ b/operator/controllers/controller/clusterrole_test.go
@@ -46,7 +46,7 @@ var _ = Describe("clusterRoleForController", func() {
 
 			expected := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ControllerServiceName,
+					Name: controllerName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   ControllerName,
@@ -108,7 +108,7 @@ var _ = Describe("clusterRoleForController", func() {
 
 			expected := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: ControllerServiceName,
+					Name: controllerName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   ControllerName,
@@ -173,7 +173,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 
 		expected := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: ControllerServiceName,
+				Name: controllerName,
 				Labels: map[string]string{
 					"app.kubernetes.io/name":       AppName,
 					"app.kubernetes.io/instance":   ControllerName,
@@ -190,7 +190,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
-				Name:     ControllerServiceName,
+				Name:     controllerName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -228,7 +228,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 
 		expected := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: ControllerServiceName,
+				Name: controllerName,
 				Labels: map[string]string{
 					"app.kubernetes.io/name":       AppName,
 					"app.kubernetes.io/instance":   ControllerName,
@@ -245,7 +245,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
-				Name:     ControllerServiceName,
+				Name:     controllerName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -284,7 +284,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 
 		expected := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: ControllerServiceName,
+				Name: controllerName,
 				Labels: map[string]string{
 					"app.kubernetes.io/name":       AppName,
 					"app.kubernetes.io/instance":   ControllerName,
@@ -301,7 +301,7 @@ var _ = Describe("clusterRoleBindingForController", func() {
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
-				Name:     ControllerServiceName,
+				Name:     controllerName,
 			},
 			Subjects: []rbacv1.Subject{
 				{

--- a/operator/controllers/controller/controller_suite_test.go
+++ b/operator/controllers/controller/controller_suite_test.go
@@ -56,6 +56,8 @@ var (
 	cancel  context.CancelFunc
 )
 
+var controllerName = "aperture-controller-aperture"
+
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 

--- a/operator/controllers/controller/reconciler_test.go
+++ b/operator/controllers/controller/reconciler_test.go
@@ -100,10 +100,10 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			controllerServiceKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
+			clusterRoleKey := types.NamespacedName{Name: controllers.ControllerResourcesNamespacedName(instance)}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
+			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesNamespacedName(instance)}
 
 			createdControllerServiceAccount := &corev1.ServiceAccount{}
 			controllerServiceAccountKey := types.NamespacedName{Name: controllers.ServiceAccountName(instance), Namespace: namespace}
@@ -112,7 +112,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			controllerDeploymentKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdVWC := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-			vwcKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
+			vwcKey := types.NamespacedName{Name: controllers.ControllerResourcesNamespacedName(instance)}
 
 			createdControllerSecret := &corev1.Secret{}
 			controllerSecretKey := types.NamespacedName{Name: Test, Namespace: namespace}
@@ -173,10 +173,10 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			controllerServiceKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdClusterRole := &rbacv1.ClusterRole{}
-			clusterRoleKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
+			clusterRoleKey := types.NamespacedName{Name: controllers.ControllerResourcesNamespacedName(instance)}
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
+			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesNamespacedName(instance)}
 
 			createdControllerServiceAccount := &corev1.ServiceAccount{}
 			controllerServiceAccountKey := types.NamespacedName{Name: controllers.ServiceAccountName(instance), Namespace: namespace}
@@ -185,7 +185,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			controllerDeploymentKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance), Namespace: namespace}
 
 			createdVWC := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-			vwcKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
+			vwcKey := types.NamespacedName{Name: controllers.ControllerResourcesNamespacedName(instance)}
 
 			createdControllerSecret := &corev1.Secret{}
 			controllerSecretKey := types.NamespacedName{Name: fmt.Sprintf("%s-controller-apikey", instance.GetName()), Namespace: namespace}
@@ -276,6 +276,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 
 			instance.Namespace = namespace
 			instance.Spec.CommonSpec.ServiceAccountSpec.Create = false
+			instance.Spec.CommonSpec.ServiceAccountSpec.Name = Test
 			instance.Spec.Secrets.FluxNinjaExtension.Create = true
 			instance.Spec.Secrets.FluxNinjaExtension.Value = Test
 			instance.Spec.Image.Digest = TestDigest
@@ -306,7 +307,7 @@ var _ = Describe("Controller Reconciler", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			createdClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesName(instance)}
+			clusterRoleBindingKey := types.NamespacedName{Name: controllers.ControllerResourcesNamespacedName(instance)}
 
 			Eventually(func() bool {
 				return K8sClient.Get(Ctx, clusterRoleBindingKey, createdClusterRoleBinding) == nil

--- a/operator/controllers/controller/validating_webhook_configuration.go
+++ b/operator/controllers/controller/validating_webhook_configuration.go
@@ -31,7 +31,7 @@ func validatingWebhookConfiguration(instance *controllerv1alpha1.Controller, cer
 
 	validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        controllers.ControllerResourcesName(instance),
+			Name:        controllers.ControllerResourcesNamespacedName(instance),
 			Labels:      controllers.CommonLabels(instance.Spec.Labels, instance.GetName(), controllers.ControllerServiceName),
 			Annotations: controllers.ControllerAnnotationsWithOwnerRef(instance),
 		},

--- a/operator/controllers/controller/validating_webhook_configuration_test.go
+++ b/operator/controllers/controller/validating_webhook_configuration_test.go
@@ -58,7 +58,7 @@ var _ = Describe("ValidatingWebhookConfiguration for Controller", func() {
 
 			expected := &admissionregistrationv1.ValidatingWebhookConfiguration{
 				ObjectMeta: v1.ObjectMeta{
-					Name: ControllerServiceName,
+					Name: controllerName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   ControllerName,
@@ -141,7 +141,7 @@ var _ = Describe("ValidatingWebhookConfiguration for Controller", func() {
 
 			expected := &admissionregistrationv1.ValidatingWebhookConfiguration{
 				ObjectMeta: v1.ObjectMeta{
-					Name: ControllerServiceName,
+					Name: controllerName,
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       AppName,
 						"app.kubernetes.io/instance":   ControllerName,

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -471,6 +471,11 @@ func ControllerResourcesName(instance *controllerv1alpha1.Controller) string {
 	return fmt.Sprintf("%s-%s", AppName, instance.GetName())
 }
 
+// ControllerResourcesNamespacedName generates a name for the controller related resources.
+func ControllerResourcesNamespacedName(instance *controllerv1alpha1.Controller) string {
+	return fmt.Sprintf("%s-%s-%s", AppName, instance.GetName(), instance.GetNamespace())
+}
+
 // ServiceAccountName generate a name for the controller service account.
 func ServiceAccountName(instance *controllerv1alpha1.Controller) string {
 	if instance.Spec.ServiceAccountSpec.Create && instance.Spec.ServiceAccountSpec.Name == "" {
@@ -757,7 +762,7 @@ func GetOrGenerateCertificate(client client.Client, instance *controllerv1alpha1
 	}
 
 	// regenerate certificate if it is expired
-	if time.Now().After(cert.NotAfter) || reflect.DeepEqual(cert.DNSNames, GetCertificateDNSNames(ControllerResourcesName(instance), instance.GetNamespace())) {
+	if time.Now().After(cert.NotAfter) || !reflect.DeepEqual(cert.DNSNames, GetCertificateDNSNames(ControllerResourcesName(instance), instance.GetNamespace())) {
 		return generateCert()
 	}
 


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```markdown
### Refactor:
- Changed the naming function for Kubernetes ClusterRole, ClusterRoleBinding, and ValidatingWebhookConfiguration resources in the operator controller.
- Modified the reconciliation logic in `ControllerReconciler`, specifically the migration process.

### New Feature:
- Introduced a new function `ControllerResourcesNamespacedName` to generate namespaced names for controller resources.
- Updated the condition in `GetOrGenerateCertificate` to regenerate a certificate if the DNS names do not match with the current ones.

### Chore:
- Added a new global variable `controllerName`.
```

> Here's to the code that's ever so bright, 🌟  
> Naming functions changed, making it right. ✅  
> Reconciliation logic got a new sight, 👀  
> And certificates now regenerate at night! 🌙
<!-- end of auto-generated comment: release notes by coderabbit.ai -->