### PR TITLE
Update go version v1.20.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ commands:
       - restore_cache:
           name: Restore ASDF cache
           keys:
-            - aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            - aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
               parameters.cache_name >>-{{ checksum ".tool-versions" }}-{{
               checksum "go.mod" }}
-            - aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            - aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
               parameters.cache_name >>-
       - run:
           name: Copy tool-versions in HOME dir
@@ -66,7 +66,7 @@ commands:
       - save_cache:
           name: Save ASDF cache
           key:
-            aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
             parameters.cache_name >>-{{ checksum ".tool-versions" }}-{{ checksum
             "go.mod" }}
           paths:

--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -13,7 +13,7 @@ executors:
       - image: cimg/base:2022.07
   go-cimg-executor:
     docker:
-      - image: cimg/go:1.20.5
+      - image: cimg/go:1.20.6
         user: root
   python-cimg-executor:
     docker:
@@ -316,7 +316,7 @@ jobs:
       - restore_cache:
           name: Restore daily cache
           keys:
-            - aperture-v8-daily-cache-{{ checksum "~/day" }}
+            - aperture-v9-daily-cache-{{ checksum "~/day" }}
       - run: &install_opsninja
           name: Install opsninja and its dependencies
           command: |
@@ -397,7 +397,7 @@ jobs:
             fi
       - save_cache:
           name: Save daily cache
-          key: aperture-v8-daily-cache-{{ checksum "~/day" }}
+          key: aperture-v9-daily-cache-{{ checksum "~/day" }}
           paths:
             - ../.cache/go-build
             - ../.cache/golangci-lint
@@ -1082,7 +1082,7 @@ jobs:
       - restore_cache:
           name: Restore go cache
           keys:
-            - aperture-v1-upload-policies-go-cache
+            - aperture-v2-go-cache-upload-policies
       - run:
           name: Apply Policy
           working_directory: .
@@ -1091,7 +1091,7 @@ jobs:
             --controller << parameters.controller-endpoint >> --api-key ${CONTROLLER_API_KEY} -f -s
       - save_cache:
           name: Save go cache
-          key: aperture-v1-upload-policies-go-cache
+          key: aperture-v2-go-cache-upload-policies
           paths:
             - ../.cache/go-build
             - ./blueprints/vendor
@@ -1491,10 +1491,10 @@ commands:
       - restore_cache:
           name: Restore ASDF cache
           keys:
-            - aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            - aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
               parameters.cache_name >>-{{ checksum ".tool-versions" }}-{{
               checksum "tools/go/go.mod" }}
-            - aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            - aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
               parameters.cache_name >>-
       - run:
           name: Copy tool-versions in HOME dir
@@ -1516,7 +1516,7 @@ commands:
       - save_cache:
           name: Save ASDF cache
           key:
-            aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
             parameters.cache_name >>-{{ checksum ".tool-versions" }}-{{ checksum
             "tools/go/go.mod" }}
           paths:

--- a/.circleci/post-release.yaml
+++ b/.circleci/post-release.yaml
@@ -399,10 +399,10 @@ commands:
       - restore_cache:
           name: Restore ASDF cache
           keys:
-            - aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            - aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
               parameters.cache_name >>-{{ checksum ".tool-versions" }}-{{
               checksum "go.mod" }}-{{ checksum "~/installed-tools" }}
-            - aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            - aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
               parameters.cache_name >>-
       - run:
           name: Copy tool-versions in HOME dir
@@ -427,7 +427,7 @@ commands:
       - save_cache:
           name: Save ASDF cache
           key:
-            aperture-asdf-cache-v10-{{ checksum "~/month" }}-<<
+            aperture-asdf-cache-v11-{{ checksum "~/month" }}-<<
             parameters.cache_name >>-{{ checksum ".tool-versions" }}-{{ checksum
             "go.mod" }}-{{ checksum "~/installed-tools" }}
           paths:

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ pre-commit 3.3.1
 bats 1.9.0
 python 3.11.4
 gcloud 429.0.0
-golang 1.20.5
+golang 1.20.6
 golangci-lint 1.53.3
 grpcurl 1.8.7
 mockery 2.26.1

--- a/cmd/aperture-agent/Dockerfile
+++ b/cmd/aperture-agent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.20.5-bullseye AS builder
+FROM golang:1.20.6-bullseye AS builder
 
 WORKDIR /src
 COPY --link . .
@@ -15,8 +15,8 @@ ARG APERTURECTL_BUILD_FLAGS
 ENV APERTURECTL_BUILD_FLAGS=${APERTURECTL_BUILD_FLAGS}
 
 RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/,id=agent-1.20.5,sharing=private \
-  --mount=type=cache,target=/root/.aperturectl,id=agent-1.20.5,sharing=private \
+  --mount=type=cache,target=/root/.cache/go-build/,id=agent-1.20.6,sharing=private \
+  --mount=type=cache,target=/root/.aperturectl,id=agent-1.20.6,sharing=private \
   /bin/bash -c \
   'set -eu; \
   go mod download; \

--- a/cmd/aperture-controller/Dockerfile
+++ b/cmd/aperture-controller/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.20.5-bullseye AS builder
+FROM golang:1.20.6-bullseye AS builder
 
 WORKDIR /src
 COPY --link . .
@@ -15,8 +15,8 @@ ARG APERTURECTL_BUILD_FLAGS
 ENV APERTURECTL_BUILD_FLAGS=${APERTURECTL_BUILD_FLAGS}
 
 RUN --mount=type=cache,target=/go/pkg/ \
-  --mount=type=cache,target=/root/.cache/go-build/,id=controller-1.20.5,sharing=private \
-  --mount=type=cache,target=/root/.aperturectl,id=controller-1.20.5,sharing=private \
+  --mount=type=cache,target=/root/.cache/go-build/,id=controller-1.20.6,sharing=private \
+  --mount=type=cache,target=/root/.aperturectl,id=controller-1.20.6,sharing=private \
   /bin/bash -c \
   'go mod download; \
   ./scripts/build_aperturectl.sh ./cmd/aperturectl; \

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.20.5-bullseye AS builder
+FROM golang:1.20.6-bullseye AS builder
 
 WORKDIR /src
 COPY --link . .

--- a/playground/resources/demo-app/Dockerfile
+++ b/playground/resources/demo-app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.20.5-bullseye AS builder
+FROM golang:1.20.6-bullseye AS builder
 
 WORKDIR /src
 

--- a/playground/resources/graphql-demo-app/Dockerfile
+++ b/playground/resources/graphql-demo-app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.20.5-bullseye AS builder
+FROM golang:1.20.6-bullseye AS builder
 
 WORKDIR /src
 

--- a/scripts/invalidate_asdf_ci_cache.sh
+++ b/scripts/invalidate_asdf_ci_cache.sh
@@ -18,3 +18,9 @@ done
 "$FIND" .circleci -type f \( -name "*.yml" -o -name "*.yaml" \) -print0 | while read -r -d $'\0' file; do
 	"$AWK" -i inplace '/aperture-v[0-9]+-daily-cache-/ {match($0, /aperture-v([0-9]+)(.*)/, a); $0 = gensub(/aperture-v[0-9]+-daily-cache-/, "aperture-v" a[1]+1 "-daily-cache-", "g", $0)} {print}' "$file"
 done
+
+# invalidate aperture-v<version>-go-cache-* as well
+# shellcheck disable=SC2016
+"$FIND" .circleci -type f \( -name "*.yml" -o -name "*.yaml" \) -print0 | while read -r -d $'\0' file; do
+	"$AWK" -i inplace '/aperture-v[0-9]+-go-cache-/ {match($0, /aperture-v([0-9]+)(.*)/, a); $0 = gensub(/aperture-v[0-9]+-go-cache-/, "aperture-v" a[1]+1 "-go-cache-", "g", $0)} {print}' "$file"
+done

--- a/sdks/aperture-go/Dockerfile
+++ b/sdks/aperture-go/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.20.5 AS builder
+FROM golang:1.20.6 AS builder
 
 WORKDIR /src
 COPY --link . .


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:
- Chore: Updated Go version to v1.20.6 in various files, including Dockerfiles and configuration files.
- Chore: Modified logic and functionality in `invalidate_asdf_ci_cache.sh` script.

> "A dance of code unfolds,
> Go version upgraded, stories untold.
> Dockerfiles and scripts, revamped with care,
> A touch of logic, a breath of fresh air.
> With each change, progress is made,
> Celebrating the art of the upgrade."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->