### PR TITLE
Improve etcd error reporting and move etcd session startup to background

### DIFF
--- a/pkg/etcd/client/session.go
+++ b/pkg/etcd/client/session.go
@@ -1,0 +1,145 @@
+package etcd
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	concurrencyv3 "go.etcd.io/etcd/client/v3/concurrency"
+	"go.uber.org/fx"
+
+	"github.com/fluxninja/aperture/v2/pkg/log"
+	panichandler "github.com/fluxninja/aperture/v2/pkg/panic-handler"
+	"github.com/fluxninja/aperture/v2/pkg/utils"
+)
+
+// Session wraps concurrencyv3.Session.
+//
+// Session may be available at OnStart, but that's not guaranteed.
+// Session will shutdown the app when it expires.
+type Session struct {
+	session      *concurrencyv3.Session // should be read only after creationDone is closed
+	creationDone chan struct{}          // when closed, session is either non-nil, or nil (failed to create)
+}
+
+// SessionScopedKV implements clientv3.KV by attaching the session's lease to
+// all Put requests, effectively scoping all created keys to the session.
+type SessionScopedKV struct {
+	KVWrapper
+}
+
+// WaitSession waits (up to context deadline) for etcd session to be established or errors.
+func (s *Session) WaitSession(ctx context.Context) (*concurrencyv3.Session, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.creationDone:
+		if s.session == nil {
+			return nil, errNoSessionFailed
+		}
+		return s.session, nil
+	}
+}
+
+var errNoSessionFailed = errors.New("etcd session unavailable: failed to establish")
+
+// ProvideSession provides Session.
+func ProvideSession(
+	client *Client,
+	lc fx.Lifecycle,
+	shutdowner fx.Shutdowner,
+) (*Session, error) {
+	sessionWrapper := Session{
+		creationDone: make(chan struct{}),
+	}
+
+	lc.Append(fx.StartHook(func() {
+		// We don't join this goroutine anywhere, as it should finish when
+		// client's context is canceled anyway.
+		panichandler.Go(func() {
+			session, err := createSession(client.Client, int(client.leaseTTL.AsDuration().Seconds()))
+			if err != nil {
+				close(sessionWrapper.creationDone)
+				log.Error().Err(err).Msg("Unable to establish etcd session")
+				utils.Shutdown(shutdowner)
+				return
+			}
+			sessionWrapper.session = session
+			close(sessionWrapper.creationDone)
+			log.Info().Msg("etcd session established")
+
+			// wait for session to be closed
+			<-session.Done()
+
+			select {
+			case <-session.Client().Ctx().Done():
+				return
+			default:
+				// session close not caused by client shutdown
+				log.Error().Msg("etcd session expired, request shutdown")
+				utils.Shutdown(shutdowner)
+			}
+		})
+	}))
+
+	// Try to establish session already in OnStart, but only if it takes reasonable time.
+	lc.Append(fx.StartHook(func(ctx context.Context) {
+		ctx, cancel := context.WithTimeout(ctx, maxBlockingSessionWaitTime)
+		defer cancel()
+
+		select {
+		case <-sessionWrapper.creationDone:
+			return
+		case <-ctx.Done():
+			log.Warn().Msg("Establishing etcd session takes long time, putting in background")
+			return
+		}
+	}))
+
+	return &sessionWrapper, nil
+}
+
+func createSession(client *clientv3.Client, ttl int) (*concurrencyv3.Session, error) {
+	// Normally, session uses its long-lived context to obtain its
+	// lease, which in case of errors may results in "hanging" for a
+	// long time without printing anything.
+	// To have more chance to show errors, we first try to manually
+	// grab a lease with a short timeout.
+	initialLeaseGrantCtx, cancelInitialCtx := context.WithTimeout(client.Ctx(), 4*time.Second)
+	defer cancelInitialCtx()
+	lease, err := client.Lease.Grant(initialLeaseGrantCtx, int64(ttl))
+	if err != nil {
+		if client.Ctx().Err() != nil {
+			// Client shutdown, don't retry.
+			return nil, err
+		}
+
+		// Actual error will be printed out by etcd as a warning.
+		log.Error().Err(err).Msg("Initial attempt to establish etcd session failed, retrying")
+		return concurrencyv3.NewSession(client, concurrencyv3.WithTTL(ttl))
+	}
+
+	return concurrencyv3.NewSession(
+		client,
+		concurrencyv3.WithTTL(ttl),
+		concurrencyv3.WithLease(lease.ID),
+	)
+}
+
+// Max time to wait on session creation, before it's deferred to background.
+const maxBlockingSessionWaitTime = 600 * time.Millisecond
+
+// ProvideSessionScopedKV provides SessionScopedKV.
+//
+// Note: This requires Session, so any usage of SessionScopedKV will cause app to shut down.
+func ProvideSessionScopedKV(client *Client, session *Session, lc fx.Lifecycle) *SessionScopedKV {
+	var scopedKV SessionScopedKV
+	lc.Append(fx.StartHook(func() {
+		scopedKV.KV = kvWithLease{
+			rawKV:   client.KV,
+			session: session,
+		}
+	}))
+	return &scopedKV
+}

--- a/pkg/etcd/election/election.go
+++ b/pkg/etcd/election/election.go
@@ -53,16 +53,25 @@ func ProvideElection(in ElectionIn) (*Election, error) {
 
 	in.Lifecycle.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
-			// Create an election for this client
-			election.Election = concurrencyv3.NewElection(in.Session.Session, "/election/"+in.AgentInfo.GetAgentGroup())
 			// A goroutine to do leader election
 			panichandler.Go(func() {
 				defer close(election.doneChan)
+
+				session, err := in.Session.WaitSession(ctx)
+				if err != nil {
+					log.Error().Err(err).Msg("Failed to get etcd session for leader election")
+					utils.Shutdown(in.Shutdowner)
+					return
+				}
+
+				// Create an election for this client
+				election.election = concurrencyv3.NewElection(session, "/election/"+in.AgentInfo.GetAgentGroup())
 				// Campaign for leadership
-				err := election.Election.Campaign(ctx, info.GetHostInfo().Uuid)
+				err = election.election.Campaign(ctx, info.GetHostInfo().Uuid)
 				if err != nil {
 					log.Error().Err(err).Msg("Unable to elect a leader")
 					utils.Shutdown(in.Shutdowner)
+					return
 				}
 				// Check if canceled
 				if ctx.Err() != nil {
@@ -84,12 +93,15 @@ func ProvideElection(in ElectionIn) (*Election, error) {
 			// resign from the election if we are the leader
 			if election.IsLeader() {
 				election.isLeader.Store(false)
-				err = election.Election.Resign(stopCtx)
+				if election.election == nil {
+					return nil
+				}
+				err = election.election.Resign(stopCtx)
 				if err != nil {
 					log.Error().Err(err).Msg("Unable to resign from the election")
 				}
 			}
-			return err
+			return nil
 		},
 	})
 
@@ -98,7 +110,7 @@ func ProvideElection(in ElectionIn) (*Election, error) {
 
 // Election is a wrapper around etcd election.
 type Election struct {
-	Election *concurrencyv3.Election
+	election *concurrencyv3.Election
 	isLeader atomic.Bool
 
 	// When closed, leader election has stopped (either due to becoming the

--- a/pkg/etcd/election/election.go
+++ b/pkg/etcd/election/election.go
@@ -101,7 +101,7 @@ func ProvideElection(in ElectionIn) (*Election, error) {
 					log.Error().Err(err).Msg("Unable to resign from the election")
 				}
 			}
-			return nil
+			return err
 		},
 	})
 


### PR DESCRIPTION
### Description of change

Before actually creating an etcd session, we first try to quickly obtain
a lease using short timeout, so we can print error if it fails.

Also, etcd session creation and leadership election was moved to
background. Note that this doesn't mean that agent can start without
etcd, because:
* Peers need etcd in OnStart,
* Every watcher tries to bootstrap in OnStart.

---

Example log with error:

```
12:02PM WRN client/v3@v3.5.9/retry_interceptor.go62 > retrying of unary invoker failed error="rpc error: code = DeadlineExceeded desc = latest balancer error: last connection error: connection error: desc = \"transport: Error while dialing: dial tcp: lookup controller-etcd.aperture-controller.svc.cluster.local: no such host\"" attempt=0 component=etcd-client target=etcd-endpoints://0xc004432000/controller-etcd.aperture-controller.svc.cluster.local:2379
12:02PM ERR etcd/client/session.go118 > Initial attempt to establish etcd session failed, retrying error="context deadline exceeded" service=aperture-agent
```

Example (filtered) log when etcd becomes available during startup.

```
12:13PM INF etcd/client/client.go129 > Initializing etcd client service=aperture-agent
...
12:13PM INF fx@v1.20.0/fxevent/zap.go51 > OnStart hook executing callee=github.com/fluxninja/aperture/v2/pkg/etcd/client.ProvideSession.func2() component=fx
12:13PM WRN etcd/client/session.go95 > Establishing etcd session takes long time, putting in background service=aperture-agent
12:13PM INF fx@v1.20.0/fxevent/zap.go51 > OnStart hook executed callee=github.com/fluxninja/aperture/v2/pkg/etcd/client.ProvideSession.func2() component=fx runtime=600.2952ms
...
12:13PM WRN client/v3@v3.5.9/retry_interceptor.go62 > retrying of unary invoker failed error="rpc error: code = DeadlineExceeded desc = latest balancer error: last connection error: connection error: desc = \"transport: Error while dialing: dial tcp 10.96.161.9:2379: connect: connection refused\"" attempt=0 component=etcd-client target=etcd-endpoints://0xc000c46540/controller-etcd.aperture-controller.svc.cluster.local:2379
12:13PM ERR etcd/client/session.go119 > Initial attempt to establish etcd session failed, retrying error="context deadline exceeded" service=aperture-agent
12:13PM INF etcd/client/session.go70 > etcd session established service=aperture-agent
...
12:13PM INF etcd/election/election.go82 > Node is now a leader service=aperture-agent
```

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### Refactor:
- Enhanced etcd error reporting and session management across multiple files.
- Introduced a new `Session` struct in `session.go` for improved session handling.
- Updated `election.go` to handle errors related to session acquisition and leader election more effectively.

> 🎉 Here's to the code that's now much neater,  
> With sessions and errors handled better.  
> In the world of etcd, we're now a trendsetter,  
> Making our software run smoother and faster. 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->