### PR TITLE
Added documentation of customizing packaged etcd and prometheus installation

### DIFF
--- a/docs/content/get-started/installation/controller/kubernetes/kubernetes.md
+++ b/docs/content/get-started/installation/controller/kubernetes/kubernetes.md
@@ -43,6 +43,62 @@ Install the tool of your choice using the following links:
       helm repo update
       ```
 
+## Configuring the packaged etcd and Prometheus
+
+If the Aperture Controller is going to be installed with the packaged etcd and
+Prometheus, the following steps can be used to customize the installation of
+them:
+
+1. The packaged **etcd** is installed using the
+   [Bitnami Helm Chart](https://artifacthub.io/packages/helm/bitnami/etcd/8.9.0),
+   and it can be customized using all the available options in the chart.
+
+   All the available options can be found
+   [here](https://artifacthub.io/packages/helm/bitnami/etcd/8.9.0?modal=values),
+   and the values can be overridden by creating a `values.yaml` file under the
+   `etcd` key.
+
+   For example, to change the default image used for etcd, create a file named
+   `values.yaml` with the following content:
+
+   ```yaml
+   etcd:
+     image:
+       registry: YOUR_REGISTRY
+       repository: YOUR_REPOSITORY
+       tag: ETCD_IMAGE_TAG
+   ```
+
+2. The packaged **Prometheus** is installed using the
+   [Prometheus Community Helm Chart](https://artifacthub.io/packages/helm/prometheus-community/prometheus/15.18.0),
+   and it can be customized using all the available options in the chart.
+
+   All the available options can be found
+   [here](https://artifacthub.io/packages/helm/prometheus-community/prometheus/15.18.0?modal=values),
+   and the values can be overridden by creating a `values.yaml` file under the
+   `prometheus` key.
+
+   For example, to change the default images used for Prometheus server, create
+   a file named `values.yaml` with the following content:
+
+   ```yaml
+   prometheus:
+     server:
+       image:
+         registry: YOUR_REGISTRY
+         repository: YOUR_REPOSITORY
+         tag: PROMETHEUS_IMAGE_TAG
+     configmapReload:
+       prometheus:
+         image:
+           registry: YOUR_REGISTRY
+           repository: YOUR_REPOSITORY
+           tag: CONFIG_RELOAD_IMAGE_TAG
+   ```
+
+The `values.yaml` file created above can be used with the
+[Installation](#installation) steps below.
+
 ## Installation
 
 The Aperture Controller can be installed on Kubernetes using the below options:

--- a/docs/content/get-started/installation/controller/kubernetes/kubernetes.md
+++ b/docs/content/get-started/installation/controller/kubernetes/kubernetes.md
@@ -45,7 +45,7 @@ Install the tool of your choice using the following links:
 
 ## Configuring the packaged etcd and Prometheus
 
-If the Aperture Controller is going to be installed with the packaged etcd and
+If the Aperture Controller will be installed with the packaged etcd and
 Prometheus, the following steps can be used to customize the installation of
 them:
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:
- Documentation: Added instructions for customizing the installation of packaged etcd and Prometheus using Helm charts. Users can now create a `values.yaml` file to override default values for etcd and Prometheus images.

> "Customize your installation,
> With Helm charts, a great foundation.
> Override values with ease,
> Etcd and Prometheus, just as you please.
> Install and configure, with control and precision,
> A documentation update, enhancing your mission."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->