### PR TITLE
Test

### DIFF
--- a/pkg/net/grpc/server.go
+++ b/pkg/net/grpc/server.go
@@ -27,7 +27,7 @@ const (
 // ServerModule is an fx module that provides annotated gRPC Server using the default listener and registers its metrics with the prometheus registry.
 func ServerModule() fx.Option {
 	return fx.Options(
-		ServerConstructor{}.Annotate(),
+		ServerConstructor{Name: "main"}.Annotate(),
 		fx.Invoke(RegisterGRPCServerMetrics),
 	)
 }
@@ -36,7 +36,7 @@ func ServerModule() fx.Option {
 func GMuxServerModule() fx.Option {
 	return fx.Options(
 		listener.GMuxConstructor{ListenerName: defaultGMuxListener}.Annotate(),
-		ServerConstructor{ListenerName: defaultGMuxListener}.Annotate(),
+		ServerConstructor{Name: "main", ListenerName: defaultGMuxListener}.Annotate(),
 		fx.Invoke(RegisterGRPCServerMetrics),
 	)
 }

--- a/pkg/net/grpc/server.go
+++ b/pkg/net/grpc/server.go
@@ -126,6 +126,7 @@ func (constructor ServerConstructor) provideServer(
 		otelgrpc.UnaryServerInterceptor(),
 		validatorUnaryInterceptor(),
 	}
+	log.Warn().Int("no", len(additionalUnaryInterceptors)).Msg("TEST")
 	unaryServerInterceptors = append(unaryServerInterceptors, constructor.UnaryServerInterceptors...)
 	unaryServerInterceptors = append(unaryServerInterceptors, additionalUnaryInterceptors...)
 	serverOptions = append(serverOptions, grpc.ChainUnaryInterceptor(unaryServerInterceptors...))

--- a/pkg/net/grpc/server.go
+++ b/pkg/net/grpc/server.go
@@ -83,9 +83,9 @@ func (constructor ServerConstructor) Annotate() fx.Option {
 				constructor.provideServer,
 				fx.ParamTags(
 					config.NameTag(constructor.ListenerName),
-					config.GroupTag(constructor.Name)+` optional:"true"`,
-					config.GroupTag(constructor.Name)+` optional:"true"`,
-					config.GroupTag(constructor.Name)+` optional:"true"`,
+					config.GroupTag(constructor.Name),
+					config.GroupTag(constructor.Name),
+					config.GroupTag(constructor.Name),
 				),
 				fx.ResultTags(
 					config.NameTag(constructor.Name),


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added `Name` field to the `ServerConstructor` struct in `pkg/net/grpc/server.go`.
- Enhanced `Annotate` method to use the new `Name` field for additional tags.
- Introduced a log warning for excessive `additionalUnaryInterceptors`.

> 🎉 With a name tag so bright, our server now takes flight,
> In the world of gRPC, it's a delightful sight.
> Beware of interceptors' might, their numbers ignite a light,
> A warning log to set things right, ensuring our code is tight! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->