### PR TITLE
Extract dashboard field in grouped dashboards

### DIFF
--- a/blueprints/grafana/dashboard_group.libsonnet
+++ b/blueprints/grafana/dashboard_group.libsonnet
@@ -11,7 +11,7 @@ function(policyJSON, cfg) {
     dashboard+: {
       title: 'Aperture Signals - %s' % policyName,
     },
-  }),
+  }).dashboard,
 
   mainDashboard: mainDashboard,
   signalsDashboard: signalsDashboard,


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Modified the return value of a function in `dashboard_group.libsonnet` to extract the 'dashboard' field from the returned object. This change enhances the specificity and clarity of the function's output.

> Here's to the code that we tweak and refine, 🎉
> Making it cleaner, one line at a time. 🧹
> With each little change, we're making it shine, 💎
> In the world of code, this is truly divine! 🌟
<!-- end of auto-generated comment: release notes by coderabbit.ai -->