### PR TITLE
Made etcd and prometheus non-mandatory for agent CR

### DIFF
--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1982,9 +1982,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                required:
-                - etcd
-                - prometheus
                 type: object
               containerSecurityContext:
                 description: Configure Containers' Security Context

--- a/operator/api/agent/v1alpha1/agent_types.go
+++ b/operator/api/agent/v1alpha1/agent_types.go
@@ -27,10 +27,12 @@ import (
 	afconfig "github.com/fluxninja/aperture/v2/pkg/agent-functions/config"
 	agentinfo "github.com/fluxninja/aperture/v2/pkg/agent-info"
 	distcache "github.com/fluxninja/aperture/v2/pkg/dist-cache/config"
+	"github.com/fluxninja/aperture/v2/pkg/etcd"
 	"github.com/fluxninja/aperture/v2/pkg/net/http"
 	peers "github.com/fluxninja/aperture/v2/pkg/peers/config"
 	autoscalek8sconfig "github.com/fluxninja/aperture/v2/pkg/policies/autoscale/kubernetes/config"
 	preview "github.com/fluxninja/aperture/v2/pkg/policies/flowcontrol/service/preview/config"
+	prometheus "github.com/fluxninja/aperture/v2/pkg/prometheus/config"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -62,6 +64,14 @@ type AgentConfigSpec struct {
 	// CommonConfigSpec
 	//+kubebuilder:validation:Optional
 	common.CommonConfigSpec `json:",inline"`
+
+	// Etcd configuration.
+	//+kubebuilder:validation:Optional
+	Etcd etcd.EtcdConfig `json:"etcd"`
+
+	// Prometheus configuration.
+	//+kubebuilder:validation:Optional
+	Prometheus prometheus.PrometheusConfig `json:"prometheus"`
 
 	// AgentInfo configuration.
 	//+kubebuilder:validation:Optional

--- a/operator/api/agent/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/agent/v1alpha1/zz_generated.deepcopy.go
@@ -56,6 +56,8 @@ func (in *Agent) DeepCopyObject() runtime.Object {
 func (in *AgentConfigSpec) DeepCopyInto(out *AgentConfigSpec) {
 	*out = *in
 	in.CommonConfigSpec.DeepCopyInto(&out.CommonConfigSpec)
+	in.Etcd.DeepCopyInto(&out.Etcd)
+	in.Prometheus.DeepCopyInto(&out.Prometheus)
 	out.AgentInfo = in.AgentInfo
 	out.DistCache = in.DistCache
 	in.KubernetesClient.DeepCopyInto(&out.KubernetesClient)

--- a/operator/api/common/common_types.go
+++ b/operator/api/common/common_types.go
@@ -24,7 +24,6 @@ import (
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	kubernetes "github.com/fluxninja/aperture/v2/pkg/discovery/kubernetes/config"
 	static "github.com/fluxninja/aperture/v2/pkg/discovery/static/config"
-	"github.com/fluxninja/aperture/v2/pkg/etcd"
 	googletoken "github.com/fluxninja/aperture/v2/pkg/google/config"
 	jobs "github.com/fluxninja/aperture/v2/pkg/jobs/config"
 	"github.com/fluxninja/aperture/v2/pkg/metrics"
@@ -34,7 +33,6 @@ import (
 	"github.com/fluxninja/aperture/v2/pkg/net/listener"
 	"github.com/fluxninja/aperture/v2/pkg/net/tlsconfig"
 	"github.com/fluxninja/aperture/v2/pkg/profilers"
-	prometheus "github.com/fluxninja/aperture/v2/pkg/prometheus/config"
 	watchdogconfig "github.com/fluxninja/aperture/v2/pkg/watchdog/config"
 
 	corev1 "k8s.io/api/core/v1"
@@ -303,10 +301,6 @@ type CommonConfigSpec struct {
 	//+kubebuilder:validation:Optional
 	Client ClientConfigSpec `json:"client"`
 
-	// Etcd configuration.
-	//+kubebuilder:validation:Required
-	Etcd etcd.EtcdConfig `json:"etcd"`
-
 	// Liveness probe configuration.
 	//+kubebuilder:validation:Optional
 	Liveness ProbeConfigSpec `json:"liveness"`
@@ -326,10 +320,6 @@ type CommonConfigSpec struct {
 	// Profilers configuration.
 	//+kubebuilder:validation:Optional
 	Profilers profilers.ProfilersConfig `json:"profilers"`
-
-	// Prometheus configuration.
-	//+kubebuilder:validation:Required
-	Prometheus prometheus.PrometheusConfig `json:"prometheus"`
 
 	// Google Token Source configuration
 	//+kubebuilder:validation:Optional

--- a/operator/api/common/zz_generated.deepcopy.go
+++ b/operator/api/common/zz_generated.deepcopy.go
@@ -111,13 +111,11 @@ func (in *ClientConfigSpec) DeepCopy() *ClientConfigSpec {
 func (in *CommonConfigSpec) DeepCopyInto(out *CommonConfigSpec) {
 	*out = *in
 	in.Client.DeepCopyInto(&out.Client)
-	in.Etcd.DeepCopyInto(&out.Etcd)
 	in.Liveness.DeepCopyInto(&out.Liveness)
 	in.Readiness.DeepCopyInto(&out.Readiness)
 	in.Log.DeepCopyInto(&out.Log)
 	out.Metrics = in.Metrics
 	out.Profilers = in.Profilers
-	in.Prometheus.DeepCopyInto(&out.Prometheus)
 	in.TokenSource.DeepCopyInto(&out.TokenSource)
 	in.Server.DeepCopyInto(&out.Server)
 	in.Watchdog.DeepCopyInto(&out.Watchdog)

--- a/operator/api/controller/v1alpha1/controller_types.go
+++ b/operator/api/controller/v1alpha1/controller_types.go
@@ -22,8 +22,10 @@ import (
 	controller "github.com/fluxninja/aperture/v2/cmd/aperture-controller/config"
 	"github.com/fluxninja/aperture/v2/operator/api"
 	"github.com/fluxninja/aperture/v2/operator/api/common"
+	"github.com/fluxninja/aperture/v2/pkg/etcd"
 	jobs "github.com/fluxninja/aperture/v2/pkg/jobs/config"
 	"github.com/fluxninja/aperture/v2/pkg/policies/controlplane/crwatcher"
+	prometheus "github.com/fluxninja/aperture/v2/pkg/prometheus/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,6 +55,14 @@ type ControllerConfigSpec struct {
 	// CommonSpec
 	//+kubebuilder:validation:Optional
 	common.CommonConfigSpec `json:",inline"`
+
+	// Etcd configuration.
+	//+kubebuilder:validation:Required
+	Etcd etcd.EtcdConfig `json:"etcd"`
+
+	// Prometheus configuration.
+	//+kubebuilder:validation:Required
+	Prometheus prometheus.PrometheusConfig `json:"prometheus"`
 
 	// Policies configuration.
 	//+kubebuilder:validation:Optional

--- a/operator/api/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/controller/v1alpha1/zz_generated.deepcopy.go
@@ -57,6 +57,8 @@ func (in *Controller) DeepCopyObject() runtime.Object {
 func (in *ControllerConfigSpec) DeepCopyInto(out *ControllerConfigSpec) {
 	*out = *in
 	in.CommonConfigSpec.DeepCopyInto(&out.CommonConfigSpec)
+	in.Etcd.DeepCopyInto(&out.Etcd)
+	in.Prometheus.DeepCopyInto(&out.Prometheus)
 	out.Policies = in.Policies
 	in.OTel.DeepCopyInto(&out.OTel)
 }

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1982,9 +1982,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                required:
-                - etcd
-                - prometheus
                 type: object
               containerSecurityContext:
                 description: Configure Containers' Security Context

--- a/operator/controllers/agent/agent_suite_test.go
+++ b/operator/controllers/agent/agent_suite_test.go
@@ -115,13 +115,11 @@ var _ = BeforeSuite(func() {
 		},
 		Spec: agentv1alpha1.AgentSpec{
 			ConfigSpec: agentv1alpha1.AgentConfigSpec{
-				CommonConfigSpec: common.CommonConfigSpec{
-					Etcd: etcd.EtcdConfig{
-						Endpoints: []string{"10.10.10.10:1010"},
-					},
-					Prometheus: prometheus.PrometheusConfig{
-						Address: "20.20.20.20:2020",
-					},
+				Etcd: etcd.EtcdConfig{
+					Endpoints: []string{"10.10.10.10:1010"},
+				},
+				Prometheus: prometheus.PrometheusConfig{
+					Address: "20.20.20.20:2020",
 				},
 			},
 			CommonSpec: common.CommonSpec{

--- a/operator/controllers/agent/configmaps_test.go
+++ b/operator/controllers/agent/configmaps_test.go
@@ -73,13 +73,13 @@ var _ = Describe("ConfigMap for Agent", func() {
 									},
 								},
 							},
-							Etcd: etcd.EtcdConfig{
-								Endpoints: []string{"http://agent-etcd:2379"},
-								LeaseTTL:  config.MakeDuration(60 * time.Second),
-							},
-							Prometheus: prometheus.PrometheusConfig{
-								Address: "http://aperture-prometheus-server:80",
-							},
+						},
+						Etcd: etcd.EtcdConfig{
+							Endpoints: []string{"http://agent-etcd:2379"},
+							LeaseTTL:  config.MakeDuration(60 * time.Second),
+						},
+						Prometheus: prometheus.PrometheusConfig{
+							Address: "http://aperture-prometheus-server:80",
 						},
 						DistCache: distcacheconfig.DistCacheConfig{
 							BindAddr:           ":3320",

--- a/operator/controllers/controller/configmaps_test.go
+++ b/operator/controllers/controller/configmaps_test.go
@@ -78,13 +78,13 @@ var _ = Describe("ConfigMap for Controller", func() {
 									},
 								},
 							},
-							Etcd: etcd.EtcdConfig{
-								Endpoints: []string{"http://agent-etcd:2379"},
-								LeaseTTL:  config.MakeDuration(60 * time.Second),
-							},
-							Prometheus: prometheus.PrometheusConfig{
-								Address: "http://aperture-prometheus-server:80",
-							},
+						},
+						Etcd: etcd.EtcdConfig{
+							Endpoints: []string{"http://agent-etcd:2379"},
+							LeaseTTL:  config.MakeDuration(60 * time.Second),
+						},
+						Prometheus: prometheus.PrometheusConfig{
+							Address: "http://aperture-prometheus-server:80",
 						},
 						OTel: controller.ControllerOTelConfig{
 							CommonOTelConfig: otelconfig.CommonOTelConfig{

--- a/operator/controllers/controller/controller_suite_test.go
+++ b/operator/controllers/controller/controller_suite_test.go
@@ -120,13 +120,11 @@ var _ = BeforeSuite(func() {
 		},
 		Spec: controllerv1alpha1.ControllerSpec{
 			ConfigSpec: controllerv1alpha1.ControllerConfigSpec{
-				CommonConfigSpec: common.CommonConfigSpec{
-					Etcd: etcd.EtcdConfig{
-						Endpoints: []string{"10.10.10.10:1010"},
-					},
-					Prometheus: prometheus.PrometheusConfig{
-						Address: "20.20.20.20:2020",
-					},
+				Etcd: etcd.EtcdConfig{
+					Endpoints: []string{"10.10.10.10:1010"},
+				},
+				Prometheus: prometheus.PrometheusConfig{
+					Address: "20.20.20.20:2020",
 				},
 			},
 			CommonSpec: common.CommonSpec{

--- a/operator/controllers/namespace/namespace_suite_test.go
+++ b/operator/controllers/namespace/namespace_suite_test.go
@@ -118,13 +118,11 @@ var _ = BeforeSuite(func() {
 		},
 		Spec: agentv1alpha1.AgentSpec{
 			ConfigSpec: agentv1alpha1.AgentConfigSpec{
-				CommonConfigSpec: common.CommonConfigSpec{
-					Etcd: etcd.EtcdConfig{
-						Endpoints: []string{"10.10.10.10:1010"},
-					},
-					Prometheus: prometheus.PrometheusConfig{
-						Address: "20.20.20.20:2020",
-					},
+				Etcd: etcd.EtcdConfig{
+					Endpoints: []string{"10.10.10.10:1010"},
+				},
+				Prometheus: prometheus.PrometheusConfig{
+					Address: "20.20.20.20:2020",
 				},
 			},
 			CommonSpec: common.CommonSpec{

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -116,13 +116,11 @@ var _ = BeforeSuite(func() {
 		},
 		Spec: controllerv1alpha1.ControllerSpec{
 			ConfigSpec: controllerv1alpha1.ControllerConfigSpec{
-				CommonConfigSpec: common.CommonConfigSpec{
-					Etcd: etcd.EtcdConfig{
-						Endpoints: []string{"10.10.10.10:1010"},
-					},
-					Prometheus: prometheusconfig.PrometheusConfig{
-						Address: "20.20.20.20:2020",
-					},
+				Etcd: etcd.EtcdConfig{
+					Endpoints: []string{"10.10.10.10:1010"},
+				},
+				Prometheus: prometheusconfig.PrometheusConfig{
+					Address: "20.20.20.20:2020",
 				},
 			},
 			CommonSpec: common.CommonSpec{
@@ -160,13 +158,11 @@ var _ = BeforeSuite(func() {
 		},
 		Spec: agentv1alpha1.AgentSpec{
 			ConfigSpec: agentv1alpha1.AgentConfigSpec{
-				CommonConfigSpec: common.CommonConfigSpec{
-					Etcd: etcd.EtcdConfig{
-						Endpoints: []string{"10.10.10.10:1010"},
-					},
-					Prometheus: prometheusconfig.PrometheusConfig{
-						Address: "20.20.20.20:2020",
-					},
+				Etcd: etcd.EtcdConfig{
+					Endpoints: []string{"10.10.10.10:1010"},
+				},
+				Prometheus: prometheusconfig.PrometheusConfig{
+					Address: "20.20.20.20:2020",
 				},
 			},
 			CommonSpec: common.CommonSpec{


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

### Release Notes
- **Refactor**: Made `etcd` and `prometheus` configurations optional in the `AgentConfigSpec`, `CommonConfigSpec`, and `ControllerConfigSpec` structs. This change provides more flexibility for users who may not require these configurations.
- **New Feature**: Introduced default values for `etcd` and `prometheus` configurations, enhancing user experience by reducing the need for manual configuration.

> 🎉 Here's to code that's lean and mean,
> With configs optional, not foreseen.
> Etcd and Prometheus, no longer a must,
> Making our software robust and just! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->