### PR TITLE
Fix timout behavior when client dealine is not provided

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -240,6 +240,8 @@ message Scheduler {
 
       // Timeout for the flow in the workload.
       // If timeout is provided on the Check call as well, we pick the minimum of the two.
+      // If this override is not provided, the timeout provided in the check call is used.
+      // 0 timeout value implies that the request will not wait in the queue and will be accepted/dropped immediately.
       // This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
       google.protobuf.Duration queue_timeout = 3;
     }

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -2459,6 +2459,8 @@ type Scheduler_Workload_Parameters struct {
 	Tokens uint64 `protobuf:"varint,2,opt,name=tokens,proto3" json:"tokens,omitempty"`
 	// Timeout for the flow in the workload.
 	// If timeout is provided on the Check call as well, we pick the minimum of the two.
+	// If this override is not provided, the timeout provided in the check call is used.
+	// 0 timeout value implies that the request will not wait in the queue and will be accepted/dropped immediately.
 	// This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
 	QueueTimeout *durationpb.Duration `protobuf:"bytes,3,opt,name=queue_timeout,json=queueTimeout,proto3" json:"queue_timeout,omitempty"`
 }

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -2899,7 +2899,7 @@
           "x-go-tag-validate": "gt=0"
         },
         "queue_timeout": {
-          "description": "Timeout for the flow in the workload.\nIf timeout is provided on the Check call as well, we pick the minimum of the two.\nThis field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an \"s\" to indicate 'seconds.' For example, a value of \"10s\" would signify a duration of 10 seconds.",
+          "description": "Timeout for the flow in the workload.\nIf timeout is provided on the Check call as well, we pick the minimum of the two.\nIf this override is not provided, the timeout provided in the check call is used.\n0 timeout value implies that the request will not wait in the queue and will be accepted/dropped immediately.\nThis field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an \"s\" to indicate 'seconds.' For example, a value of \"10s\" would signify a duration of 10 seconds.",
           "type": "string"
         },
         "tokens": {

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -3137,6 +3137,8 @@ definitions:
                 description: |-
                     Timeout for the flow in the workload.
                     If timeout is provided on the Check call as well, we pick the minimum of the two.
+                    If this override is not provided, the timeout provided in the check call is used.
+                    0 timeout value implies that the request will not wait in the queue and will be accepted/dropped immediately.
                     This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
                 type: string
             tokens:

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -3771,6 +3771,8 @@ definitions:
                 description: |-
                     Timeout for the flow in the workload.
                     If timeout is provided on the Check call as well, we pick the minimum of the two.
+                    If this override is not provided, the timeout provided in the check call is used.
+                    0 timeout value implies that the request will not wait in the queue and will be accepted/dropped immediately.
                     This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
                 type: string
             tokens:

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -7239,7 +7239,10 @@ $$
 <!-- vale on -->
 
 Timeout for the flow in the workload. If timeout is provided on the Check call
-as well, we pick the minimum of the two. This field employs the
+as well, we pick the minimum of the two. If this override is not provided, the
+timeout provided in the check call is used. 0 timeout value implies that the
+request will not wait in the queue and will be accepted/dropped immediately.
+This field employs the
 [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON
 representation from Protocol Buffers. The format accommodates fractional seconds
 up to nine digits after the decimal point, offering nanosecond precision. Every

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -3077,6 +3077,8 @@ definitions:
                 description: |-
                     Timeout for the flow in the workload.
                     If timeout is provided on the Check call as well, we pick the minimum of the two.
+                    If this override is not provided, the timeout provided in the check call is used.
+                    0 timeout value implies that the request will not wait in the queue and will be accepted/dropped immediately.
                     This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
                 type: string
             tokens:

--- a/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
+++ b/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
@@ -445,6 +445,7 @@ func (s *Scheduler) Decide(ctx context.Context, labels labels.Labels) iface.Limi
 		defer cancel()
 		reqCtx = timeoutCtx
 	} else if hasWorkloadTimeout {
+		// If there is no client deadline but there is a workload timeout, we create a new context with the workload timeout.
 		timeoutCtx, cancel := context.WithTimeout(ctx, matchedWorkloadTimeout)
 		defer cancel()
 		reqCtx = timeoutCtx

--- a/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
+++ b/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
@@ -402,11 +402,9 @@ func (s *Scheduler) Decide(ctx context.Context, labels labels.Labels) iface.Limi
 	}
 
 	var matchedWorkloadTimeout time.Duration
+	hasWorkloadTimeout := false
 	if matchedWorkloadParametersProto.QueueTimeout != nil {
 		matchedWorkloadTimeout = matchedWorkloadParametersProto.QueueTimeout.AsDuration()
-	}
-	hasWorkloadTimeout := false
-	if matchedWorkloadTimeout > 0 {
 		hasWorkloadTimeout = true
 	}
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Bug fix:**
- Modified the timeout handling logic in the `Decide` function of `scheduler.go`. This change ensures that a context timeout is set based on the workload timeout even if no client deadline is given. 

**Documentation:**
- Added comments to the `queue_timeout` field in the `Scheduler` message in `flowcontrol.proto`, clarifying its behavior when no client deadline is provided and when its value is 0.
- Updated the documentation for a timeout field in a workload flow in `spec.md`, explaining the implication of a 0 timeout value and the behavior when no override is provided.

> 🎉 Here's to the code that now runs with grace,  
> With timeouts handled, no matter the case.  
> No client deadline? Don't show a frown,  
> The workload timeout won't let you down! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->