### PR TITLE
docs: Add intro to FluxNinja ARC

### DIFF
--- a/docs/content/arc/extension.md
+++ b/docs/content/arc/extension.md
@@ -1,17 +1,11 @@
 ---
-title: FluxNinja ARC Extension
-sidebar_label: Extension
+title: FluxNinja ARC Configuration
+sidebar_label: Configuration
 sidebar_position: 8
 keywords:
   - cloud
   - extension
 ---
-
-:::caution
-
-This page will be removed>
-
-:::
 
 ```mdx-code-block
 import Tabs from '@theme/Tabs';

--- a/docs/content/arc/introduction.md
+++ b/docs/content/arc/introduction.md
@@ -31,23 +31,16 @@ To sign-up, [click here][sign-up].
 
 ## FluxNinja ARC load management features
 
-FluxNinja ARC load management capabilities are powered by [Aperture][]:
+FluxNinja ARC [load management capabilities][] are powered by [Aperture][]:
 
-- **[Adaptive Service Protection][]**
-- **[Global Quota Management][]**
-- **[Workload Prioritization][]**
-- **[Load-based Auto Scaling][]**
-- **[Distributed Rate-Limiting][]**
-- **[Percentage Rollouts][]**
+- **[Adaptive Service Protection](/use-cases/adaptive-service-protection/adaptive-service-protection.md)**
+- **[Global Quota Management](/use-cases/managing-quotas/managing-quotas.md)**
+- **[Workload Prioritization](/use-cases/adaptive-service-protection/workload-prioritization.md)**
+- **[Load-based Auto Scaling](/use-cases/auto-scaling/load-based-auto-scaling.md)**
+- **[Distributed Rate-Limiting](/use-cases/rate-limiting/rate-limiting.md)**
+- **[Percentage Rollouts](/use-cases/percentage-rollouts/percentage-rollouts.md)**
 
-[Adaptive Service Protection]:
-  /use-cases/adaptive-service-protection/adaptive-service-protection.md
-[Global Quota Management]: /use-cases/managing-quotas/managing-quotas.md
-[Workload Prioritization]:
-  /use-cases/adaptive-service-protection/workload-prioritization.md
-[Load-based Auto Scaling]: /use-cases/auto-scaling/load-based-auto-scaling.md
-[Distributed Rate-Limiting]: /use-cases/rate-limiting/rate-limiting.md
-[Percentage Rollouts]: /use-cases/percentage-rollouts/percentage-rollouts.md
 [FluxNinja ARC]: https://www.fluxninja.com/product
 [sign-up]: https://app.fluxninja.com/sign-up
 [Aperture]: /introduction.md
+[load management capabilities]: /introduction.md#load-management-capabilities

--- a/docs/content/arc/introduction.md
+++ b/docs/content/arc/introduction.md
@@ -11,25 +11,43 @@ keywords:
   - reliability center
 ---
 
-## Application Reliability Center (ARC)
+[FluxNinja ARC][] (Application Reliability Center) is a cloud reliability
+platform for your applications and infrastructure. It provides a hassle-free
+experience and offers a unified solution for managing all tasks related to
+reliability. Regardless of whether your applications are hosted on your own
+bare-metal servers or in the cloud, the only requirement is to install Agents
+and set up integrations. This allows you to start implementing policies to
+control your traffic.
 
-[FluxNinja ARC](https://www.fluxninja.com/product) is a cloud native application
-reliability center that extends open source Aperture installation with advanced
-analytics, monitoring and alerting capabilities.
+[Aperture][], the core component of FluxNinja ARC, empowers you to manage your
+load effectively by classifying, scheduling, and rate-limiting API traffic in
+cloud applications.
 
 :::info Sign-up
 
-To sign-up, [register here](https://app.fluxninja.com/sign-up).
+To sign-up, [click here][sign-up].
 
 :::
 
-### ARC Controller
+## FluxNinja ARC load management features
 
-FluxNinja ARC Organization includes an ARC Controller, which is a SaaS version
-of the Aperture Controller, This controller can be used instead of Aperture
-Controller deployed On-premise, and doesn't require local etcd and Prometheus
-services.
+FluxNinja ARC load management capabilities are powered by [Aperture][]:
 
-Check the [FluxNinja extension configuration](extension.md#configuration), ARC
-Controller section, for how to configure Aperture Agents to talk to the ARC
-Controller.
+- **[Adaptive Service Protection][]**
+- **[Global Quota Management][]**
+- **[Workload Prioritization][]**
+- **[Load-based Auto Scaling][]**
+- **[Distributed Rate-Limiting][]**
+- **[Percentage Rollouts][]**
+
+[Adaptive Service Protection]:
+  /use-cases/adaptive-service-protection/adaptive-service-protection.md
+[Global Quota Management]: /use-cases/managing-quotas/managing-quotas.md
+[Workload Prioritization]:
+  /use-cases/adaptive-service-protection/workload-prioritization.md
+[Load-based Auto Scaling]: /use-cases/auto-scaling/load-based-auto-scaling.md
+[Distributed Rate-Limiting]: /use-cases/rate-limiting/rate-limiting.md
+[Percentage Rollouts]: /use-cases/percentage-rollouts/percentage-rollouts.md
+[FluxNinja ARC]: https://www.fluxninja.com/product
+[sign-up]: https://app.fluxninja.com/sign-up
+[Aperture]: /introduction.md

--- a/docs/content/get-started/installation/controller/controller.md
+++ b/docs/content/get-started/installation/controller/controller.md
@@ -42,8 +42,8 @@ configure Aperture Agents to talk to the ARC Controller.
 To start with ARC Controller, start by creating your own organization on
 [FluxNinja ARC](https://www.fluxninja.com/product) and start the free trial.
 
-This rest page describes installation of self-hosted ARC Controller and can be
-skipped.
+This rest page describes installation of self-hosted Aperture Controller and
+can be skipped.
 
 :::
 

--- a/docs/content/get-started/installation/controller/controller.md
+++ b/docs/content/get-started/installation/controller/controller.md
@@ -32,11 +32,18 @@ process variables and maintain their values within the optimal range.
 
 ## Installation
 
-:::tip
+:::tip ARC Controller
 
-Instead of installing On-Premise Aperture Controller, you can start with
-[ARC Controller](/arc/introduction.md#arc-controller) by creating your own
-organization on [FluxNinja ARC](https://www.fluxninja.com/product)
+Every [FluxNinja ARC][] Organization already includes an ARC Controller in the
+`default` project. Check the
+[FluxNinja extension configuration](/arc/extension.md#configuration), for how to
+configure Aperture Agents to talk to the ARC Controller.
+
+To start with ARC Controller, start by creating your own organization on
+[FluxNinja ARC](https://www.fluxninja.com/product) and start the free trial.
+
+This rest page describes installation of self-hosted ARC Controller and can be
+skipped.
 
 :::
 
@@ -62,3 +69,5 @@ is to create and apply policies.
 step-by-step instructions on customizing, creating, and applying policies within
 Aperture. Additionally, the [use-cases](/use-cases/use-cases.md) section serves
 as a valuable resource for tailoring policies to meet specific requirements.
+
+[Fluxninja ARC]: /arc/introduction.md

--- a/docs/content/get-started/installation/controller/controller.md
+++ b/docs/content/get-started/installation/controller/controller.md
@@ -42,8 +42,8 @@ configure Aperture Agents to talk to the ARC Controller.
 To start with ARC Controller, start by creating your own organization on
 [FluxNinja ARC](https://www.fluxninja.com/product) and start the free trial.
 
-This rest page describes installation of self-hosted Aperture Controller and can
-be skipped.
+This rest of this page describes installation of self-hosted Aperture Controller
+and can be skipped.
 
 :::
 

--- a/docs/content/get-started/installation/controller/controller.md
+++ b/docs/content/get-started/installation/controller/controller.md
@@ -42,8 +42,8 @@ configure Aperture Agents to talk to the ARC Controller.
 To start with ARC Controller, start by creating your own organization on
 [FluxNinja ARC](https://www.fluxninja.com/product) and start the free trial.
 
-This rest page describes installation of self-hosted Aperture Controller and
-can be skipped.
+This rest page describes installation of self-hosted Aperture Controller and can
+be skipped.
 
 :::
 

--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -50,7 +50,7 @@ service meshes, and application middlewares. Moreover, it offers SDKs for
 developers who need to establish control points around specific features or code
 sections inside applications.
 
-## ⚙️ Load management capabilities
+## ⚙️ Load management capabilities {#load-management-capabilities}
 
 Aperture provides a variety of advanced load management features:
 
@@ -100,7 +100,7 @@ Aperture provides a variety of advanced load management features:
   service disruptions and maintains consistent performance, even when rolling
   out new features.
 
-## 🛠️ How it works
+## 🛠️ How it works {#how-it-works}
 
 Load management, at its core, consists of a control loop that observes,
 analyzes, and actuates workloads to ensure the stability and reliability of
@@ -123,7 +123,7 @@ service-level objectives.
 ![Aperture Control Loop](assets/img/oaalight.png#gh-light-mode-only)
 ![Aperture Control Loop](assets/img/oaadark.png#gh-dark-mode-only)
 
-## ✨ Get started
+## ✨ Get started {#get-started}
 
 - [**Setting up your application**](/get-started/setting-up-application/setting-up-application.md)
 - [**Install Aperture**](/get-started/installation/installation.md)
@@ -134,7 +134,7 @@ For an in-depth understanding of how Aperture interacts with applications and
 its various integral components, explore the
 [Architecture](/architecture/architecture.md) section.
 
-## 📖 Learn
+## 📖 Learn {#learn}
 
 The [Concepts section](/concepts/concepts.md) provides detailed insights into
 essential elements of Aperture's system and policies, offering a comprehensive

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1557,7 +1557,8 @@ EnableCloudController.
 Whether to connect to ARC controller.
 
 Overrides etcd configuration and disables local Prometheus OTel pipelines. See
-[FluxNinja ARC](/arc/introduction.md) for more details.
+[ARC Controller](/get-started/installation/controller/controller.md#installation)
+for more details.
 
 </dd>
 <dt>endpoint</dt>

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -978,7 +978,8 @@ EnableCloudController.
 Whether to connect to ARC controller.
 
 Overrides etcd configuration and disables local Prometheus OTel pipelines. See
-[FluxNinja ARC](/arc/introduction.md) for more details.
+[ARC Controller](/get-started/installation/controller/controller.md#installation)
+for more details.
 
 </dd>
 <dt>endpoint</dt>

--- a/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
+++ b/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
@@ -119,7 +119,7 @@ definitions:
                     Whether to connect to ARC controller.
 
                     Overrides etcd configuration and disables local Prometheus OTel pipelines.
-                    See [FluxNinja ARC](/arc/introduction.md) for more details.
+                    See [ARC Controller](/get-started/installation/controller/controller.md#installation) for more details.
                 type: boolean
                 x-go-name: EnableCloudController
                 x-go-tag-default: "false"

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -31,7 +31,7 @@ type FluxNinjaExtensionConfig struct {
 	// Whether to connect to ARC controller.
 	//
 	// Overrides etcd configuration and disables local Prometheus OTel pipelines.
-	// See [FluxNinja ARC](/arc/introduction.md) for more details.
+	// See [ARC Controller](/get-started/installation/controller/controller.md#installation) for more details.
 	EnableCloudController bool `json:"enable_cloud_controller" default:"false"`
 
 	// Interval between each heartbeat.

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1303,7 +1303,8 @@ spec:
                       enable_cloud_controller:
                         description: "Whether to connect to ARC controller. \n Overrides
                           etcd configuration and disables local Prometheus OTel pipelines.
-                          See [FluxNinja ARC](/arc/introduction.md) for more details."
+                          See [ARC Controller](/get-started/installation/controller/controller.md#installation)
+                          for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -1187,7 +1187,8 @@ spec:
                       enable_cloud_controller:
                         description: "Whether to connect to ARC controller. \n Overrides
                           etcd configuration and disables local Prometheus OTel pipelines.
-                          See [FluxNinja ARC](/arc/introduction.md) for more details."
+                          See [ARC Controller](/get-started/installation/controller/controller.md#installation)
+                          for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1303,7 +1303,8 @@ spec:
                       enable_cloud_controller:
                         description: "Whether to connect to ARC controller. \n Overrides
                           etcd configuration and disables local Prometheus OTel pipelines.
-                          See [FluxNinja ARC](/arc/introduction.md) for more details."
+                          See [ARC Controller](/get-started/installation/controller/controller.md#installation)
+                          for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1187,7 +1187,8 @@ spec:
                       enable_cloud_controller:
                         description: "Whether to connect to ARC controller. \n Overrides
                           etcd configuration and disables local Prometheus OTel pipelines.
-                          See [FluxNinja ARC](/arc/introduction.md) for more details."
+                          See [ARC Controller](/get-started/installation/controller/controller.md#installation)
+                          for more details."
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in


### PR DESCRIPTION
* Add intro to FluxNinja ARC by @martarogala.
* Move ARC Controller description to install section (the on-premise
  instructions are still there, will be moved out in a subsequent PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

### Release Notes

**Documentation**: Updated and reorganized FluxNinja ARC documentation. The introduction to FluxNinja ARC is now more comprehensive, with detailed installation instructions and updated links. The description of the ARC Controller has been moved to the installation section for better clarity. Also, the documentation now includes a more in-depth explanation of FluxNinja ARC's load management features.

> 🎉 Celebrate the changes, oh so grand,  
> To FluxNinja's docs, they lend a hand.  
> Clearer instructions, links anew,  
> For users old and users new.  
> Understanding grows, confusion flees,  
> With our ARC Controller, navigate with ease! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->