### PR TITLE
Fixes in agent and controller charts

### DIFF
--- a/manifests/charts/aperture-agent/templates/_helpers.tpl
+++ b/manifests/charts/aperture-agent/templates/_helpers.tpl
@@ -93,7 +93,7 @@ Fetch the Name of the API Key secret for Aperture Agent
 {{- if .agent.secrets.fluxNinjaExtension.secretKeyRef.name -}}
     {{ print .agent.secrets.fluxNinjaExtension.secretKeyRef.name }}
 {{- else -}}
-    {{ print "%s-agent-apikey" .context.Release.Name }}
+    {{ printf "%s-agent-apikey" .context.Release.Name }}
 {{- end -}}
 {{- end -}}
 

--- a/manifests/charts/aperture-agent/templates/agent-cm.yaml
+++ b/manifests/charts/aperture-agent/templates/agent-cm.yaml
@@ -16,8 +16,8 @@ metadata:
   {{- end }}
 data:
   aperture-agent.yaml: |-
-    {{- if (omit .Values.agent.config "etcd" "prometheus" "auto_scale" "service_discovery" "agent_functions" "otel") }}
-    {{- omit .Values.agent.config "etcd" "prometheus" "auto_scale" "service_discovery" "agent_functions" "otel" | toYaml | nindent 4 }}
+    {{- if (omit .Values.agent.config "etcd" "prometheus" "auto_scale" "service_discovery" "agent_functions" "otel" "fluxninja") }}
+    {{- omit .Values.agent.config "etcd" "prometheus" "auto_scale" "service_discovery" "agent_functions" "otel" "fluxninja" | toYaml | nindent 4 }}
     {{- end }}
     otel:
       {{- if and .Values.agent.config.otel (omit .Values.agent.config.otel "disable_kubernetes_scraper" "disable_kubelet_scraper")}}
@@ -40,7 +40,19 @@ data:
       {{- omit .Values.agent.config.fluxninja "endpoint" | toYaml | nindent 6 }}
       {{- end }}
       endpoint: {{ include "agent.fluxninja.endpoint" (dict "fluxninja" .Values.agent.config.fluxninja "context" . $) }}
+    {{- if (omit .Values.agent.config.etcd "endpoints")}}
+    etcd:
+      {{- omit .Values.agent.config.etcd "endpoints" | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if (omit .Values.agent.config.prometheus "address")}}
+    prometheus:
+      {{- omit .Values.agent.config.prometheus "address" | toYaml | nindent 6 }}
+    {{- end }}
     {{- else }}
+    {{- if and .Values.agent.config .Values.agent.config.fluxninja }}
+    fluxninja:
+      {{- .Values.agent.config.fluxninja | toYaml | nindent 6 }}
+    {{- end }}
     etcd:
       {{- if (omit .Values.agent.config.etcd "endpoints")}}
       {{- omit .Values.agent.config.etcd "endpoints" | toYaml | nindent 6 }}

--- a/manifests/charts/aperture-agent/templates/agent-cr.yaml
+++ b/manifests/charts/aperture-agent/templates/agent-cr.yaml
@@ -155,14 +155,22 @@ spec:
   {{- end }}
   config:
     {{- if and .Values.agent.config .Values.agent.config.fluxninja .Values.agent.config.fluxninja.enable_cloud_controller }}
-    {{- if (omit .Values.agent.config "fluxninja") }}
-    {{- omit .Values.agent.config "fluxninja" | toYaml | nindent 4 }}
+    {{- if (omit .Values.agent.config "fluxninja" "etcd" "prometheus") }}
+    {{- omit .Values.agent.config "fluxninja" "etcd" "prometheus" | toYaml | nindent 4 }}
     {{- end }}
     fluxninja:
       {{- if (omit .Values.agent.config.fluxninja "endpoint")}}
       {{- omit .Values.agent.config.fluxninja "endpoint" | toYaml | nindent 6 }}
       {{- end }}
       endpoint: {{ include "agent.fluxninja.endpoint" (dict "fluxninja" .Values.agent.config.fluxninja "context" . $) }}
+    {{- if (omit .Values.agent.config.etcd "endpoints")}}
+    etcd:
+      {{- omit .Values.agent.config.etcd "endpoints" | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if (omit .Values.agent.config.prometheus "address")}}
+    prometheus:
+      {{- omit .Values.agent.config.prometheus "address" | toYaml | nindent 6 }}
+    {{- end }}
     {{- else }}
     {{- if (omit .Values.agent.config "etcd" "prometheus") }}
     {{- omit .Values.agent.config "etcd" "prometheus" | toYaml | nindent 4 }}
@@ -173,6 +181,9 @@ spec:
       {{- end }}
       endpoints: {{ include "agent.etcd.endpoints" (dict "etcd" .Values.agent.config.etcd "context" . $) }}
     prometheus:
+      {{- if (omit .Values.agent.config.prometheus "address")}}
+      {{- omit .Values.agent.config.prometheus "address" | toYaml | nindent 6 }}
+      {{- end }}
       address: {{ include "agent.prometheus.address" (dict "prometheus" .Values.agent.config.prometheus "context" . $) }}
     {{- end }}
 {{- end }}

--- a/manifests/charts/aperture-agent/templates/agent-deployment.yaml
+++ b/manifests/charts/aperture-agent/templates/agent-deployment.yaml
@@ -43,7 +43,7 @@ spec:
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.agent.tolerations "context" . $ ) | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.agent.serviceAccount.name | default (include "common.names.fullname" .) }}
-      {{- if .Values.agent.podSecurityContext.enabled }}
+      {{- if and .Values.agent.podSecurityContext .Values.agent.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.agent.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.agent.terminationGracePeriodSeconds }}
@@ -82,7 +82,7 @@ spec:
                   fieldPath: metadata.name
             - name: APERTURE_AGENT_SERVICE_DISCOVERY_KUBERNETES_ENABLED
               value: "false"
-            {{- if or .Values.agent.secrets.fluxNinjaExtension.create .Values.agent.secrets.fluxNinjaExtension.secretKeyRef.name -}}
+            {{- if or (and .Values.agent.secrets.fluxNinjaExtension .Values.agent.secrets.fluxNinjaExtension.create) (and .Values.agent.secrets.fluxNinjaExtension .Values.agent.secrets.fluxNinjaExtension.secretKeyRef .Values.agent.secrets.fluxNinjaExtension.secretKeyRef.name) }}
             - name: APERTURE_AGENT_FLUXNINJA_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/manifests/charts/aperture-controller/templates/_helpers.tpl
+++ b/manifests/charts/aperture-controller/templates/_helpers.tpl
@@ -89,7 +89,7 @@ Fetch the Name of the API Key secret for Aperture Controller
 {{- if .controller.secrets.fluxNinjaExtension.secretKeyRef.name -}}
     {{ print .controller.secrets.fluxNinjaExtension.secretKeyRef.name }}
 {{- else -}}
-    {{ print "%s-controller-apikey" .context.Release.Name }}
+    {{ printf "%s-controller-apikey" .context.Release.Name }}
 {{- end -}}
 {{- end -}}
 

--- a/manifests/charts/aperture-controller/templates/controller-deployment.yaml
+++ b/manifests/charts/aperture-controller/templates/controller-deployment.yaml
@@ -118,7 +118,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if or .Values.controller.secrets.fluxNinjaExtension.create .Values.controller.secrets.fluxNinjaExtension.secretKeyRef.name -}}
+            {{- if or (and .Values.controller.secrets.fluxNinjaExtension .Values.controller.secrets.fluxNinjaExtension.create) (and .Values.controller.secrets.fluxNinjaExtension .Values.controller.secrets.fluxNinjaExtension.secretKeyRef .Values.controller.secrets.fluxNinjaExtension.secretKeyRef.name) }}
             - name: APERTURE_CONTROLLER_FLUXNINJA_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### Refactor
- Switched from `print` to `printf` for string formatting in the Aperture Agent and Controller charts. This change enhances the code's readability and maintainability, ensuring a more consistent approach to string formatting across the codebase.

> 🎉 Here's to the refactor, so neat and clean,
> 
> With `printf` now, our code's serene.
> 
> No more `print`, we've taken flight,
> 
> To a codebase that's a delightful sight! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->