### PR TITLE
Add fine-grained locks for Otel Collector config provider

### DIFF
--- a/extensions/fluxninja/otel/otel_test.go
+++ b/extensions/fluxninja/otel/otel_test.go
@@ -69,10 +69,12 @@ var _ = DescribeTable("FN Extension OTel", func(
 	err = app.Start(context.TODO())
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(configProvider.MustGetConfig().Receivers).To(Equal(expected.Receivers))
-	Expect(configProvider.MustGetConfig().Processors).To(Equal(expected.Processors))
-	Expect(configProvider.MustGetConfig().Exporters).To(Equal(expected.Exporters))
-	Expect(configProvider.MustGetConfig().Service.Pipelines).To(Equal(expected.Service.Pipelines))
+	c := configProvider.GetConfig()
+	Expect(c).ToNot(BeNil())
+	Expect(c.Receivers).To(Equal(expected.Receivers))
+	Expect(c.Processors).To(Equal(expected.Processors))
+	Expect(c.Exporters).To(Equal(expected.Exporters))
+	Expect(c.Service.Pipelines).To(Equal(expected.Service.Pipelines))
 
 	err = app.Stop(context.TODO())
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/otelcollector/config/provider.go
+++ b/pkg/otelcollector/config/provider.go
@@ -17,11 +17,12 @@ var _ confmap.Provider = (*Provider)(nil)
 //
 // It allows updating the config and registering hooks.
 type Provider struct {
-	lock      sync.Mutex // protects config, watchFunc & hooks
-	config    *Config    // nil only after Shutdown.
-	watchFunc confmap.WatcherFunc
-	hooks     []func(*Config)
-	scheme    string
+	configLock    sync.RWMutex // protects config, watchFunc & hooks
+	watchFuncLock sync.Mutex   // protects watchFunc
+	config        *Config      // nil only after Shutdown.
+	watchFunc     confmap.WatcherFunc
+	hooks         []func(*Config)
+	scheme        string
 }
 
 // NewProvider creates a new OTelConfigProvider.
@@ -40,25 +41,21 @@ func (p *Provider) Retrieve(
 	_ string,
 	watchFn confmap.WatcherFunc,
 ) (*confmap.Retrieved, error) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	if p.config == nil {
-		log.Bug().Msg("Retrieve after Shutdown")
+	c := p.GetConfig()
+	if c == nil {
+		log.Bug().Msg("Retrieve called after Shutdown")
 		return nil, errors.New("already shut down")
 	}
 
-	p.watchFunc = watchFn
+	p.SetWatchFunc(watchFn)
 	return confmap.NewRetrieved(p.config.AsMap())
 }
 
 // Shutdown implements confmap.Provider.
 func (p *Provider) Shutdown(ctx context.Context) error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
 	// Prevent UpdateConfig to run after Shutdown.
-	p.watchFunc = nil
-	p.config = nil
+	p.SetWatchFunc(nil)
+	p.SetConfig(nil)
 	return nil
 }
 
@@ -76,34 +73,15 @@ func (p *Provider) UpdateConfig(config *Config) {
 		config = New()
 	}
 
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	for _, hook := range p.hooks {
 		hook(config)
 	}
 
-	p.setConfig(config)
-}
-
-// Set post-hooks config and trigger update, assuming p.lock locked.
-func (p *Provider) setConfig(config *Config) {
-	if p.config == nil {
-		log.Warn().Msg("OtelConfigProvider: tried to update config after Shutdown")
-		return
+	p.SetConfigIfNotNil(config)
+	wf := p.GetWatchFunc()
+	if wf != nil {
+		wf(&confmap.ChangeEvent{})
 	}
-
-	p.config = config
-	if p.watchFunc != nil {
-		p.watchFunc(&confmap.ChangeEvent{})
-		// Prevent calling watchFunc another time before the next Retrieve
-		// (perhaps it's even illegal). We won't miss any update though, as
-		// explained below.
-		p.watchFunc = nil
-	}
-	// If watchFunc is nil, then:
-	// * either we have not any Retrieve yet, so there's no reason to notify, or
-	// * we already notified of the change, but didn't got Retrieve yet.
 }
 
 // AddMutatingHook adds a hook to be run before applying config.
@@ -111,10 +89,9 @@ func (p *Provider) setConfig(config *Config) {
 // The hook should treat the given config as temporary.
 // The hook will also be executed immediately, to ensure that current config
 // was passed through all the added hooks.
+//
+// WARNING: This is supposed to be called only during initialization.
 func (p *Provider) AddMutatingHook(hook func(*Config)) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	if p.config == nil {
 		log.Warn().Msg("OtelConfigProvider.AddHook: already shut down")
 		return
@@ -122,15 +99,44 @@ func (p *Provider) AddMutatingHook(hook func(*Config)) {
 
 	p.hooks = append(p.hooks, hook)
 
-	// Now the config provided to collector is outdated, run the newly-added hook.
-	hook(p.config)
-	p.setConfig(p.config)
+	p.UpdateConfig(p.config)
 }
 
-// MustGetConfig returns a snapshot of the current config.
-func (p *Provider) MustGetConfig() *Config {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	// Copying to avoid concurrent modification by hooks.
-	return p.config.MustCopy()
+// GetConfig returns the current config.
+func (p *Provider) GetConfig() *Config {
+	p.configLock.RLock()
+	defer p.configLock.RUnlock()
+	return p.config
+}
+
+// SetConfig sets the new config, replacing the old one.
+func (p *Provider) SetConfig(config *Config) {
+	p.configLock.Lock()
+	defer p.configLock.Unlock()
+	p.config = config
+}
+
+// SetConfigIfNotNil sets the new config only if it nil.
+func (p *Provider) SetConfigIfNotNil(config *Config) {
+	p.configLock.Lock()
+	defer p.configLock.Unlock()
+	if p.config == nil {
+		log.Warn().Msg("OtelConfigProvider: tried to update config after Shutdown")
+		return
+	}
+	p.config = config
+}
+
+// GetWatchFunc returns the current watch function.
+func (p *Provider) GetWatchFunc() confmap.WatcherFunc {
+	p.watchFuncLock.Lock()
+	defer p.watchFuncLock.Unlock()
+	return p.watchFunc
+}
+
+// SetWatchFunc sets the new watch function, replacing the old one.
+func (p *Provider) SetWatchFunc(watchFunc confmap.WatcherFunc) {
+	p.watchFuncLock.Lock()
+	defer p.watchFuncLock.Unlock()
+	p.watchFunc = watchFunc
 }

--- a/pkg/otelcollector/config/provider.go
+++ b/pkg/otelcollector/config/provider.go
@@ -17,7 +17,7 @@ var _ confmap.Provider = (*Provider)(nil)
 //
 // It allows updating the config and registering hooks.
 type Provider struct {
-	configLock    sync.RWMutex // protects config, watchFunc & hooks
+	configLock    sync.RWMutex // protects config
 	watchFuncLock sync.Mutex   // protects watchFunc
 	config        *Config      // nil only after Shutdown.
 	watchFunc     confmap.WatcherFunc


### PR DESCRIPTION
### Description of change

This helps in solving the issue where the collector hangs whenever more than 1 policies are applied and multiple UpdateConfigs was causing a deadlock.

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Modified assertion statements in `otel_test.go` and `provider.go` to use `GetConfig` method instead of `MustGetConfig` for avoiding potential deadlock issues.
- Refactored the `Provider` struct to introduce fine-grained locking for the Otel Collector config provider.
- Added new methods `GetConfig`, `GetWatchFunc`, and `SetWatchFunc` for better access control.

> 🎉 Here's to the code that's now more robust, 🥂
> With deadlock issues a thing of the past. 🚀
> Fine-grained locking, a must we trust, 🛠️
> Makes our Otel Collector stand steadfast! 💪
<!-- end of auto-generated comment: release notes by coderabbit.ai -->