### PR TITLE
refactor: Split out Session from etcd/client.Client

### DIFF
--- a/extensions/fluxninja/heartbeats/peers-watcher.go
+++ b/extensions/fluxninja/heartbeats/peers-watcher.go
@@ -30,7 +30,8 @@ type PeersOut struct {
 
 func setupPeersWatcher(
 	extensionConfig *extconfig.FluxNinjaExtensionConfig,
-	client *etcdclient.Client,
+	etcdClient *etcdclient.Client,
+	sessionScopedKV *etcdclient.SessionScopedKV,
 	lc fx.Lifecycle,
 ) (PeersOut, error) {
 	if extensionConfig.APIKey == "" {
@@ -40,7 +41,7 @@ func setupPeersWatcher(
 	if info.Service != utils.ApertureController {
 		return PeersOut{}, nil
 	}
-	pd, err := peers.NewPeerDiscovery("aperture-agent", client, nil)
+	pd, err := peers.NewPeerDiscovery("aperture-agent", etcdClient, sessionScopedKV, nil)
 	if err != nil {
 		return PeersOut{}, err
 	}

--- a/pkg/etcd/client/client.go
+++ b/pkg/etcd/client/client.go
@@ -20,8 +20,10 @@ import (
 
 // Module is a fx module that provides etcd client.
 func Module() fx.Option {
-	return fx.Options(
-		fx.Provide(ProvideClient),
+	return fx.Provide(
+		ProvideClient,
+		ProvideSession,
+		ProvideSessionScopedKV,
 	)
 }
 
@@ -48,7 +50,6 @@ type ClientIn struct {
 
 	Unmarshaller   config.Unmarshaller
 	Lifecycle      fx.Lifecycle
-	Shutdowner     fx.Shutdowner
 	Logger         *log.Logger
 	ConfigOverride *ConfigOverride `optional:"true"`
 }
@@ -58,7 +59,33 @@ type ClientIn struct {
 // Client.Client is nil before OnStart.
 type Client struct {
 	*clientv3.Client
+	KVWrapper KVWrapper // wraps the same KV as Client
+	// hack: This field is here only so that it can be propagated from config
+	// to Session.
+	leaseTTL config.Duration
+}
+
+// Session wraps concurrencyv3.Session.
+//
+// Session.Session is nil before OnStart.
+type Session struct {
 	Session *concurrencyv3.Session
+}
+
+// KVWrapper wraps clientv3.KV, can be used when wanting to depend on clientv3.KV
+// already before OnStart.
+//
+// KVWrapper.KV is nil before OnStart.
+//
+// Note: This is not named just KV not to break .KV field access.
+type KVWrapper struct {
+	clientv3.KV
+}
+
+// SessionScopedKV implements clientv3.KV by attaching the session's lease to
+// all Put requests, effectively scoping all created keys to the session.
+type SessionScopedKV struct {
+	KVWrapper
 }
 
 // ProvideClient creates a new Etcd Client and provides it via Fx.
@@ -79,7 +106,9 @@ func ProvideClient(in ClientIn) (*Client, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	etcdClient := &Client{}
+	etcdClient := Client{
+		leaseTTL: config.LeaseTTL,
+	}
 
 	in.Lifecycle.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
@@ -131,26 +160,7 @@ func ProvideClient(in ClientIn) (*Client, error) {
 			}
 
 			etcdClient.Client = cli
-
-			// Create a new Session
-			session, err := concurrencyv3.NewSession(cli, concurrencyv3.WithTTL((int)(config.LeaseTTL.AsDuration().Seconds())))
-			if err != nil {
-				log.Error().Err(err).Msg("Unable to create a new session")
-				cancel()
-				return err
-			}
-			etcdClient.Session = session
-			// A goroutine to check if the session is expired
-			panichandler.Go(func() {
-				// wait for the context to be done or session to be closed
-				select {
-				case <-ctx.Done():
-					// regular shutdown
-				case <-session.Done():
-					log.Error().Msg("Etcd session is done, request shutdown")
-					utils.Shutdown(in.Shutdowner)
-				}
-			})
+			etcdClient.KVWrapper.KV = cli.KV
 
 			return nil
 		},
@@ -160,6 +170,58 @@ func ProvideClient(in ClientIn) (*Client, error) {
 			return etcdClient.Client.Close()
 		},
 	})
+	return &etcdClient, nil
+}
 
-	return etcdClient, nil
+// ProvideSession provides Session.
+//
+// When the session expires, app will be shut down.
+func ProvideSession(
+	client *Client,
+	lc fx.Lifecycle,
+	shutdowner fx.Shutdowner,
+) (*Session, error) {
+	var sessionWrapper Session
+	lc.Append(fx.StartHook(func() error {
+		// Create a new Session
+		session, err := concurrencyv3.NewSession(client.Client, concurrencyv3.WithTTL((int)(client.leaseTTL.AsDuration().Seconds())))
+		if err != nil {
+			log.Error().Err(err).Msg("Unable to create a new session")
+			return err
+		}
+		sessionWrapper.Session = session
+
+		// A goroutine to check if the session is expired
+		panichandler.Go(func() {
+			// wait for session to be closed
+			<-session.Done()
+
+			select {
+			case <-session.Client().Ctx().Done():
+				return
+			default:
+				// session close not caused by client shutdown
+				log.Error().Msg("Etcd session expired, request shutdown")
+				utils.Shutdown(shutdowner)
+			}
+		})
+
+		return nil
+	}))
+
+	return &sessionWrapper, nil
+}
+
+// ProvideSessionScopedKV provides SessionScopedKV.
+//
+// Note: This requires Session, so any usage of SessionScopedKV will cause app to shut down.
+func ProvideSessionScopedKV(session *Session, lc fx.Lifecycle) *SessionScopedKV {
+	var scopedKV SessionScopedKV
+	lc.Append(fx.StartHook(func() {
+		scopedKV.KV = kvWithLease{
+			rawKV: session.Session.Client().KV,
+			lease: session.Session.Lease(),
+		}
+	}))
+	return &scopedKV
 }

--- a/pkg/etcd/client/with-lease.go
+++ b/pkg/etcd/client/with-lease.go
@@ -1,0 +1,63 @@
+package etcd
+
+import (
+	"context"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/fluxninja/aperture/v2/pkg/log"
+)
+
+// kvWithLease implements KV by attaching Lease to every Put it makes.
+//
+// This makes all the keys it creates scoped to the session.
+type kvWithLease struct {
+	lease clientv3.LeaseID
+	rawKV clientv3.KV
+}
+
+// Get implements clientv3.KV.
+func (c kvWithLease) Get(
+	ctx context.Context,
+	key string,
+	opts ...clientv3.OpOption,
+) (*clientv3.GetResponse, error) {
+	return c.rawKV.Get(ctx, key, opts...)
+}
+
+// Put implements clientv3.KV.
+func (c kvWithLease) Put(
+	ctx context.Context,
+	key, val string,
+	opts ...clientv3.OpOption,
+) (*clientv3.PutResponse, error) {
+	return c.rawKV.Put(ctx, key, val, append(opts, clientv3.WithLease(c.lease))...)
+}
+
+// Delete implements clientv3.KV.
+func (c kvWithLease) Delete(
+	ctx context.Context,
+	key string,
+	opts ...clientv3.OpOption,
+) (*clientv3.DeleteResponse, error) {
+	return c.rawKV.Delete(ctx, key, opts...)
+}
+
+// Compact implements clientv3.KV.
+func (c kvWithLease) Compact(ctx context.Context, rev int64, opts ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
+	return c.rawKV.Compact(ctx, rev, opts...)
+}
+
+// Do implements clientv3.KV.
+func (c kvWithLease) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
+	// It's possible to implement, but we don't have a need for it now.
+	log.Panic().Msg("kvWithLease.Do unimplemented")
+	return clientv3.OpResponse{}, nil
+}
+
+// Txn implements clientv3.KV.
+func (c kvWithLease) Txn(ctx context.Context) clientv3.Txn {
+	// It's possible to implement, but we don't have a need for it now.
+	log.Panic().Msg("kvWithLease.Txn unimplemented")
+	return nil
+}

--- a/pkg/etcd/election/election.go
+++ b/pkg/etcd/election/election.go
@@ -38,7 +38,7 @@ type ElectionIn struct {
 	fx.In
 	Lifecycle  fx.Lifecycle
 	Shutdowner fx.Shutdowner
-	Client     *etcd.Client
+	Session    *etcd.Session
 	AgentInfo  *agentinfo.AgentInfo
 	Trackers   notifiers.Trackers `name:"etcd_election"`
 }
@@ -54,7 +54,7 @@ func ProvideElection(in ElectionIn) (*Election, error) {
 	in.Lifecycle.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
 			// Create an election for this client
-			election.Election = concurrencyv3.NewElection(in.Client.Session, "/election/"+in.AgentInfo.GetAgentGroup())
+			election.Election = concurrencyv3.NewElection(in.Session.Session, "/election/"+in.AgentInfo.GetAgentGroup())
 			// A goroutine to do leader election
 			panichandler.Go(func() {
 				defer close(election.doneChan)

--- a/pkg/etcd/notifier/key.go
+++ b/pkg/etcd/notifier/key.go
@@ -22,10 +22,10 @@ var _ notifiers.KeyNotifier = (*KeyToEtcdNotifier)(nil)
 func NewKeyToEtcdNotifier(
 	key notifiers.Key,
 	etcdPath string,
-	etcdClient *etcdclient.Client,
+	kv *etcdclient.KVWrapper,
 	withLease bool,
 ) (*KeyToEtcdNotifier, error) {
-	return newKeyToEtcdNotifier(key, etcdPath, etcdwriter.NewWriter(etcdClient, withLease))
+	return newKeyToEtcdNotifier(key, etcdPath, etcdwriter.NewWriter(kv))
 }
 
 func newKeyToEtcdNotifier(

--- a/pkg/etcd/notifier/key.go
+++ b/pkg/etcd/notifier/key.go
@@ -23,7 +23,6 @@ func NewKeyToEtcdNotifier(
 	key notifiers.Key,
 	etcdPath string,
 	kv *etcdclient.KVWrapper,
-	withLease bool,
 ) (*KeyToEtcdNotifier, error) {
 	return newKeyToEtcdNotifier(key, etcdPath, etcdwriter.NewWriter(kv))
 }

--- a/pkg/etcd/notifier/prefix.go
+++ b/pkg/etcd/notifier/prefix.go
@@ -1,8 +1,6 @@
 package notifier
 
 import (
-	clientv3 "go.etcd.io/etcd/client/v3"
-
 	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
 	etcdwriter "github.com/fluxninja/aperture/v2/pkg/etcd/writer"
 	"github.com/fluxninja/aperture/v2/pkg/notifiers"
@@ -11,7 +9,6 @@ import (
 // PrefixToEtcdNotifier holds the state of a notifier that writes raw/transformed contents of a watched prefix to etcd.
 type PrefixToEtcdNotifier struct {
 	notifiers.PrefixBase
-	etcdClient *etcdclient.Client
 	etcdWriter *etcdwriter.Writer
 	etcdPath   string
 }
@@ -22,15 +19,13 @@ var _ notifiers.PrefixNotifier = (*PrefixToEtcdNotifier)(nil)
 // NewPrefixToEtcdNotifier returns a new prefix notifier that writes raw/transformed contents to etcd at "etcdPath/key".
 func NewPrefixToEtcdNotifier(
 	etcdPath string,
-	etcdClient *etcdclient.Client,
-	withLease bool,
+	kv *etcdclient.KVWrapper,
 ) *PrefixToEtcdNotifier {
 	pen := &PrefixToEtcdNotifier{
 		// subscribe to all prefixes
 		PrefixBase: notifiers.NewPrefixBase(""),
 		etcdPath:   etcdPath,
-		etcdClient: etcdClient,
-		etcdWriter: etcdwriter.NewWriter(etcdClient, withLease),
+		etcdWriter: etcdwriter.NewWriter(kv),
 	}
 	return pen
 }
@@ -38,7 +33,7 @@ func NewPrefixToEtcdNotifier(
 // Start starts the prefix notifier.
 func (pen *PrefixToEtcdNotifier) Start() error {
 	// purge etcd path -- as OnStart hooks are executed in order, this would be the first operation on the writer
-	pen.etcdWriter.Delete(pen.etcdPath, clientv3.WithPrefix())
+	pen.etcdWriter.DeletePrefix(pen.etcdPath)
 	return nil
 }
 

--- a/pkg/etcd/writer/writer.go
+++ b/pkg/etcd/writer/writer.go
@@ -62,7 +62,7 @@ func NewWriter(etcdClient *etcdclient.Client, withLease bool, opts ...clientv3.O
 			case opt := <-ew.opChannel.Out():
 				opt.opts = append(opt.opts, opts...)
 				if ew.withLease && opt.opType == put {
-					opt.opts = append(opt.opts, clientv3.WithLease(ew.etcdClient.LeaseID))
+					opt.opts = append(opt.opts, clientv3.WithLease(ew.etcdClient.Session.Lease()))
 				}
 
 				var err error

--- a/pkg/etcd/writer/writer.go
+++ b/pkg/etcd/writer/writer.go
@@ -13,32 +13,30 @@ import (
 )
 
 const (
-	put = 0
-	del = 1
+	put       = 0
+	del       = 1
+	delPrefix = 2
 )
 
-type op struct {
+type operation struct {
 	key    string
 	value  []byte
-	opts   []clientv3.OpOption
 	opType int
 }
 
 // Writer holds fields for etcd writer.
 type Writer struct {
-	context    context.Context
-	etcdClient *etcdclient.Client
-	opChannel  infchan.Channel[op]
-	cancel     context.CancelFunc
-	withLease  bool
+	context   context.Context
+	kv        *etcdclient.KVWrapper
+	opChannel infchan.Channel[operation]
+	cancel    context.CancelFunc
 }
 
 // NewWriter returns a new etcd writer.
-func NewWriter(etcdClient *etcdclient.Client, withLease bool, opts ...clientv3.OpOption) *Writer {
+func NewWriter(kv *etcdclient.KVWrapper, opts ...clientv3.OpOption) *Writer {
 	ew := &Writer{
-		etcdClient: etcdClient,
-		withLease:  withLease,
-		opChannel:  infchan.NewChannel[op](),
+		kv:        kv,
+		opChannel: infchan.NewChannel[operation](),
 	}
 	// Set finalizer to automatically close channel
 	runtime.SetFinalizer(ew, func(ew *Writer) {
@@ -59,18 +57,17 @@ func NewWriter(etcdClient *etcdclient.Client, withLease bool, opts ...clientv3.O
 		// start processing ops
 		for {
 			select {
-			case opt := <-ew.opChannel.Out():
-				opt.opts = append(opt.opts, opts...)
-				if ew.withLease && opt.opType == put {
-					opt.opts = append(opt.opts, clientv3.WithLease(ew.etcdClient.Session.Lease()))
-				}
-
+			case op := <-ew.opChannel.Out():
 				var err error
-				switch opt.opType {
+				switch op.opType {
 				case put:
-					_, err = ew.etcdClient.KV.Put(clientv3.WithRequireLeader(ew.context), opt.key, string(opt.value), opt.opts...)
+					_, err = ew.kv.Put(clientv3.WithRequireLeader(ew.context), op.key, string(op.value), opts...)
 				case del:
-					_, err = ew.etcdClient.KV.Delete(clientv3.WithRequireLeader(ew.context), opt.key, opt.opts...)
+					_, err = ew.kv.Delete(clientv3.WithRequireLeader(ew.context), op.key, opts...)
+				case delPrefix:
+					opOpts := []clientv3.OpOption{clientv3.WithPrefix()}
+					opOpts = append(opOpts, opts...)
+					_, err = ew.kv.Delete(clientv3.WithRequireLeader(ew.context), op.key, opOpts...)
 				}
 				if err != nil {
 					log.Error().Err(err).Msg("failed to write to etcd")
@@ -85,13 +82,18 @@ func NewWriter(etcdClient *etcdclient.Client, withLease bool, opts ...clientv3.O
 }
 
 // Write writes a key value pair to etcd with options.
-func (ew *Writer) Write(key string, value []byte, opts ...clientv3.OpOption) {
-	ew.opChannel.In() <- op{opType: put, key: key, value: value, opts: opts}
+func (ew *Writer) Write(key string, value []byte) {
+	ew.opChannel.In() <- operation{opType: put, key: key, value: value}
 }
 
 // Delete deletes a key from etcd.
-func (ew *Writer) Delete(key string, opts ...clientv3.OpOption) {
-	ew.opChannel.In() <- op{opType: del, key: key, opts: opts}
+func (ew *Writer) Delete(key string) {
+	ew.opChannel.In() <- operation{opType: del, key: key}
+}
+
+// DeletePrefix deletes a whole prefix from etcd.
+func (ew *Writer) DeletePrefix(key string) {
+	ew.opChannel.In() <- operation{opType: delPrefix, key: key}
 }
 
 // Close closes the etcd writer.

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -69,13 +69,14 @@ type PeerDiscoveryPrefix string
 // PeerDiscoveryIn holds parameters for newPeerDiscovery.
 type PeerDiscoveryIn struct {
 	fx.In
-	Lifecycle      fx.Lifecycle
-	Unmarshaller   config.Unmarshaller
-	Client         *etcdclient.Client
-	Listener       *listener.Listener
-	StatusRegistry status.Registry
-	Prefix         PeerDiscoveryPrefix
-	Watchers       PeerWatchers `group:"peer-watchers"`
+	Lifecycle       fx.Lifecycle
+	Unmarshaller    config.Unmarshaller
+	Client          *etcdclient.Client
+	SessionScopedKV *etcdclient.SessionScopedKV
+	Listener        *listener.Listener
+	StatusRegistry  status.Registry
+	Prefix          PeerDiscoveryPrefix
+	Watchers        PeerWatchers `group:"peer-watchers"`
 }
 
 func (constructor Constructor) providePeerDiscovery(in PeerDiscoveryIn) (*PeerDiscovery, error) {
@@ -91,7 +92,7 @@ func (constructor Constructor) providePeerDiscovery(in PeerDiscoveryIn) (*PeerDi
 		return nil, err
 	}
 
-	pd, err := NewPeerDiscovery(string(in.Prefix), in.Client, in.Watchers)
+	pd, err := NewPeerDiscovery(string(in.Prefix), in.Client, in.SessionScopedKV, in.Watchers)
 	if err != nil {
 		return nil, err
 	}
@@ -143,18 +144,24 @@ func (constructor Constructor) providePeerDiscovery(in PeerDiscoveryIn) (*PeerDi
 
 // PeerDiscovery holds fields to manage peer discovery.
 type PeerDiscovery struct {
-	lock         sync.RWMutex
-	peers        *peersv1.Peers
-	client       *etcdclient.Client
-	etcdWatcher  notifiers.Watcher
-	selfKey      string
-	etcdPath     string
-	peerNotifier notifiers.PrefixNotifier
-	watchers     PeerWatchers
+	lock            sync.RWMutex
+	peers           *peersv1.Peers
+	client          *etcdclient.Client
+	sessionScopedKV *etcdclient.SessionScopedKV
+	etcdWatcher     notifiers.Watcher
+	selfKey         string
+	etcdPath        string
+	peerNotifier    notifiers.PrefixNotifier
+	watchers        PeerWatchers
 }
 
 // NewPeerDiscovery creates a new PeerDiscovery.
-func NewPeerDiscovery(prefix string, client *etcdclient.Client, watchers PeerWatchers) (*PeerDiscovery, error) {
+func NewPeerDiscovery(
+	prefix string,
+	client *etcdclient.Client,
+	sessionScopedKV *etcdclient.SessionScopedKV,
+	watchers PeerWatchers,
+) (*PeerDiscovery, error) {
 	var err error
 	pd := &PeerDiscovery{
 		peers: &peersv1.Peers{
@@ -163,9 +170,10 @@ func NewPeerDiscovery(prefix string, client *etcdclient.Client, watchers PeerWat
 			},
 			Peers: make(map[string]*peersv1.Peer),
 		},
-		watchers: watchers,
-		etcdPath: path.Join(etcdPath, prefix),
-		client:   client,
+		watchers:        watchers,
+		etcdPath:        path.Join(etcdPath, prefix),
+		client:          client,
+		sessionScopedKV: sessionScopedKV,
 	}
 
 	// create and start etcdwatcher to track peers and sync them to disk
@@ -215,8 +223,7 @@ func (pd *PeerDiscovery) uploadSelfPeer(ctx context.Context) error {
 		log.Error().Err(err).Msg("failed to convert json to yaml")
 		return err
 	}
-	_, err = pd.client.KV.Put(clientv3.WithRequireLeader(ctx),
-		pd.selfKey, string(b), clientv3.WithLease(pd.client.Session.Lease()))
+	_, err = pd.sessionScopedKV.Put(clientv3.WithRequireLeader(ctx), pd.selfKey, string(b))
 
 	return err
 }

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -216,7 +216,7 @@ func (pd *PeerDiscovery) uploadSelfPeer(ctx context.Context) error {
 		return err
 	}
 	_, err = pd.client.KV.Put(clientv3.WithRequireLeader(ctx),
-		pd.selfKey, string(b), clientv3.WithLease(pd.client.LeaseID))
+		pd.selfKey, string(b), clientv3.WithLease(pd.client.Session.Lease()))
 
 	return err
 }

--- a/pkg/peers/peers_test.go
+++ b/pkg/peers/peers_test.go
@@ -17,7 +17,7 @@ var (
 
 var _ = Describe("Peers", func() {
 	BeforeEach(func() {
-		pd, err = NewPeerDiscovery("", nil, nil)
+		pd, err = NewPeerDiscovery("", nil, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		for _, peer := range hardCodedPeers.Peers {
 			pd.addPeer(peer)

--- a/pkg/policies/controlplane/components/autoscale/podscaler/config-sync.go
+++ b/pkg/policies/controlplane/components/autoscale/podscaler/config-sync.go
@@ -58,7 +58,7 @@ func NewConfigSyncOptions(
 	), nil
 }
 
-func (configSync *podScalerConfigSync) doSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (configSync *podScalerConfigSync) doSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) error {
 	logger := configSync.policyReadAPI.GetStatusRegistry().GetLogger()
 	// Add/remove file in lifecycle hooks in order to sync with etcd.
 	lifecycle.Append(fx.Hook{
@@ -76,8 +76,7 @@ func (configSync *podScalerConfigSync) doSync(etcdClient *etcdclient.Client, lif
 				logger.Error().Err(err).Msg("Failed to marshal flux meter config")
 				return err
 			}
-			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+			_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configSync.etcdPath, string(dat))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to put flux meter config")
 				return err
@@ -85,7 +84,7 @@ func (configSync *podScalerConfigSync) doSync(etcdClient *etcdclient.Client, lif
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
-			_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
+			_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to delete flux meter config")
 				return err

--- a/pkg/policies/controlplane/components/autoscale/podscaler/config-sync.go
+++ b/pkg/policies/controlplane/components/autoscale/podscaler/config-sync.go
@@ -77,7 +77,7 @@ func (configSync *podScalerConfigSync) doSync(etcdClient *etcdclient.Client, lif
 				return err
 			}
 			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to put flux meter config")
 				return err

--- a/pkg/policies/controlplane/components/flowcontrol/load-scheduler/config-sync.go
+++ b/pkg/policies/controlplane/components/flowcontrol/load-scheduler/config-sync.go
@@ -70,7 +70,7 @@ func (configSync *loadSchedulerConfigSync) doSync(etcdClient *etcdclient.Client,
 				return err
 			}
 			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to put flux meter config")
 				return err

--- a/pkg/policies/controlplane/components/flowcontrol/load-scheduler/config-sync.go
+++ b/pkg/policies/controlplane/components/flowcontrol/load-scheduler/config-sync.go
@@ -51,7 +51,7 @@ func NewConfigSyncOptions(
 	return fx.Options(options...), nil
 }
 
-func (configSync *loadSchedulerConfigSync) doSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (configSync *loadSchedulerConfigSync) doSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) error {
 	logger := configSync.policyBaseAPI.GetStatusRegistry().GetLogger()
 	// Add/remove file in lifecycle hooks in order to sync with etcd.
 	lifecycle.Append(fx.Hook{
@@ -69,8 +69,7 @@ func (configSync *loadSchedulerConfigSync) doSync(etcdClient *etcdclient.Client,
 				logger.Error().Err(err).Msg("Failed to marshal flux meter config")
 				return err
 			}
-			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+			_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configSync.etcdPath, string(dat))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to put flux meter config")
 				return err
@@ -78,7 +77,7 @@ func (configSync *loadSchedulerConfigSync) doSync(etcdClient *etcdclient.Client,
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
-			_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
+			_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to delete flux meter config")
 				return err

--- a/pkg/policies/controlplane/components/flowcontrol/quota-scheduler/quota-scheduler.go
+++ b/pkg/policies/controlplane/components/flowcontrol/quota-scheduler/quota-scheduler.go
@@ -102,7 +102,7 @@ func (limiterSync *quotaSchedulerSync) setupSync(etcdClient *etcdclient.Client, 
 			var merr error
 			for _, configEtcdPath := range limiterSync.configEtcdPaths {
 				_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 				if err != nil {
 					logger.Error().Err(err).Msg("failed to put rate limiter config")
 					merr = multierr.Append(merr, err)

--- a/pkg/policies/controlplane/components/flowcontrol/quota-scheduler/quota-scheduler.go
+++ b/pkg/policies/controlplane/components/flowcontrol/quota-scheduler/quota-scheduler.go
@@ -82,7 +82,7 @@ func NewQuotaSchedulerAndOptions(
 	), nil
 }
 
-func (limiterSync *quotaSchedulerSync) setupSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (limiterSync *quotaSchedulerSync) setupSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) error {
 	logger := limiterSync.policyReadAPI.GetStatusRegistry().GetLogger()
 	lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -101,14 +101,13 @@ func (limiterSync *quotaSchedulerSync) setupSync(etcdClient *etcdclient.Client, 
 			}
 			var merr error
 			for _, configEtcdPath := range limiterSync.configEtcdPaths {
-				_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+				_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configEtcdPath, string(dat))
 				if err != nil {
 					logger.Error().Err(err).Msg("failed to put rate limiter config")
 					merr = multierr.Append(merr, err)
 				}
 			}
-			limiterSync.decisionWriter = etcdwriter.NewWriter(etcdClient, true)
+			limiterSync.decisionWriter = etcdwriter.NewWriter(&scopedKV.KVWrapper)
 			return merr
 		},
 		OnStop: func(ctx context.Context) error {
@@ -116,7 +115,7 @@ func (limiterSync *quotaSchedulerSync) setupSync(etcdClient *etcdclient.Client, 
 			deleteEtcdPath := func(paths []string) error {
 				var merr error
 				for _, path := range paths {
-					_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), path)
+					_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), path)
 					if err != nil {
 						logger.Error().Err(err).Msgf("failed to delete etcd path %s", path)
 						merr = multierr.Append(merr, err)

--- a/pkg/policies/controlplane/components/flowcontrol/rate-limiter/rate-limiter.go
+++ b/pkg/policies/controlplane/components/flowcontrol/rate-limiter/rate-limiter.go
@@ -82,7 +82,7 @@ func NewRateLimiterAndOptions(
 	), nil
 }
 
-func (limiterSync *rateLimiterSync) setupSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (limiterSync *rateLimiterSync) setupSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) {
 	logger := limiterSync.policyReadAPI.GetStatusRegistry().GetLogger()
 	lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -101,14 +101,13 @@ func (limiterSync *rateLimiterSync) setupSync(etcdClient *etcdclient.Client, lif
 			}
 			var merr error
 			for _, configEtcdPath := range limiterSync.configEtcdPaths {
-				_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+				_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configEtcdPath, string(dat))
 				if err != nil {
 					logger.Error().Err(err).Msg("failed to put rate limiter config")
 					merr = multierr.Append(merr, err)
 				}
 			}
-			limiterSync.decisionWriter = etcdwriter.NewWriter(etcdClient, true)
+			limiterSync.decisionWriter = etcdwriter.NewWriter(&scopedKV.KVWrapper)
 			return merr
 		},
 		OnStop: func(ctx context.Context) error {
@@ -116,7 +115,7 @@ func (limiterSync *rateLimiterSync) setupSync(etcdClient *etcdclient.Client, lif
 			deleteEtcdPath := func(paths []string) error {
 				var merr error
 				for _, path := range paths {
-					_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), path)
+					_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), path)
 					if err != nil {
 						logger.Error().Err(err).Msgf("failed to delete etcd path %s", path)
 						merr = multierr.Append(merr, err)
@@ -130,7 +129,6 @@ func (limiterSync *rateLimiterSync) setupSync(etcdClient *etcdclient.Client, lif
 			return merr
 		},
 	})
-	return nil
 }
 
 // Execute implements runtime.Component.Execute.

--- a/pkg/policies/controlplane/components/flowcontrol/rate-limiter/rate-limiter.go
+++ b/pkg/policies/controlplane/components/flowcontrol/rate-limiter/rate-limiter.go
@@ -102,7 +102,7 @@ func (limiterSync *rateLimiterSync) setupSync(etcdClient *etcdclient.Client, lif
 			var merr error
 			for _, configEtcdPath := range limiterSync.configEtcdPaths {
 				_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 				if err != nil {
 					logger.Error().Err(err).Msg("failed to put rate limiter config")
 					merr = multierr.Append(merr, err)

--- a/pkg/policies/controlplane/components/flowcontrol/sampler/sampler.go
+++ b/pkg/policies/controlplane/components/flowcontrol/sampler/sampler.go
@@ -81,7 +81,7 @@ func NewSamplerAndOptions(
 	), nil
 }
 
-func (samplerSync *samplerSync) setupSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (samplerSync *samplerSync) setupSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) error {
 	logger := samplerSync.policyReadAPI.GetStatusRegistry().GetLogger()
 	lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -100,14 +100,13 @@ func (samplerSync *samplerSync) setupSync(etcdClient *etcdclient.Client, lifecyc
 			}
 			var merr error
 			for _, configEtcdPath := range samplerSync.configEtcdPaths {
-				_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+				_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configEtcdPath, string(dat))
 				if err != nil {
 					logger.Error().Err(err).Msg("failed to put sampler config")
 					merr = multierr.Append(merr, err)
 				}
 			}
-			samplerSync.decisionWriter = etcdwriter.NewWriter(etcdClient, true)
+			samplerSync.decisionWriter = etcdwriter.NewWriter(&scopedKV.KVWrapper)
 			return merr
 		},
 		OnStop: func(ctx context.Context) error {
@@ -115,7 +114,7 @@ func (samplerSync *samplerSync) setupSync(etcdClient *etcdclient.Client, lifecyc
 			deleteEtcdPath := func(paths []string) error {
 				var merr error
 				for _, path := range paths {
-					_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), path)
+					_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), path)
 					if err != nil {
 						logger.Error().Err(err).Msgf("failed to delete etcd path %s", path)
 						merr = multierr.Append(merr, err)

--- a/pkg/policies/controlplane/components/flowcontrol/sampler/sampler.go
+++ b/pkg/policies/controlplane/components/flowcontrol/sampler/sampler.go
@@ -101,7 +101,7 @@ func (samplerSync *samplerSync) setupSync(etcdClient *etcdclient.Client, lifecyc
 			var merr error
 			for _, configEtcdPath := range samplerSync.configEtcdPaths {
 				_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+					configEtcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 				if err != nil {
 					logger.Error().Err(err).Msg("failed to put sampler config")
 					merr = multierr.Append(merr, err)

--- a/pkg/policies/controlplane/policy-factory.go
+++ b/pkg/policies/controlplane/policy-factory.go
@@ -63,6 +63,7 @@ type PolicyFactory struct {
 	lock                             sync.RWMutex
 	circuitJobGroup                  *jobs.JobGroup
 	etcdClient                       *etcdclient.Client
+	sessionScopedKV                  *etcdclient.SessionScopedKV
 	prometheusEnforcer               *prom.PrometheusEnforcer
 	alerterIface                     alerts.Alerter
 	registry                         status.Registry
@@ -77,6 +78,7 @@ func providePolicyFactory(
 	fxOptionsFuncs []notifiers.FxOptionsFunc,
 	alerterIface alerts.Alerter,
 	etcdClient *etcdclient.Client,
+	sessionScopedKV *etcdclient.SessionScopedKV,
 	enforcer *prom.PrometheusEnforcer,
 	lifecycle fx.Lifecycle,
 	registry status.Registry,
@@ -95,6 +97,7 @@ func providePolicyFactory(
 		registry:                         policiesStatusRegistry,
 		circuitJobGroup:                  circuitJobGroup,
 		etcdClient:                       etcdClient,
+		sessionScopedKV:                  sessionScopedKV,
 		prometheusEnforcer:               enforcer,
 		alerterIface:                     alerterIface,
 		policiesDynamicConfigEtcdWatcher: policiesDynamicConfigEtcdWatcher,
@@ -169,6 +172,7 @@ func (factory *PolicyFactory) provideControllerPolicyFxOptions(
 			),
 			factory.circuitJobGroup,
 			factory.etcdClient,
+			factory.sessionScopedKV,
 			factory.prometheusEnforcer,
 			factory.alerterIface,
 			&wrapperMessage,

--- a/pkg/policies/controlplane/policy-service.go
+++ b/pkg/policies/controlplane/policy-service.go
@@ -46,7 +46,7 @@ func RegisterPolicyService(
 
 	lifecycle.Append(fx.Hook{
 		OnStart: func(context.Context) error {
-			svc.etcdWriter = etcdwriter.NewWriter(etcdClient, false)
+			svc.etcdWriter = etcdwriter.NewWriter(&etcdClient.KVWrapper)
 			return nil
 		},
 		OnStop: func(context.Context) error {

--- a/pkg/policies/controlplane/provider.go
+++ b/pkg/policies/controlplane/provider.go
@@ -113,7 +113,7 @@ func setupPoliciesNotifier(
 	policyDynamicConfigTrackers notifiers.Trackers,
 	policyAPIWatcher notifiers.Watcher,
 	policyAPIDynamicConfigWatcher notifiers.Watcher,
-	etcdClient *etcdclient.Client,
+	scopedKV *etcdclient.SessionScopedKV,
 	lifecycle fx.Lifecycle,
 ) {
 	wrapPolicy := func(key notifiers.Key, bytes []byte, etype notifiers.EventType) (notifiers.Key, []byte, error) {
@@ -152,11 +152,11 @@ func setupPoliciesNotifier(
 		return key, dat, nil
 	}
 
-	policyEtcdNotifier := etcdnotifier.NewPrefixToEtcdNotifier(paths.PoliciesConfigPath, etcdClient, true)
+	policyEtcdNotifier := etcdnotifier.NewPrefixToEtcdNotifier(paths.PoliciesConfigPath, &scopedKV.KVWrapper)
 	// content transform callback to wrap policy in config properties wrapper
 	policyEtcdNotifier.SetTransformFunc(wrapPolicy)
 
-	policyDynamicConfigEtcdNotifier := etcdnotifier.NewPrefixToEtcdNotifier(paths.PoliciesDynamicConfigPath, etcdClient, true)
+	policyDynamicConfigEtcdNotifier := etcdnotifier.NewPrefixToEtcdNotifier(paths.PoliciesDynamicConfigPath, &scopedKV.KVWrapper)
 
 	lifecycle.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {

--- a/pkg/policies/controlplane/resources/classifier/classifier.go
+++ b/pkg/policies/controlplane/resources/classifier/classifier.go
@@ -69,7 +69,7 @@ func (configSync *classifierConfigSync) doSync(etcdClient *etcdclient.Client, li
 				return err
 			}
 			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to put classifier")
 				return err

--- a/pkg/policies/controlplane/resources/classifier/classifier.go
+++ b/pkg/policies/controlplane/resources/classifier/classifier.go
@@ -51,7 +51,7 @@ func NewClassifierOptions(
 	return fx.Options(options...), nil
 }
 
-func (configSync *classifierConfigSync) doSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (configSync *classifierConfigSync) doSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) {
 	logger := configSync.policyReadAPI.GetStatusRegistry().GetLogger()
 	lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -68,8 +68,7 @@ func (configSync *classifierConfigSync) doSync(etcdClient *etcdclient.Client, li
 				logger.Error().Err(err).Msg("Failed to marshal classifier")
 				return err
 			}
-			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+			_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configSync.etcdPath, string(dat))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to put classifier")
 				return err
@@ -77,7 +76,7 @@ func (configSync *classifierConfigSync) doSync(etcdClient *etcdclient.Client, li
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
-			_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
+			_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to delete classifier")
 				return err
@@ -85,6 +84,4 @@ func (configSync *classifierConfigSync) doSync(etcdClient *etcdclient.Client, li
 			return nil
 		},
 	})
-
-	return nil
 }

--- a/pkg/policies/controlplane/resources/fluxmeter/flux-meter.go
+++ b/pkg/policies/controlplane/resources/fluxmeter/flux-meter.go
@@ -81,7 +81,7 @@ func (configSync *fluxMeterConfigSync) doSync(etcdClient *etcdclient.Client, lif
 			// Put the marshaled data in etcd using the provided etcdPath and LeaseID.
 			// It returns an error in case of any failure.
 			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 			if err != nil {
 				// Log the error and return it in case of any failure.
 				logger.Error().Err(err).Msg("Failed to put flux meter config")

--- a/pkg/policies/controlplane/resources/fluxmeter/flux-meter.go
+++ b/pkg/policies/controlplane/resources/fluxmeter/flux-meter.go
@@ -53,9 +53,7 @@ func NewFluxMeterOptions(
 }
 
 // doSync is a method of fluxMeterConfigSync struct that syncs the flux meter configuration to etcd.
-// It takes an etcdClient of type etcdclient.Client and a lifecycle of type fx.Lifecycle as input parameters.
-// It returns an error in case of any failure during the sync process.
-func (configSync *fluxMeterConfigSync) doSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (configSync *fluxMeterConfigSync) doSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) {
 	// Get the logger instance from the status registry.
 	logger := configSync.policyReadAPI.GetStatusRegistry().GetLogger()
 
@@ -80,8 +78,7 @@ func (configSync *fluxMeterConfigSync) doSync(etcdClient *etcdclient.Client, lif
 
 			// Put the marshaled data in etcd using the provided etcdPath and LeaseID.
 			// It returns an error in case of any failure.
-			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+			_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configSync.etcdPath, string(dat))
 			if err != nil {
 				// Log the error and return it in case of any failure.
 				logger.Error().Err(err).Msg("Failed to put flux meter config")
@@ -96,7 +93,7 @@ func (configSync *fluxMeterConfigSync) doSync(etcdClient *etcdclient.Client, lif
 		OnStop: func(ctx context.Context) error {
 			// Delete the data from etcd using the provided etcdPath.
 			// It returns an error in case of any failure.
-			_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
+			_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
 			if err != nil {
 				// Log the error and return it in case of any failure.
 				logger.Error().Err(err).Msg("Failed to delete flux meter config")
@@ -107,7 +104,4 @@ func (configSync *fluxMeterConfigSync) doSync(etcdClient *etcdclient.Client, lif
 			return nil
 		},
 	})
-
-	// Return nil to indicate success.
-	return nil
 }

--- a/pkg/policies/controlplane/resources/infra-meters/infra-meters.go
+++ b/pkg/policies/controlplane/resources/infra-meters/infra-meters.go
@@ -71,7 +71,7 @@ func (configSync *infraMeterConfigSync) doSync(etcdClient *etcdclient.Client, li
 			// Put the marshaled data in etcd using the provided etcdPath and LeaseID.
 			// It returns an error in case of any failure.
 			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.LeaseID))
+				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
 			if err != nil {
 				// Log the error and return it in case of any failure.
 				logger.Error().Err(err).Msg("Failed to put infra meter config")

--- a/pkg/policies/controlplane/resources/infra-meters/infra-meters.go
+++ b/pkg/policies/controlplane/resources/infra-meters/infra-meters.go
@@ -46,7 +46,7 @@ func NewInfraMetersOptions(
 	return fx.Options(options...), nil
 }
 
-func (configSync *infraMeterConfigSync) doSync(etcdClient *etcdclient.Client, lifecycle fx.Lifecycle) error {
+func (configSync *infraMeterConfigSync) doSync(scopedKV *etcdclient.SessionScopedKV, lifecycle fx.Lifecycle) {
 	// Get the logger instance from the status registry.
 	logger := configSync.policyReadAPI.GetStatusRegistry().GetLogger()
 
@@ -70,8 +70,7 @@ func (configSync *infraMeterConfigSync) doSync(etcdClient *etcdclient.Client, li
 
 			// Put the marshaled data in etcd using the provided etcdPath and LeaseID.
 			// It returns an error in case of any failure.
-			_, err = etcdClient.KV.Put(clientv3.WithRequireLeader(ctx),
-				configSync.etcdPath, string(dat), clientv3.WithLease(etcdClient.Session.Lease()))
+			_, err = scopedKV.Put(clientv3.WithRequireLeader(ctx), configSync.etcdPath, string(dat))
 			if err != nil {
 				// Log the error and return it in case of any failure.
 				logger.Error().Err(err).Msg("Failed to put infra meter config")
@@ -86,7 +85,7 @@ func (configSync *infraMeterConfigSync) doSync(etcdClient *etcdclient.Client, li
 		OnStop: func(ctx context.Context) error {
 			// Delete the data from etcd using the provided etcdPath.
 			// It returns an error in case of any failure.
-			_, err := etcdClient.KV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
+			_, err := scopedKV.Delete(clientv3.WithRequireLeader(ctx), configSync.etcdPath)
 			if err != nil {
 				// Log the error and return it in case of any failure.
 				logger.Error().Err(err).Msg("Failed to delete infra meter config")
@@ -97,7 +96,4 @@ func (configSync *infraMeterConfigSync) doSync(etcdClient *etcdclient.Client, li
 			return nil
 		},
 	})
-
-	// Return nil to indicate success.
-	return nil
 }

--- a/test/etcd_watcher_test.go
+++ b/test/etcd_watcher_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Etcd Watcher", func() {
 
 		BeforeEach(func() {
 			k := notifiers.Key(notifierKey)
-			etcdKeyNotifier, err = etcdnotifier.NewKeyToEtcdNotifier(k, notifierPrefix, etcdClient)
+			etcdKeyNotifier, err = etcdnotifier.NewKeyToEtcdNotifier(k, notifierPrefix, &etcdClient.KVWrapper)
 			Expect(err).NotTo(HaveOccurred())
 			etcdKeyNotifier.Start()
 			err := etcdWatcher.AddKeyNotifier(etcdKeyNotifier)
@@ -153,7 +153,7 @@ var _ = Describe("Etcd Watcher", func() {
 			etcdClient.KV.Put(ctx, "foo/key1", "val1")
 			etcdClient.KV.Put(ctx, "foo/key2", "val2")
 			etcdClient.KV.Put(ctx, "foo/key3", "val3")
-			etcdNotifier = etcdnotifier.NewPrefixToEtcdNotifier("bar/", etcdClient, false)
+			etcdNotifier = etcdnotifier.NewPrefixToEtcdNotifier("bar/", &etcdClient.KVWrapper)
 			etcdNotifier.Start()
 			err := etcdWatcher.AddPrefixNotifier(etcdNotifier)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/etcd_watcher_test.go
+++ b/test/etcd_watcher_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Etcd Watcher", func() {
 
 		BeforeEach(func() {
 			k := notifiers.Key(notifierKey)
-			etcdKeyNotifier, err = etcdnotifier.NewKeyToEtcdNotifier(k, notifierPrefix, etcdClient, false)
+			etcdKeyNotifier, err = etcdnotifier.NewKeyToEtcdNotifier(k, notifierPrefix, etcdClient)
 			Expect(err).NotTo(HaveOccurred())
 			etcdKeyNotifier.Start()
 			err := etcdWatcher.AddKeyNotifier(etcdKeyNotifier)


### PR DESCRIPTION
### Description of change

There's a logic to shut down the app when etcd session expires. This is
not desired in all usecases of etcd.Client, so Session is now a separate
type.

Also, the withLease flag on etcdwriter was replaced by SessionScopedKV
wrapper, that handles attaching leases to Put requests.


##### Checklist

- [x] Tested in playground or other setup
   - [x] default scenario
   - [x] autoscale scenario (as autoscale is the only actuator that writes to etcd on agent side)
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Split out the `Session` type from `etcd/client.Client`.
- Replaced the `withLease` flag with a `SessionScopedKV` wrapper.
- Updated the `Writer` struct and its methods to accommodate the changes.
- Modified the `doSync` function in `podScalerConfigSync` and `loadSchedulerConfigSync` to accept a `scopedKV` parameter.
- The `Put` and `Delete` operations on `etcdClient.KV` have been replaced with equivalent operations on `scopedKV`.
- The `setupWriter` method in the `ScaleActuator` struct now uses a `SessionScopedKV` wrapper.

> 🎉 Code refactor, oh what a sight! 🌟
> 
> With `SessionScopedKV`, we've taken flight. ✈️
> 
> No more `withLease`, it's out of sight, 🚀
> 
> Our code is cleaner, and oh-so right! 💫
<!-- end of auto-generated comment: release notes by coderabbit.ai -->