### PR TITLE
Support override of controller TLS certificate & keys paths in CR

### DIFF
--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -459,10 +459,19 @@ func (r *ControllerReconciler) checkDefaults(ctx context.Context, instance *cont
 
 // manageResources creates/updates required resources.
 func (r *ControllerReconciler) manageResources(ctx context.Context, log logr.Logger, instance *controllerv1alpha1.Controller) error {
-	// When controller TLS is enabled, force the TLS configuration
+	certFilePath := instance.Spec.ConfigSpec.Server.TLS.CertFile
+	if certFilePath == "" {
+		certFilePath = path.Join(controllers.ControllerCertPath, controllers.ControllerCertName)
+	}
+
+	keyFilePath := instance.Spec.ConfigSpec.Server.TLS.KeyFile
+	if keyFilePath == "" {
+		keyFilePath = path.Join(controllers.ControllerCertPath, controllers.ControllerCertKeyName)
+	}
+
 	instance.Spec.ConfigSpec.Server.TLS = tlsconfig.ServerTLSConfig{
-		CertFile: path.Join(controllers.ControllerCertPath, controllers.ControllerCertName),
-		KeyFile:  path.Join(controllers.ControllerCertPath, controllers.ControllerCertKeyName),
+		CertFile: certFilePath,
+		KeyFile:  keyFilePath,
 		Enabled:  true,
 	}
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added support for overriding the paths of the controller's TLS certificate and keys from the Controller resource.
- Defaults to existing paths if no paths are provided in the resource.

> 🎉 With paths that now can sway,  
> Security finds a new way.  
> No path given? Do not fray,  
> Defaults will save the day! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->