### PR TITLE
Added job to upload policy to latest and Added support to load policy CR in apply and flags to force apply

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ workflows:
             operator/config/crd/bases/.* updated-aperture-charts true
             playground/resources/demo-app/.* updated-demo-app true
             playground/resources/java-demo-app/.* updated-java-demo-app true
+            playground/scenarios/service-protection-rl-escalation/policies/.*-cr.yaml updated-playground-policies true
             sdks/aperture-go/.* updated-aperture-go true
             sdks/aperture-js/.* updated-aperture-js true
             sdks/aperture-java/.* updated-aperture-java true

--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -71,6 +71,9 @@ parameters:
   updated-blueprints:
     type: boolean
     default: false
+  updated-playground-policies:
+    type: boolean
+    default: false
 
 jobs:
   build-push-add-tag:
@@ -1062,8 +1065,52 @@ jobs:
       - asdf_save_cache:
           cache_name: aperture-{{ .Environment.COMPONENT }}-packages
 
+  upload-policy-to-latest:
+    parameters:
+      policy-name:
+        type: string
+        description: Name of the playground policy to apply
+      scenario-name:
+        type: string
+        description: Name of the playground scenario to apply
+      controller-endpoint:
+        type: string
+        description: The endpoint of the controller to which the policy should be applied
+    executor: go-cimg-executor
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore go cache
+          keys:
+            - aperture-v1-upload-policies-go-cache
+      - run:
+          name: Apply Policy
+          working_directory: .
+          command: |
+            go run ./cmd/aperturectl/main.go apply policy --file ./playground/scenarios/<< parameters.scenario-name >>/policies/<< parameters.policy-name >>-cr.yaml \
+            --controller << parameters.controller-endpoint >> --api-key ${CONTROLLER_API_KEY} -f -s
+      - save_cache:
+          name: Save go cache
+          key: aperture-v1-upload-policies-go-cache
+          paths:
+            - ../.cache/go-build
+            - ./blueprints/vendor
+          when: on_success
+
 workflows:
   version: 2
+
+  upload-policy-to-latest:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - << pipeline.parameters.updated-playground-policies >>
+    jobs:
+      - upload-policy-to-latest:
+          name: upload-policy-to-latest
+          policy-name: service1-demo-app
+          scenario-name: service-protection-rl-escalation
+          controller-endpoint: fluxninja.latest.dev.fluxninja.com:443
 
   build-aperture-agent-bare-metal-package:
     when:

--- a/cmd/aperturectl/cmd/apply/policy.go
+++ b/cmd/aperturectl/cmd/apply/policy.go
@@ -17,13 +17,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	languagev1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/tui"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
 	"github.com/fluxninja/aperture/v2/operator/api"
 	policyv1alpha1 "github.com/fluxninja/aperture/v2/operator/api/policy/v1alpha1"
-	"github.com/fluxninja/aperture/v2/pkg/config"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 )
 
@@ -92,8 +92,7 @@ func getPolicies(policyDir string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		fileBase := info.Name()[:len(info.Name())-len(filepath.Ext(info.Name()))]
-		if filepath.Ext(info.Name()) == ".yaml" && !strings.HasSuffix(fileBase, "-cr") {
+		if filepath.Ext(info.Name()) == ".yaml" {
 			_, err := getPolicy(path)
 			if err != nil {
 				return err
@@ -117,7 +116,7 @@ func getPolicy(policyFile string) (*languagev1.Policy, error) {
 		}
 
 		policy = &languagev1.Policy{}
-		err = config.UnmarshalYAML(policyCR.Spec.Raw, policy)
+		err = yaml.Unmarshal(policyCR.Spec.Raw, policy)
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +134,7 @@ func getPolicyCR(policyFile string) (*policyv1alpha1.Policy, error) {
 	}
 
 	policyCR := &policyv1alpha1.Policy{}
-	err = config.UnmarshalYAML(policyBytes, policyCR)
+	err = yaml.Unmarshal(policyBytes, policyCR)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -31,6 +31,8 @@ func init() {
 	generateCmd.Flags().BoolVar(&noValidate, "no-validation", false, "Do not validate values.yaml file")
 	generateCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing output directory")
 	generateCmd.Flags().IntVar(&graphDepth, "graph-depth", 1, "Max depth of the graph when generating DOT and Mermaid files")
+	generateCmd.Flags().BoolVarP(&force, "force", "f", false, "Force apply policy even if it already exists")
+	generateCmd.Flags().BoolVarP(&selectAll, "select-all", "s", false, "Apply all the generated Policies")
 }
 
 type metadata struct {

--- a/cmd/aperturectl/cmd/blueprints/globals.go
+++ b/cmd/aperturectl/cmd/blueprints/globals.go
@@ -11,4 +11,6 @@ var (
 	noValidate     bool
 	overwrite      bool
 	graphDepth     int
+	force          bool
+	selectAll      bool
 )

--- a/docs/content/reference/aperturectl/apply/policy/policy.md
+++ b/docs/content/reference/aperturectl/apply/policy/policy.md
@@ -33,7 +33,9 @@ aperturectl apply policy --dir=policies
 ```
       --dir string    Path to directory containing Aperture Policy files
       --file string   Path to Aperture Policy file
+  -f, --force         Force apply policy even if it already exists
   -h, --help          help for policy
+  -s, --select-all    Apply all policies in the directory
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/reference/aperturectl/blueprints/generate/generate.md
+++ b/docs/content/reference/aperturectl/blueprints/generate/generate.md
@@ -35,6 +35,7 @@ aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-lim
       --apply                  Apply generated policies on the Kubernetes cluster in the namespace where Aperture Controller is installed
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
+  -f, --force                  Force apply policy even if it already exists
       --graph-depth int        Max depth of the graph when generating DOT and Mermaid files (default 1)
   -h, --help                   help for generate
       --insecure               Allow connection to controller running without TLS
@@ -45,6 +46,7 @@ aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-lim
       --no-yaml-modeline       Do not add YAML language server modeline to generated YAML files
       --output-dir string      Directory path where the generated Policy resources will be stored. If not provided, will use current directory
       --overwrite              Overwrite existing output directory
+  -s, --select-all             Apply all the generated Policies
       --skip-verify            Skip TLS certificate verification while connecting to controller
       --values-file string     Path to the values file for Blueprint's input
 ```


### PR DESCRIPTION
Fixes #2352 

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added a new CI/CD job `upload-policy-to-latest` that applies playground policies to a controller endpoint when updated.
- Introduced `force` and `select-all` flags in the `generateCmd` command for policy application. The `force` flag allows applying a policy even if it already exists, while the `select-all` flag applies all generated policies.

**Documentation:**
- Updated documentation to reflect the new features in the `generateCmd` command.

> 🎉 Here's to the code that keeps evolving, 🔄
> To the flags that keep revolving! 🚩
> With every push, we're problem-solving, 💡
> In the realm of automation, we're revolving! 🌐🎊
<!-- end of auto-generated comment: release notes by coderabbit.ai -->