### PR TITLE
Avoid notifying otel collector of changes multiple times

### DIFF
--- a/extensions/fluxninja/otel/otel_test.go
+++ b/extensions/fluxninja/otel/otel_test.go
@@ -69,12 +69,10 @@ var _ = DescribeTable("FN Extension OTel", func(
 	err = app.Start(context.TODO())
 	Expect(err).NotTo(HaveOccurred())
 
-	c := configProvider.GetConfig()
-	Expect(c).ToNot(BeNil())
-	Expect(c.Receivers).To(Equal(expected.Receivers))
-	Expect(c.Processors).To(Equal(expected.Processors))
-	Expect(c.Exporters).To(Equal(expected.Exporters))
-	Expect(c.Service.Pipelines).To(Equal(expected.Service.Pipelines))
+	Expect(configProvider.MustGetConfig().Receivers).To(Equal(expected.Receivers))
+	Expect(configProvider.MustGetConfig().Processors).To(Equal(expected.Processors))
+	Expect(configProvider.MustGetConfig().Exporters).To(Equal(expected.Exporters))
+	Expect(configProvider.MustGetConfig().Service.Pipelines).To(Equal(expected.Service.Pipelines))
 
 	err = app.Stop(context.TODO())
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/otelcollector/config/provider_test.go
+++ b/pkg/otelcollector/config/provider_test.go
@@ -54,6 +54,8 @@ var _ = Describe("Provider", func() {
 		By("Adding a hook")
 		Expect(triggered).To(BeFalse())
 		provider.AddMutatingHook(func(cfg *otelconfig.Config) {
+			// Make sure we don't rerun the same hook
+			Expect(cfg.Receivers).NotTo(HaveKey("ext1"))
 			cfg.AddReceiver("ext1", map[string]any{})
 		})
 		Expect(triggered).To(BeTrue())


### PR DESCRIPTION
### Description of change

I'm not sure if we can call WatchFunc multiple times, so let's avoid doing it.
The changes will be visible at the next retrieve anyway. Perhaps this will help
otelcollector avoid starting and stopping at the same time.

Also: Revert #2378 as with this change the deadlock which that PR was fixing
should (hopefully) not happen anymore.

May fix #2356 

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```
**Refactor:**
- Modified the code to prevent multiple calls to `WatchFunc` and rerunning of hooks.
- Replaced individual locks (`configLock` and `watchFuncLock`) with a single lock (`lock`).
- Updated methods that access and modify the config and watch function to use the new lock.
- Ensured correct retrieval of expected configuration values.
- Added verification to ensure receiver "ext1" is not already present in the `cfg.Receivers` map before adding it.

> 🎉 With a lock that's singular, we've made our code more regular. 🔄 No more reruns, no more fuss, just efficient code for us! 🚀
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->