### PR TITLE
Fix OTel ConfiProvider

### DIFF
--- a/extensions/fluxninja/otel/otel_test.go
+++ b/extensions/fluxninja/otel/otel_test.go
@@ -70,6 +70,7 @@ var _ = DescribeTable("FN Extension OTel", func(
 	Expect(err).NotTo(HaveOccurred())
 
 	c := configProvider.GetConfig()
+	Expect(c).ToNot(BeNil())
 	Expect(c.Receivers).To(Equal(expected.Receivers))
 	Expect(c.Processors).To(Equal(expected.Processors))
 	Expect(c.Exporters).To(Equal(expected.Exporters))

--- a/extensions/fluxninja/otel/otel_test.go
+++ b/extensions/fluxninja/otel/otel_test.go
@@ -69,10 +69,11 @@ var _ = DescribeTable("FN Extension OTel", func(
 	err = app.Start(context.TODO())
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(configProvider.MustGetConfig().Receivers).To(Equal(expected.Receivers))
-	Expect(configProvider.MustGetConfig().Processors).To(Equal(expected.Processors))
-	Expect(configProvider.MustGetConfig().Exporters).To(Equal(expected.Exporters))
-	Expect(configProvider.MustGetConfig().Service.Pipelines).To(Equal(expected.Service.Pipelines))
+	c := configProvider.GetConfig()
+	Expect(c.Receivers).To(Equal(expected.Receivers))
+	Expect(c.Processors).To(Equal(expected.Processors))
+	Expect(c.Exporters).To(Equal(expected.Exporters))
+	Expect(c.Service.Pipelines).To(Equal(expected.Service.Pipelines))
 
 	err = app.Stop(context.TODO())
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/otelcollector/config/provider.go
+++ b/pkg/otelcollector/config/provider.go
@@ -41,21 +41,21 @@ func (p *Provider) Retrieve(
 	_ string,
 	watchFn confmap.WatcherFunc,
 ) (*confmap.Retrieved, error) {
-	c := p.getConfig()
+	c := p.GetConfig()
 	if c == nil {
 		log.Bug().Msg("Retrieve after Shutdown")
 		return nil, errors.New("already shut down")
 	}
 
-	p.setWatchFunc(watchFn)
+	p.SetWatchFunc(watchFn)
 	return confmap.NewRetrieved(p.config.AsMap())
 }
 
 // Shutdown implements confmap.Provider.
 func (p *Provider) Shutdown(ctx context.Context) error {
 	// Prevent UpdateConfig to run after Shutdown.
-	p.setWatchFunc(nil)
-	p.setConfig(nil)
+	p.SetWatchFunc(nil)
+	p.SetConfig(nil)
 	return nil
 }
 
@@ -77,8 +77,8 @@ func (p *Provider) UpdateConfig(config *Config) {
 		hook(config)
 	}
 
-	p.setConfigIfNotNil(config)
-	wf := p.getWatchFunc()
+	p.SetConfigIfNotNil(config)
+	wf := p.GetWatchFunc()
 	if wf != nil {
 		wf(&confmap.ChangeEvent{})
 	}
@@ -102,19 +102,22 @@ func (p *Provider) AddMutatingHook(hook func(*Config)) {
 	p.UpdateConfig(p.config)
 }
 
-func (p *Provider) getConfig() *Config {
+// GetConfig returns the current config.
+func (p *Provider) GetConfig() *Config {
 	p.configLock.RLock()
 	defer p.configLock.RUnlock()
 	return p.config
 }
 
-func (p *Provider) setConfig(config *Config) {
+// SetConfig sets the new config, replacing the old one.
+func (p *Provider) SetConfig(config *Config) {
 	p.configLock.Lock()
 	defer p.configLock.Unlock()
 	p.config = config
 }
 
-func (p *Provider) setConfigIfNotNil(config *Config) {
+// SetConfigIfNotNil sets the new config only if it nil.
+func (p *Provider) SetConfigIfNotNil(config *Config) {
 	p.configLock.Lock()
 	defer p.configLock.Unlock()
 	if p.config == nil {
@@ -124,13 +127,15 @@ func (p *Provider) setConfigIfNotNil(config *Config) {
 	p.config = config
 }
 
-func (p *Provider) getWatchFunc() confmap.WatcherFunc {
+// GetWatchFunc returns the current watch function.
+func (p *Provider) GetWatchFunc() confmap.WatcherFunc {
 	p.watchFuncLock.Lock()
 	defer p.watchFuncLock.Unlock()
 	return p.watchFunc
 }
 
-func (p *Provider) setWatchFunc(watchFunc confmap.WatcherFunc) {
+// SetWatchFunc sets the new watch function, replacing the old one.
+func (p *Provider) SetWatchFunc(watchFunc confmap.WatcherFunc) {
 	p.watchFuncLock.Lock()
 	defer p.watchFuncLock.Unlock()
 	p.watchFunc = watchFunc

--- a/pkg/otelcollector/config/provider_test.go
+++ b/pkg/otelcollector/config/provider_test.go
@@ -54,8 +54,6 @@ var _ = Describe("Provider", func() {
 		By("Adding a hook")
 		Expect(triggered).To(BeFalse())
 		provider.AddMutatingHook(func(cfg *otelconfig.Config) {
-			// Make sure we don't rerun the same hook
-			Expect(cfg.Receivers).NotTo(HaveKey("ext1"))
 			cfg.AddReceiver("ext1", map[string]any{})
 		})
 		Expect(triggered).To(BeTrue())

--- a/pkg/profilers/profilers.go
+++ b/pkg/profilers/profilers.go
@@ -8,12 +8,12 @@ import (
 	"path"
 	"runtime/pprof"
 
-	"github.com/fluxninja/lumberjack"
 	"github.com/gorilla/mux"
 	"go.uber.org/fx"
 
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	"github.com/fluxninja/aperture/v2/pkg/log"
+	"github.com/fluxninja/lumberjack"
 )
 
 const (
@@ -91,6 +91,7 @@ func (constructor Constructor) setupProfilers(unmarshaller config.Unmarshaller,
 		router.HandleFunc(path.Join(httpPathPrefix, "profile"), httppprof.Profile)
 		router.HandleFunc(path.Join(httpPathPrefix, "symbol"), httppprof.Symbol)
 		router.Handle(path.Join(httpPathPrefix, "heap"), httppprof.Handler("heap"))
+		router.Handle(path.Join(httpPathPrefix, "goroutine"), httppprof.Handler("goroutine"))
 	}
 
 	lc.Append(fx.Hook{


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- **Refactor**: Introduced new locks in `Provider` struct for concurrent access protection to `config`, `watchFunc`, and `hooks` fields.
- **New Feature**: Added a new route handler for `/goroutine` in the `setupProfilers` function for goroutine profiling.
- **Test**: Updated `otel_test.go` to use `GetConfig` method instead of `MustGetConfig` from `configProvider` object, improving error handling.

> 🎉 With locks that guard and routes anew,
> 
> Tests refined, their purpose true.
> 
> In code we trust, in change we thrive,
> 
> To the future of our codebase, we high-five! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->