### PR TITLE
Fix operator tests

### DIFF
--- a/operator/controllers/controller/deployment_test.go
+++ b/operator/controllers/controller/deployment_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Controller Deployment", func() {
 				},
 			}
 
-			result, err := deploymentForController(instance.DeepCopy(), true, logr.Logger{}, scheme.Scheme)
+			result, err := deploymentForController(instance.DeepCopy(), logr.Logger{}, scheme.Scheme)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Spec.Template.Spec.Containers).To(Equal(expected.Spec.Template.Spec.Containers))
@@ -618,7 +618,7 @@ var _ = Describe("Controller Deployment", func() {
 				},
 			}
 
-			result, err := deploymentForController(instance.DeepCopy(), true, logr.Logger{}, scheme.Scheme)
+			result, err := deploymentForController(instance.DeepCopy(), logr.Logger{}, scheme.Scheme)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Spec.Template.Spec.ImagePullSecrets).To(Equal(expected.Spec.Template.Spec.ImagePullSecrets))

--- a/operator/controllers/utils_test.go
+++ b/operator/controllers/utils_test.go
@@ -964,7 +964,7 @@ var _ = Describe("Tests for controllerVolumeMounts", func() {
 				},
 			}
 
-			result := ControllerVolumeMounts(true, instance.Spec.CommonSpec)
+			result := ControllerVolumeMounts(instance.Spec.CommonSpec)
 			Expect(result).To(Equal(expected))
 		})
 	})
@@ -1004,7 +1004,7 @@ var _ = Describe("Tests for controllerVolumeMounts", func() {
 				},
 			}
 
-			result := ControllerVolumeMounts(true, instance.Spec.CommonSpec)
+			result := ControllerVolumeMounts(instance.Spec.CommonSpec)
 			Expect(result).To(Equal(expected))
 		})
 	})
@@ -1044,7 +1044,7 @@ var _ = Describe("Tests for controllerVolumes", func() {
 				},
 			}
 
-			result := ControllerVolumes(true, instance.DeepCopy())
+			result := ControllerVolumes(instance.DeepCopy())
 			Expect(result).To(Equal(expected))
 		})
 	})
@@ -1099,7 +1099,7 @@ var _ = Describe("Tests for controllerVolumes", func() {
 				},
 			}
 
-			result := ControllerVolumes(true, instance.DeepCopy())
+			result := ControllerVolumes(instance.DeepCopy())
 			Expect(result).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```markdown
### Refactor:
- Removed a boolean parameter from the function calls `deploymentForController`, `ControllerVolumeMounts`, and `ControllerVolumes` in `operator/controllers/controller/deployment_test.go` and `operator/controllers/utils_test.go`. This simplifies the function signatures and streamlines their usage.

> 🎉 Code's been pruned, less is more, 🧹  
> No more booleans to ignore. 🚫  
> With every refactor, we soar, 🦅  
> Making our codebase less of a chore! 🥳
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->