### PR TITLE
remove finalizers from the CR if operator get deleted first

### DIFF
--- a/manifests/charts/aperture-agent/templates/operator-deployment.yaml
+++ b/manifests/charts/aperture-agent/templates/operator-deployment.yaml
@@ -106,8 +106,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: AGENT_CR_NAME
-              value: {{ .Release.Name }}
             - name: APERTURE_OPERATOR_SERVICE_NAME
               value: {{ template "common.names.fullname" . }}-manager
             {{- if .Values.operator.extraEnvVars }}

--- a/manifests/charts/aperture-agent/templates/operator-deployment.yaml
+++ b/manifests/charts/aperture-agent/templates/operator-deployment.yaml
@@ -106,6 +106,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: AGENT_CR_NAME
+              value: {{ .Release.Name }}
             - name: APERTURE_OPERATOR_SERVICE_NAME
               value: {{ template "common.names.fullname" . }}-manager
             {{- if .Values.operator.extraEnvVars }}

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -852,6 +852,7 @@ func (r *AgentReconciler) RemoveFinalizerFromAgentCR(ctx context.Context, setupL
 	err := r.Client.List(ctx, agentList)
 	if err != nil {
 		setupLog.Error(err, "Error while getting the agent")
+		return
 	}
 	if agentList.Items != nil && len(agentList.Items) != 0 {
 		for _, agentCR := range agentList.Items {
@@ -862,8 +863,10 @@ func (r *AgentReconciler) RemoveFinalizerFromAgentCR(ctx context.Context, setupL
 				if err = r.updateAgent(ctx, &agentCR); err != nil && !errors.IsNotFound(err) {
 					if err.Error() == "Unauthorized" {
 						setupLog.Error(err, "Unauthorized to remove Finalizer from the agent serviceaccount might be deleted")
+						return
 					} else {
 						setupLog.Error(err, "Error while removing Finalizer from the agent")
+						return
 					}
 				}
 			}

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -858,7 +858,7 @@ func (r *AgentReconciler) RemoveFinalizerFromAgentCR(ctx context.Context, setupL
 		for _, agentCR := range agentList.Items {
 			agentCR := agentCR
 			if controllerutil.ContainsFinalizer(&agentCR, controllers.FinalizerName) {
-				setupLog.Info("Operator is getting deleted. Removing finalizer from the Agent CR")
+				setupLog.Info(fmt.Sprintf("Operator is getting deleted. Removing finalizer from the Agent CR named %s.", agentCR.Name))
 				controllerutil.RemoveFinalizer(&agentCR, controllers.FinalizerName)
 				if err = r.updateAgent(ctx, &agentCR); err != nil && !errors.IsNotFound(err) {
 					if errors.IsUnauthorized(err) {

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -861,7 +861,7 @@ func (r *AgentReconciler) RemoveFinalizerFromAgentCR(ctx context.Context, setupL
 				setupLog.Info("Operator is getting deleted. Removing finalizer from the Agent CR")
 				controllerutil.RemoveFinalizer(&agentCR, controllers.FinalizerName)
 				if err = r.updateAgent(ctx, &agentCR); err != nil && !errors.IsNotFound(err) {
-					if err.Error() == "Unauthorized" {
+					if errors.IsUnauthorized(err) {
 						setupLog.Error(err, "Unauthorized to remove Finalizer from the agent serviceaccount might be deleted")
 						return
 					} else {

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -862,10 +862,10 @@ func (r *AgentReconciler) RemoveFinalizerFromAgentCR(ctx context.Context, setupL
 				controllerutil.RemoveFinalizer(&agentCR, controllers.FinalizerName)
 				if err = r.updateAgent(ctx, &agentCR); err != nil && !errors.IsNotFound(err) {
 					if errors.IsUnauthorized(err) {
-						setupLog.Error(err, "Unauthorized to remove Finalizer from the agent serviceaccount might be deleted")
+						setupLog.Error(err, fmt.Sprintf("Unauthorized to remove Finalizer from the agent CR named %s, serviceaccount might be deleted.", agentCR.Name))
 						return
 					} else {
-						setupLog.Error(err, "Error while removing Finalizer from the agent")
+						setupLog.Error(err, fmt.Sprintf("Error while removing Finalizer from the agent CR named %s.", agentCR.Name))
 						return
 					}
 				}

--- a/operator/controllers/agent/reconciler.go
+++ b/operator/controllers/agent/reconciler.go
@@ -120,7 +120,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			r.deleteResources(ctx, logger, instance.DeepCopy())
 
 			controllerutil.RemoveFinalizer(instance, controllers.FinalizerName)
-			if err = r.updateAgent(ctx, instance); err != nil && !errors.IsNotFound(err) {
+			if err = r.UpdateAgent(ctx, instance); err != nil && !errors.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
 		}
@@ -200,7 +200,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		controllerutil.AddFinalizer(instance, controllers.FinalizerName)
 	}
 
-	if err := r.updateAgent(ctx, instance); err != nil {
+	if err := r.UpdateAgent(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -377,8 +377,8 @@ func (r *AgentReconciler) deleteResources(ctx context.Context, log logr.Logger, 
 	}
 }
 
-// updateAgent updates the Agent resource in Kubernetes.
-func (r *AgentReconciler) updateAgent(ctx context.Context, instance *agentv1alpha1.Agent) error {
+// UpdateAgent updates the Agent resource in Kubernetes.
+func (r *AgentReconciler) UpdateAgent(ctx context.Context, instance *agentv1alpha1.Agent) error {
 	attempt := 5
 	finalizers := instance.DeepCopy().Finalizers
 	spec := instance.DeepCopy().Spec

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -747,7 +747,7 @@ func (r *ControllerReconciler) RemoveFinalizerFromControllerCR(ctx context.Conte
 		for _, controllerCR := range controllerList.Items {
 			controllerCR := controllerCR
 			if controllerutil.ContainsFinalizer(&controllerCR, controllers.FinalizerName) {
-				setupLog.Info("Operator is getting deleted. Removing finalizer from the Controller CR")
+				setupLog.Info(fmt.Sprintf("Operator is getting deleted. Removing finalizer from the Controller CR named %s.", controllerCR.Name))
 				controllerutil.RemoveFinalizer(&controllerCR, controllers.FinalizerName)
 				if err = r.updateController(ctx, &controllerCR); err != nil && !errors.IsNotFound(err) {
 					if errors.IsUnauthorized(err) {

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -751,10 +751,10 @@ func (r *ControllerReconciler) RemoveFinalizerFromControllerCR(ctx context.Conte
 				controllerutil.RemoveFinalizer(&controllerCR, controllers.FinalizerName)
 				if err = r.updateController(ctx, &controllerCR); err != nil && !errors.IsNotFound(err) {
 					if errors.IsUnauthorized(err) {
-						setupLog.Error(err, "Unauthorized to remove Finalizer from the controller serviceaccount might be deleted")
+						setupLog.Error(err, fmt.Sprintf("Unauthorized to remove Finalizer from the controller CR named %s serviceaccount might be deleted.", controllerCR.Name))
 						return
 					} else {
-						setupLog.Error(err, "Error while removing Finalizer from the controller")
+						setupLog.Error(err, fmt.Sprintf("Error while removing Finalizer from the controller CR named %s.", controllerCR.Name))
 						return
 					}
 				}

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -741,6 +741,7 @@ func (r *ControllerReconciler) RemoveFinalizerFromControllerCR(ctx context.Conte
 	err := r.Client.List(ctx, controllerList)
 	if err != nil {
 		setupLog.Error(err, "Error while getting the controller")
+		return
 	}
 	if controllerList.Items != nil && len(controllerList.Items) != 0 {
 		for _, controllerCR := range controllerList.Items {
@@ -751,8 +752,10 @@ func (r *ControllerReconciler) RemoveFinalizerFromControllerCR(ctx context.Conte
 				if err = r.updateController(ctx, &controllerCR); err != nil && !errors.IsNotFound(err) {
 					if err.Error() == "Unauthorized" {
 						setupLog.Error(err, "Unauthorized to remove Finalizer from the controller serviceaccount might be deleted")
+						return
 					} else {
 						setupLog.Error(err, "Error while removing Finalizer from the controller")
+						return
 					}
 				}
 			}

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -156,7 +156,7 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 
 			controllerutil.RemoveFinalizer(instance, controllers.FinalizerName)
-			if err = r.updateController(ctx, instance); err != nil && !errors.IsNotFound(err) {
+			if err = r.UpdateController(ctx, instance); err != nil && !errors.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
 		}
@@ -242,7 +242,7 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	if err := r.updateController(ctx, instance); err != nil {
+	if err := r.UpdateController(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -255,8 +255,8 @@ func (r *ControllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-// updateController updates the Controller resource in Kubernetes.
-func (r *ControllerReconciler) updateController(ctx context.Context, instance *controllerv1alpha1.Controller) error {
+// UpdateController updates the Controller resource in Kubernetes.
+func (r *ControllerReconciler) UpdateController(ctx context.Context, instance *controllerv1alpha1.Controller) error {
 	attempt := 5
 	finalizers := instance.DeepCopy().Finalizers
 	spec := instance.DeepCopy().Spec

--- a/operator/controllers/controller/reconciler.go
+++ b/operator/controllers/controller/reconciler.go
@@ -750,7 +750,7 @@ func (r *ControllerReconciler) RemoveFinalizerFromControllerCR(ctx context.Conte
 				setupLog.Info("Operator is getting deleted. Removing finalizer from the Controller CR")
 				controllerutil.RemoveFinalizer(&controllerCR, controllers.FinalizerName)
 				if err = r.updateController(ctx, &controllerCR); err != nil && !errors.IsNotFound(err) {
-					if err.Error() == "Unauthorized" {
+					if errors.IsUnauthorized(err) {
 						setupLog.Error(err, "Unauthorized to remove Finalizer from the controller serviceaccount might be deleted")
 						return
 					} else {

--- a/operator/main.go
+++ b/operator/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/fluxninja/aperture/v2/operator/controllers/controller"
 	"github.com/fluxninja/aperture/v2/operator/controllers/mutatingwebhook"
 	"github.com/fluxninja/aperture/v2/operator/controllers/namespace"
+	"github.com/go-logr/logr"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -231,7 +232,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := setupContext(agentReconciler, controllerReconciler, agentManager)
+	ctx := setupContext(agentReconciler, controllerReconciler, agentManager, setupLog)
 	setupLog.Info("starting webhook server")
 	go func() {
 		if err := server.Start(ctx); err != nil {
@@ -247,7 +248,7 @@ func main() {
 	}
 }
 
-func setupContext(agentReconciler *agent.AgentReconciler, controllerReconciler *controller.ControllerReconciler, agentManager bool) context.Context {
+func setupContext(agentReconciler *agent.AgentReconciler, controllerReconciler *controller.ControllerReconciler, agentManager bool, setupLog logr.Logger) context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := make(chan os.Signal, 1)
@@ -256,9 +257,9 @@ func setupContext(agentReconciler *agent.AgentReconciler, controllerReconciler *
 	go func() {
 		<-c
 		if agentManager {
-			agentReconciler.RemoveFinalizerFromAgentCR(ctx)
+			agentReconciler.RemoveFinalizerFromAgentCR(ctx, setupLog)
 		} else {
-			controllerReconciler.RemoveFinalizerFromControllerCR(ctx)
+			controllerReconciler.RemoveFinalizerFromControllerCR(ctx, setupLog)
 		}
 		cancel()
 	}()


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes**

- **Refactor**: Renamed methods `updateAgent` to `UpdateAgent` and `updateController` to `UpdateController` for better code readability.
- **New Feature**: Introduced functions `RemoveFinalizerFromAgentCR` and `RemoveFinalizerFromControllerCR` to handle operator deletion more gracefully by removing finalizers from the Agent and Controller Custom Resources respectively.
- **Refactor**: Added a new function `setupContext` for setting up application context and signal handling, enhancing the robustness of the application.

> 🎉 Here's to the code that we refine,  
> With each pull request, it does shine.  
> Finalizers removed, signals caught,  
> Graceful shutdowns as we sought.  
> In our README, no badge out of line,  
> Oh, how beautifully does our codebase align! 🎉

<!-- end of auto-generated comment: release notes by coderabbit.ai -->