### PR TITLE
Always unmarshal etcd client tls config

### DIFF
--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -3,12 +3,10 @@ package extconfig
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/fx"
 
 	"github.com/fluxninja/aperture/v2/pkg/config"
-	"github.com/fluxninja/aperture/v2/pkg/etcd"
 	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
 	"github.com/fluxninja/aperture/v2/pkg/net/grpc"
 	"github.com/fluxninja/aperture/v2/pkg/net/http"
@@ -71,16 +69,14 @@ func provideConfig(unmarshaller config.Unmarshaller) (*FluxNinjaExtensionConfig,
 func provideEtcdConfigOverride(extensionConfig *FluxNinjaExtensionConfig) *etcdclient.ConfigOverride {
 	if extensionConfig.EnableCloudController {
 		return &etcdclient.ConfigOverride{
-			EtcdConfig: etcd.EtcdConfig{
-				Namespace: "",
-				Endpoints: []string{extensionConfig.Endpoint},
-				LeaseTTL:  config.MakeDuration(60 * time.Second),
-			},
+			Namespace: "",
+			Endpoints: []string{extensionConfig.Endpoint},
 			PerRPCCredentials: perRPCHeaders{
 				headers: map[string]string{
 					"apiKey": extensionConfig.APIKey,
 				},
 			},
+			OverriderName: "fluxninja extension",
 		}
 	} else {
 		return nil


### PR DESCRIPTION
### Description of change

This will allow configuring etcd client tls settings even if using
fluxninja-extension-injected etcd endpoints.

Resolves https://github.com/fluxninja/aperture/issues/2372

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Bug fix:**
- Fixed an issue where etcd client TLS settings could not be configured when using fluxninja-extension-injected etcd endpoints. This change enhances the security and flexibility of the system.

> 🎉 Here's to the bugs we squash, 🐛
> 
> To the code that never crashes. 💻
> 
> With each PR, we make a dash, 🏃‍♂️
> 
> For a future that's secure and brash! 🔒🎊
<!-- end of auto-generated comment: release notes by coderabbit.ai -->