### PR TITLE
aperturectl: Clarify directory merge behavior in warning

### DIFF
--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -304,7 +304,7 @@ func setupOutputDir(outputDir string) (string, error) {
 	// ask for user confirmation if the output directory already exists
 	if !overwrite {
 		if _, err := os.Stat(outputDir); err == nil {
-			fmt.Printf("The output directory '%s' already exists. Do you want to overwrite it? [y/N]: ", outputDir)
+			fmt.Printf("The output directory '%s' already exists. Do you want to merge the generated policy artifacts into the existing directory? [y/N]: ", outputDir)
 			var response string
 			fmt.Scanln(&response)
 			if response != "y" {


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Improved user prompt in `cmd/aperturectl/cmd/blueprints/generate.go`. When the output directory already exists, the system now asks if the user wants to merge the generated policy artifacts into the existing directory instead of overwriting it.

> 🎉 In the realm of code where changes are a sight,
> A refactor emerged, bringing users delight.
> No more confusion, no overwrite fright,
> Just merging policies, oh so right! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->