### PR TITLE
Added support to load config from environment variables in aperturectl

### DIFF
--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -117,6 +117,10 @@ func (c *ControllerConn) InitFlags(flags *flag.FlagSet) {
 
 // PreRunE verifies flags (optionally loading kubeconfig) and should be run at PreRunE stage.
 func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
+	if c.config != "" && c.apiKey != "" {
+		return errors.New("--api-key cannot be used with --config")
+	}
+
 	// Fetching config from environment variable
 	if c.config == "" {
 		c.config = os.Getenv(configEnv)
@@ -135,10 +139,6 @@ func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 		c.kube = true
 	}
 
-	if c.config != "" && c.apiKey != "" {
-		return errors.New("--api-key cannot be used with --config")
-	}
-
 	if c.controllerAddr != "" && c.kube {
 		return errors.New("--controller cannot be used with --kube")
 	}
@@ -153,7 +153,7 @@ func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-	} else if c.apiKey == "" && !c.kube {
+	} else if c.config != "" {
 		var err error
 		c.config, err = filepath.Abs(c.config)
 		if err != nil {

--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -157,7 +157,7 @@ func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 		var err error
 		c.config, err = filepath.Abs(c.config)
 		if err != nil {
-			c.config = ""
+			return fmt.Errorf("failed to resolve config file '%s' path: %w", c.config, err)
 		}
 
 		config := &Config{}

--- a/cmd/aperturectl/cmd/utils/globals.go
+++ b/cmd/aperturectl/cmd/utils/globals.go
@@ -2,6 +2,7 @@ package utils
 
 const (
 	apertureRepo = "https://github.com/fluxninja/aperture"
+	configEnv    = "APERTURE_CONFIG"
 )
 
 var AllowDeprecated = false

--- a/docs/content/reference/aperturectl/agents/agents.md
+++ b/docs/content/reference/aperturectl/agents/agents.md
@@ -24,6 +24,7 @@ aperturectl agents [flags]
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for agents

--- a/docs/content/reference/aperturectl/apply/apply.md
+++ b/docs/content/reference/aperturectl/apply/apply.md
@@ -20,6 +20,7 @@ Use this command to apply the Aperture Policies.
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for apply

--- a/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
+++ b/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
@@ -38,6 +38,7 @@ aperturectl apply dynamic-config --policy=rate-limiting --file=dynamic-config.ya
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/apply/policy/policy.md
+++ b/docs/content/reference/aperturectl/apply/policy/policy.md
@@ -42,6 +42,7 @@ aperturectl apply policy --dir=policies
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/auto-scale/auto-scale.md
+++ b/docs/content/reference/aperturectl/auto-scale/auto-scale.md
@@ -20,6 +20,7 @@ Use this command to query information about active AutoScale integrations
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for auto-scale

--- a/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
@@ -36,6 +36,7 @@ aperturectl auto-scale control-points
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/blueprints/generate/generate.md
+++ b/docs/content/reference/aperturectl/blueprints/generate/generate.md
@@ -33,6 +33,7 @@ aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-lim
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
       --apply                  Apply generated policies on the Kubernetes cluster in the namespace where Aperture Controller is installed
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -f, --force                  Force apply policy even if it already exists

--- a/docs/content/reference/aperturectl/decisions/decisions.md
+++ b/docs/content/reference/aperturectl/decisions/decisions.md
@@ -33,6 +33,7 @@ aperturectl decisions [flags]
 ```
       --all                    Get all decisions
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --decision-type string   Type of the decision to get (load_scheduler, rate_limiter, quota_scheduler, pod_scaler, sampler)

--- a/docs/content/reference/aperturectl/delete/delete.md
+++ b/docs/content/reference/aperturectl/delete/delete.md
@@ -20,6 +20,7 @@ Use this command to delete the Aperture Policies.
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for delete

--- a/docs/content/reference/aperturectl/delete/policy/policy.md
+++ b/docs/content/reference/aperturectl/delete/policy/policy.md
@@ -36,6 +36,7 @@ aperturectl delete policy --policy=rate-limiting
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/discovery/discovery.md
+++ b/docs/content/reference/aperturectl/discovery/discovery.md
@@ -20,6 +20,7 @@ Use this command to query information about active Discovery integrations
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for discovery

--- a/docs/content/reference/aperturectl/discovery/entities/entities.md
+++ b/docs/content/reference/aperturectl/discovery/entities/entities.md
@@ -41,6 +41,7 @@ aperturectl discovery entities --find-by=“ip=10.244.1.24”
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
@@ -36,6 +36,7 @@ aperturectl flow-control control-points
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/flow-control/flow-control.md
+++ b/docs/content/reference/aperturectl/flow-control/flow-control.md
@@ -20,6 +20,7 @@ Use this command to query information about active Flow Control integrations
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for flow-control

--- a/docs/content/reference/aperturectl/flow-control/preview/preview.md
+++ b/docs/content/reference/aperturectl/flow-control/preview/preview.md
@@ -33,6 +33,7 @@ aperturectl flow-control preview [--http] SERVICE CONTROL_POINT [flags]
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/policies/policies.md
+++ b/docs/content/reference/aperturectl/policies/policies.md
@@ -24,6 +24,7 @@ aperturectl policies [flags]
 
 ```
       --api-key string         FluxNinja ARC API Key to be used when using Cloud Controller
+      --config string          Path to the Aperture config file
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for policies

--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.80.0
+	github.com/pelletier/go-toml v1.9.5
 	github.com/prometheus/alertmanager v0.25.0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -1552,6 +1552,7 @@ github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTK
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
 github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
 github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=


### PR DESCRIPTION
Ref #2402

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:

- Documentation: Added support to load config from environment variables in `aperturectl`. The documentation now reflects the addition of this feature across various commands, enhancing the flexibility of the tool.

> "Config from env vars, a powerful feat,
> Aperturectl now more flexible and neat.
> With docs updated, users can see,
> How to configure with simplicity."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->