### PR TITLE
Check if controllerClientCert is not nil before trying to dereference it

### DIFF
--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -353,7 +353,14 @@ func (r *ControllerReconciler) deleteOlderInstances(ctx context.Context, log log
 		}
 	}
 
-	vwc := validatingWebhookConfiguration(singletonInstance.DeepCopy(), controllerClientCert.Bytes())
+	var certBytes []byte
+	if controllerClientCert == nil {
+		certBytes = []byte{}
+	} else {
+		certBytes = controllerClientCert.Bytes()
+	}
+
+	vwc := validatingWebhookConfiguration(singletonInstance.DeepCopy(), certBytes)
 	vwc.Name = controllers.ControllerServiceName
 	if err := r.Delete(ctx, vwc); err != nil && !errors.IsNotFound(err) {
 		log.Error(err, "Failed to delete old ValidatingWebhookConfiguration during Migration")


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```
### Bug Fix
- Added checks to prevent null pointer dereference errors in `reconciler.go`. This ensures that the `controllerClientCert` is not nil before dereferencing it. If it's nil, an empty byte slice is used instead. Also, it prevents dereferencing it to delete an old `ValidatingWebhookConfiguration`.

> 🎉 No more fear, no more fret,
> Null pointers we no longer get.
> With checks in place, we're set to go,
> Smooth sailing now in `reconciler.go`. 🚀
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->