### PR TITLE
Fixed volume not found issue in sidecar mode

### DIFF
--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -343,6 +343,14 @@ func (r *AgentReconciler) deleteSidecarModeResources(ctx context.Context, log lo
 			if err := r.Delete(ctx, secret); err != nil && !errors.IsNotFound(err) {
 				log.Error(err, fmt.Sprintf("failed to delete object of Secret '%s' in namespace %s", configMap.GetName(), ns.GetName()))
 			}
+
+			if slices.Contains(instance.Spec.Sidecar.EnableNamespaceByDefault, ns.GetName()) {
+				delete(ns.Labels, controllers.SidecarLabelKey)
+				ns := ns
+				if err := controllers.UpdateResource(r.Client, ctx, &ns); err != nil {
+					log.Error(err, fmt.Sprintf("failed to delete aperture label from namespace %s", ns.GetName()))
+				}
+			}
 		}
 	}
 }

--- a/operator/controllers/namespace/reconciler.go
+++ b/operator/controllers/namespace/reconciler.go
@@ -151,7 +151,10 @@ func (r *NamespaceReconciler) reconcileControllerCertConfigMap(ctx context.Conte
 		instance.Spec.ControllerClientCertConfig.ClientCertKeyName = controllers.ControllerClientCertKey
 	}
 
+	caFile := instance.Spec.ConfigSpec.AgentFunctions.ClientConfig.GRPCClient.ClientTLSConfig.CAFile
+	instance.Spec.ConfigSpec.AgentFunctions.ClientConfig.GRPCClient.ClientTLSConfig.CAFile = ""
 	configMap := agent.CreateAgentControllerClientCertConfigMapInNamespace(ctx, r.Client, instance, namespace)
+	instance.Spec.ConfigSpec.AgentFunctions.ClientConfig.GRPCClient.ClientTLSConfig.CAFile = caFile
 
 	if configMap == nil {
 		return nil


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```
### Bug fix
- Added a check for namespaces enabled by default in sidecar mode. If found, the sidecar label is removed from the namespace and the resource is updated.
- Fixed potential GRPC client functionality issue in `namespace/reconciler.go` by temporarily setting the `CAFile` property of the `GRPCClient.ClientTLSConfig` object to an empty string before creating a new agent controller client certificate config map.

> 🎉 Here's to the bugs we squash, 🐛  
> To the code that's now more posh! 💻  
> With each PR, we make a dash, 🏃‍♂️  
> Towards software that won't crash! 🚀
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->