### PR TITLE
Tweaks in ARC controller docs

### DIFF
--- a/docs/content/arc/extension.md
+++ b/docs/content/arc/extension.md
@@ -20,14 +20,6 @@ export const ExtensionConfig = ({children, component}) => (
   config:
     fluxninja:
       endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
-      client:
-        grpc:
-          insecure: false
-          tls:
-            insecure_skip_verify: true
-        http:
-          tls:
-            insecure_skip_verify: true
   secrets:
     fluxNinjaExtension:
       create: true
@@ -71,6 +63,13 @@ Configure the following parameters in the `values.yaml` file generated during
 installation of the Aperture Controller or Agent:
 
 <Tabs>
+  <TabItem value="ARC Controller">
+    <Tabs>
+      <TabItem value="Agent">
+        <CloudExtensionConfig />
+      </TabItem>
+    </Tabs>
+  </TabItem>
   <TabItem value="On-premise Controller">
     <Tabs>
       <TabItem value="Controller">
@@ -81,13 +80,6 @@ installation of the Aperture Controller or Agent:
       </TabItem>
     </Tabs>
   </TabItem>
-  <TabItem value="ARC Controller">
-    <Tabs>
-      <TabItem value="Agent">
-        <CloudExtensionConfig />
-      </TabItem>
-    </Tabs>
-  </TabItem>
 </Tabs>
 
 Replace the values of `ORGANIZATION_NAME` and `API_KEY` with the actual values
@@ -95,8 +87,8 @@ of the organization on FluxNinja ARC and API Key generated on it.
 
 Configuration parameters for the FluxNinja ARC Extension are as follows:
 
-- [Aperture Controller](/reference/configuration/controller.md/#flux-ninja)
-- [Aperture Agent](/reference/configuration/agent.md#flux-ninja)
+- [Aperture Agent](/reference/configuration/agent.md#flux-ninja-extension-config)
+- [Aperture Controller](/reference/configuration/controller.md/#flux-ninja-extension-config)
 
 ## See also
 

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1526,7 +1526,10 @@ API Key for this agent. If this key is not set, the extension won't be enabled.
 
 <!-- vale on -->
 
-Controller ID.
+Overrides Controller ID for Aperture Controller. If not set, random id will be
+generated and persisted in etcd.
+
+Note: This option doesn't affect Aperture Agent.
 
 </dd>
 <dt>disable_local_otel_pipeline</dt>
@@ -1538,8 +1541,8 @@ Controller ID.
 
 <!-- vale on -->
 
-Whether to configure local Prometheus OTel pipeline for metrics. Implied to be
-true by EnableCloudController.
+Disables local Prometheus OTel pipelines for metrics. Implied by
+EnableCloudController.
 
 </dd>
 <dt>enable_cloud_controller</dt>
@@ -1551,8 +1554,10 @@ true by EnableCloudController.
 
 <!-- vale on -->
 
-Whether to enable ARC controller. Overrides etcd configuration and Prometheus
-writer.
+Whether to connect to ARC controller.
+
+Overrides etcd configuration and disables local Prometheus OTel pipelines. See
+[FluxNinja ARC](/arc/arc.md) for more details.
 
 </dd>
 <dt>endpoint</dt>

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -947,7 +947,10 @@ API Key for this agent. If this key is not set, the extension won't be enabled.
 
 <!-- vale on -->
 
-Controller ID.
+Overrides Controller ID for Aperture Controller. If not set, random id will be
+generated and persisted in etcd.
+
+Note: This option doesn't affect Aperture Agent.
 
 </dd>
 <dt>disable_local_otel_pipeline</dt>
@@ -959,8 +962,8 @@ Controller ID.
 
 <!-- vale on -->
 
-Whether to configure local Prometheus OTel pipeline for metrics. Implied to be
-true by EnableCloudController.
+Disables local Prometheus OTel pipelines for metrics. Implied by
+EnableCloudController.
 
 </dd>
 <dt>enable_cloud_controller</dt>
@@ -972,8 +975,10 @@ true by EnableCloudController.
 
 <!-- vale on -->
 
-Whether to enable ARC controller. Overrides etcd configuration and Prometheus
-writer.
+Whether to connect to ARC controller.
+
+Overrides etcd configuration and disables local Prometheus OTel pipelines. See
+[FluxNinja ARC](/arc/arc.md) for more details.
 
 </dd>
 <dt>endpoint</dt>

--- a/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
+++ b/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
@@ -99,20 +99,27 @@ definitions:
                 description: Client configuration.
                 x-go-tag-json: client
             controller_id:
-                description: Controller ID.
+                description: |-
+                    Overrides Controller ID for Aperture Controller. If not set, random id will be generated and persisted in etcd.
+
+                    Note: This option doesn't affect Aperture Agent.
                 type: string
                 x-go-name: ControllerID
                 x-go-tag-json: controller_id,omitempty
             disable_local_otel_pipeline:
                 default: false
-                description: Whether to configure local Prometheus OTel pipeline for metrics. Implied to be true by EnableCloudController.
+                description: Disables local Prometheus OTel pipelines for metrics. Implied by EnableCloudController.
                 type: boolean
                 x-go-name: DisableLocalOTelPipeline
                 x-go-tag-default: "false"
                 x-go-tag-json: disable_local_otel_pipeline
             enable_cloud_controller:
                 default: false
-                description: Whether to enable ARC controller. Overrides etcd configuration and Prometheus writer.
+                description: |-
+                    Whether to connect to ARC controller.
+
+                    Overrides etcd configuration and disables local Prometheus OTel pipelines.
+                    See [FluxNinja ARC](/arc/arc.md) for more details.
                 type: boolean
                 x-go-name: EnableCloudController
                 x-go-tag-default: "false"

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -22,21 +22,27 @@ const (
 // swagger:model
 // +kubebuilder:object:generate=true
 type FluxNinjaExtensionConfig struct {
-	// Interval between each heartbeat.
-	HeartbeatInterval config.Duration `json:"heartbeat_interval" validate:"gte=0s" default:"5s"`
 	// Address to gRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
 	Endpoint string `json:"endpoint" validate:"omitempty,hostname_port|url|fqdn"`
 	// API Key for this agent. If this key is not set, the extension won't be enabled.
 	APIKey string `json:"api_key"`
-	// Client configuration.
-	ClientConfig ClientConfig `json:"client"`
 	// Installation mode describes on which underlying platform the Agent or the Controller is being run.
 	InstallationMode string `json:"installation_mode" validate:"oneof=KUBERNETES_SIDECAR KUBERNETES_DAEMONSET LINUX_BARE_METAL" default:"LINUX_BARE_METAL"`
-	// Whether to configure local Prometheus OTel pipeline for metrics. Implied to be true by EnableCloudController.
-	DisableLocalOTelPipeline bool `json:"disable_local_otel_pipeline" default:"false"`
-	// Whether to enable ARC controller. Overrides etcd configuration and Prometheus writer.
+	// Whether to connect to ARC controller.
+	//
+	// Overrides etcd configuration and disables local Prometheus OTel pipelines.
+	// See [FluxNinja ARC](/arc/arc.md) for more details.
 	EnableCloudController bool `json:"enable_cloud_controller" default:"false"`
-	// Controller ID.
+
+	// Interval between each heartbeat.
+	HeartbeatInterval config.Duration `json:"heartbeat_interval" validate:"gte=0s" default:"5s"`
+	// Client configuration.
+	ClientConfig ClientConfig `json:"client"`
+	// Disables local Prometheus OTel pipelines for metrics. Implied by EnableCloudController.
+	DisableLocalOTelPipeline bool `json:"disable_local_otel_pipeline" default:"false"`
+	// Overrides Controller ID for Aperture Controller. If not set, random id will be generated and persisted in etcd.
+	//
+	// Note: This option doesn't affect Aperture Agent.
 	ControllerID string `json:"controller_id,omitempty"`
 }
 

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1292,15 +1292,18 @@ spec:
                             type: object
                         type: object
                       controller_id:
-                        description: Controller ID.
+                        description: "Overrides Controller ID for Aperture Controller.
+                          If not set, random id will be generated and persisted in
+                          etcd. \n Note: This option doesn't affect Aperture Agent."
                         type: string
                       disable_local_otel_pipeline:
-                        description: Whether to configure local Prometheus OTel pipeline
-                          for metrics. Implied to be true by EnableCloudController.
+                        description: Disables local Prometheus OTel pipelines for
+                          metrics. Implied by EnableCloudController.
                         type: boolean
                       enable_cloud_controller:
-                        description: Whether to enable ARC controller. Overrides etcd
-                          configuration and Prometheus writer.
+                        description: "Whether to connect to ARC controller. \n Overrides
+                          etcd configuration and disables local Prometheus OTel pipelines.
+                          See [FluxNinja ARC](/arc/arc.md) for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -1176,15 +1176,18 @@ spec:
                             type: object
                         type: object
                       controller_id:
-                        description: Controller ID.
+                        description: "Overrides Controller ID for Aperture Controller.
+                          If not set, random id will be generated and persisted in
+                          etcd. \n Note: This option doesn't affect Aperture Agent."
                         type: string
                       disable_local_otel_pipeline:
-                        description: Whether to configure local Prometheus OTel pipeline
-                          for metrics. Implied to be true by EnableCloudController.
+                        description: Disables local Prometheus OTel pipelines for
+                          metrics. Implied by EnableCloudController.
                         type: boolean
                       enable_cloud_controller:
-                        description: Whether to enable ARC controller. Overrides etcd
-                          configuration and Prometheus writer.
+                        description: "Whether to connect to ARC controller. \n Overrides
+                          etcd configuration and disables local Prometheus OTel pipelines.
+                          See [FluxNinja ARC](/arc/arc.md) for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1292,15 +1292,18 @@ spec:
                             type: object
                         type: object
                       controller_id:
-                        description: Controller ID.
+                        description: "Overrides Controller ID for Aperture Controller.
+                          If not set, random id will be generated and persisted in
+                          etcd. \n Note: This option doesn't affect Aperture Agent."
                         type: string
                       disable_local_otel_pipeline:
-                        description: Whether to configure local Prometheus OTel pipeline
-                          for metrics. Implied to be true by EnableCloudController.
+                        description: Disables local Prometheus OTel pipelines for
+                          metrics. Implied by EnableCloudController.
                         type: boolean
                       enable_cloud_controller:
-                        description: Whether to enable ARC controller. Overrides etcd
-                          configuration and Prometheus writer.
+                        description: "Whether to connect to ARC controller. \n Overrides
+                          etcd configuration and disables local Prometheus OTel pipelines.
+                          See [FluxNinja ARC](/arc/arc.md) for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1176,15 +1176,18 @@ spec:
                             type: object
                         type: object
                       controller_id:
-                        description: Controller ID.
+                        description: "Overrides Controller ID for Aperture Controller.
+                          If not set, random id will be generated and persisted in
+                          etcd. \n Note: This option doesn't affect Aperture Agent."
                         type: string
                       disable_local_otel_pipeline:
-                        description: Whether to configure local Prometheus OTel pipeline
-                          for metrics. Implied to be true by EnableCloudController.
+                        description: Disables local Prometheus OTel pipelines for
+                          metrics. Implied by EnableCloudController.
                         type: boolean
                       enable_cloud_controller:
-                        description: Whether to enable ARC controller. Overrides etcd
-                          configuration and Prometheus writer.
+                        description: "Whether to connect to ARC controller. \n Overrides
+                          etcd configuration and disables local Prometheus OTel pipelines.
+                          See [FluxNinja ARC](/arc/arc.md) for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in


### PR DESCRIPTION
Follow-up to #2387

* Make ARC Controller tab default.
* Remove setting insecure from config examples.
* Reorder fields in extension config by importance, too bad it ends up
  alphabetical in docs anyway, due to #255.
* Misc tweaks to wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Documentation:**
- Updated ARC controller documentation to improve clarity and usability.
- Made the ARC Controller tab the default for easier access.
- Removed the "insecure" setting from config examples to enhance security.
- Reordered fields in the extension config by importance for better understanding.

> 🎉 Here's to the docs that guide our way,  
> Now clearer, safer, day by day.  
> With fields reordered, no more dismay,  
> On the ARC Controller tab, we'll stay! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->