### PR TITLE
Added missing tags for etcd and prometheus

### DIFF
--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -2684,7 +2684,7 @@ PrometheusConfig holds configuration for Prometheus Server.
 
 <!-- vale off -->
 
-(string, format: `empty | hostname_port | url | fqdn`)
+(string, format: `hostname_port | url | fqdn | empty`)
 
 <!-- vale on -->
 

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -2056,7 +2056,7 @@ PrometheusConfig holds configuration for Prometheus Server.
 
 <!-- vale off -->
 
-(string, format: `empty | hostname_port | url | fqdn`)
+(string, format: `hostname_port | url | fqdn | empty`)
 
 <!-- vale on -->
 

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -483,7 +483,7 @@ definitions:
                 type: array
                 x-go-name: Endpoints
                 x-go-tag-json: endpoints,omitempty
-                x-go-tag-validate: dive,hostname_port|url|fqdn
+                x-go-tag-validate: dive,hostname_port|url|fqdn,omitempty
             lease_ttl:
                 default: 60s
                 description: Lease time-to-live
@@ -1286,12 +1286,12 @@ definitions:
         properties:
             address:
                 description: Address of the Prometheus server
-                pattern: (((^$)|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$))|(^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,\'/\\\+&amp;%\$#\=~])*$))|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$)
+                pattern: (((^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$)|(^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,\'/\\\+&amp;%\$#\=~])*$))|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$))|(^$)
                 type: string
                 x-go-name: Address
-                x-go-tag-json: address
-                x-go-tag-validate: omitempty,hostname_port|url|fqdn
-                x-pattern-rules: empty | hostname_port | url | fqdn
+                x-go-tag-json: address,omitempty
+                x-go-tag-validate: hostname_port|url|fqdn,omitempty
+                x-pattern-rules: hostname_port | url | fqdn | empty
             labels:
                 description: A list of labels to be attached to every query
                 items:

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -269,7 +269,7 @@ definitions:
                 type: array
                 x-go-name: Endpoints
                 x-go-tag-json: endpoints,omitempty
-                x-go-tag-validate: dive,hostname_port|url|fqdn
+                x-go-tag-validate: dive,hostname_port|url|fqdn,omitempty
             lease_ttl:
                 default: 60s
                 description: Lease time-to-live
@@ -1033,12 +1033,12 @@ definitions:
         properties:
             address:
                 description: Address of the Prometheus server
-                pattern: (((^$)|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$))|(^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,\'/\\\+&amp;%\$#\=~])*$))|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$)
+                pattern: (((^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$)|(^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,\'/\\\+&amp;%\$#\=~])*$))|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$))|(^$)
                 type: string
                 x-go-name: Address
-                x-go-tag-json: address
-                x-go-tag-validate: omitempty,hostname_port|url|fqdn
-                x-pattern-rules: empty | hostname_port | url | fqdn
+                x-go-tag-json: address,omitempty
+                x-go-tag-validate: hostname_port|url|fqdn,omitempty
+                x-pattern-rules: hostname_port | url | fqdn | empty
             labels:
                 description: A list of labels to be attached to every query
                 items:

--- a/pkg/etcd/config.go
+++ b/pkg/etcd/config.go
@@ -20,5 +20,5 @@ type EtcdConfig struct {
 	// Client TLS configuration
 	ClientTLSConfig tlsconfig.ClientTLSConfig `json:"tls"`
 	// List of etcd server endpoints
-	Endpoints []string `json:"endpoints,omitempty" validate:"dive,hostname_port|url|fqdn"`
+	Endpoints []string `json:"endpoints,omitempty" validate:"dive,hostname_port|url|fqdn,omitempty"`
 }

--- a/pkg/prometheus/config/config.go
+++ b/pkg/prometheus/config/config.go
@@ -15,5 +15,5 @@ type PrometheusConfig struct {
 	// A list of labels to be attached to every query
 	Labels []PrometheusLabel `json:"labels,omitempty"`
 	// Address of the Prometheus server
-	Address string `json:"address" validate:"omitempty,hostname_port|url|fqdn"`
+	Address string `json:"address,omitempty" validate:"hostname_port|url|fqdn,omitempty"`
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### Bug Fix
- Adjusted the format options for a string field in `PrometheusConfig` to improve data consistency.
- Added the `omitempty` tag to the `Endpoints` field in the `EtcdConfig` struct and to the `Address` field in the `PrometheusConfig` struct. This allows these fields to be omitted when marshaling to JSON, enhancing our system's flexibility.

> 🎉 Here's to the code that we tweak and refine,  
> To bugs that we squash, making everything fine.  
> With each little change, we're improving the flow,  
> Onwards we march, with our code in tow! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->