### PR TITLE
docs: Showcase aperturectl with cloud controller in Get Started

### DIFF
--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -174,6 +174,10 @@ func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("invalid config file '%s'. Missing key 'controller.url'", c.config)
 		}
 
+		if config.Controller.APIKey == "" {
+			return fmt.Errorf("invalid config file '%s'. Missing key 'controller.api_key'", c.config)
+		}
+
 		c.controllerAddr = config.Controller.URL
 		c.apiKey = config.Controller.APIKey
 	}

--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -174,10 +174,6 @@ func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("invalid config file '%s'. Missing key 'controller.url'", c.config)
 		}
 
-		if config.Controller.APIKey == "" {
-			return fmt.Errorf("invalid config file '%s'. Missing key 'controller.api_key'", c.config)
-		}
-
 		c.controllerAddr = config.Controller.URL
 		c.apiKey = config.Controller.APIKey
 	}

--- a/docs/content/get-started/installation/agent/agent.md
+++ b/docs/content/get-started/installation/agent/agent.md
@@ -1,6 +1,6 @@
 ---
-title: Aperture Agent
-description: Install Aperture Agent
+title: Install Agents
+description: Install Aperture Agents
 keywords:
   - install
   - setup

--- a/docs/content/get-started/installation/aperture-cli/aperture-cli.md
+++ b/docs/content/get-started/installation/aperture-cli/aperture-cli.md
@@ -1,6 +1,6 @@
 ---
-title: Install CLI (apeturectl)
-description: Aperture CLI for interacting with Aperture Seamlessly.
+title: Install CLI (aperturectl)
+description: Aperture CLI for interacting with Aperture seamlessly.
 keywords:
   - cli
 sidebar_position: 1
@@ -151,4 +151,4 @@ sudo rpm -e aperturectl
 
 ---
 
-### [aperturectl](/reference/aperturectl/aperturectl.md)
+## [aperturectl](/reference/aperturectl/aperturectl.md)

--- a/docs/content/get-started/installation/configure-cli.md
+++ b/docs/content/get-started/installation/configure-cli.md
@@ -16,17 +16,17 @@ api_key = "API_KEY"
 
 :::tip
 
-You can create multiple config files and use `APERTURE_CONFIG` environment
-variable to switch between them.
+You can create multiple configuration files and use `APERTURE_CONFIG`
+environment variable to switch between them.
 
 :::
 
 :::note self-hosted controller
 
 With a [self-hosted][] controller, if the controller is at the cluster pointed
-at by `~/.kube/config` or `KUBECONFIG`, no config file nor flags are needed at
-all. Otherwise, you need the `--controller` flag. See [aperturectl][] reference
-for details.
+at by `~/.kube/config` or `KUBECONFIG`, no configuration file nor flags are
+needed at all. Otherwise, you need the `--controller` flag. See [aperturectl][]
+reference for details.
 
 :::
 

--- a/docs/content/get-started/installation/configure-cli.md
+++ b/docs/content/get-started/installation/configure-cli.md
@@ -23,10 +23,10 @@ variable to switch between them.
 
 :::note self-hosted controller
 
-With [self-hosted][] controller, if the controller is at the cluster pointed at
-by `~/.kube/config` or `KUBECONFIG`, no config file nor flags are needed at all.
-Otherwise, you need the `--controller` flag. See [aperturectl][] reference for
-details.
+With a [self-hosted][] controller, if the controller is at the cluster pointed
+at by `~/.kube/config` or `KUBECONFIG`, no config file nor flags are needed at
+all. Otherwise, you need the `--controller` flag. See [aperturectl][] reference
+for details.
 
 :::
 

--- a/docs/content/get-started/installation/configure-cli.md
+++ b/docs/content/get-started/installation/configure-cli.md
@@ -1,0 +1,34 @@
+---
+title: Configure CLI
+keywords:
+  - cli
+sidebar_position: 2
+---
+
+Configure aperturectl to point to your FluxNinja ARC endpoint: Save the
+following as `~/.aperturectl/config`:
+
+```toml
+[controller]
+url = "ORGANIZATION_NAME.app.fluxninja.com:443"
+api_key = "API_KEY"
+```
+
+:::tip
+
+You can create multiple config files and use `APERTURE_CONFIG` environment
+variable to switch between them.
+
+:::
+
+:::note self-hosted controller
+
+With [self-hosted][] controller, if the controller is at the cluster pointed at
+by `~/.kube/config` or `KUBECONFIG`, no config file nor flags are needed at all.
+Otherwise, you need the `--controller` flag. See [aperturectl][] reference for
+details.
+
+:::
+
+[self-hosted]: /self-hosting/self-hosting.md
+[aperturectl]: /reference/aperturectl/aperturectl.md

--- a/docs/content/get-started/policies/policies.md
+++ b/docs/content/get-started/policies/policies.md
@@ -179,7 +179,6 @@ Run the following command to check if the policy was created.
 aperturectl policies
 ```
 
-
 ```mdx-code-block
 </TabItem>
 <TabItem value="kubectl" label="kubectl">
@@ -195,10 +194,9 @@ kubectl get policies.fluxninja.com -n aperture-controller
 ```
 
 The policy runtime can be visualized in [FluxNinja ARC][], Grafana or any other
-Prometheus compatible analytics tool. Refer to the Prometheus compatible
-metrics available from the [controller][controller-metrics] and
-[agent][agent-metrics]. Some policy [blueprints][blueprints] come with
-recommended Grafana dashboards.
+Prometheus compatible analytics tool. Refer to the Prometheus compatible metrics
+available from the [controller][controller-metrics] and [agent][agent-metrics].
+Some policy [blueprints][blueprints] come with recommended Grafana dashboards.
 
 ## Deleting Policies
 

--- a/docs/content/get-started/policies/policies.md
+++ b/docs/content/get-started/policies/policies.md
@@ -138,18 +138,23 @@ Controller is installed.
 --values-file=values.yaml --apply --version={apertureVersion}</CodeBlock>
 ```
 
-It uses the default configuration for Kubernetes cluster under `~/.kube/config`.
-You can pass the `--kube-config` flag to pass any other path.
+:::info
 
-```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=rate-limiting/base
---values-file=values.yaml --kube-config=/path/to/config --apply --version={apertureVersion}</CodeBlock>
-```
+See [aperturectl configuration](/get-started/installation/configure-cli.md) on
+how to configure what aperturectl should connect to.
+
+:::
 
 ```mdx-code-block
 </TabItem>
 <TabItem value="kubectl" label="kubectl">
 ```
+
+:::caution
+
+You can only apply policies with kubectl on [self-hosted][] controller.
+
+:::
 
 The policy YAML generated (Kubernetes Custom Resource) using the above example
 can also be applied using `kubectl`.
@@ -165,21 +170,61 @@ kubectl apply -f policy-gen/configuration/rate-limiting-cr.yaml -n aperture-cont
 
 Run the following command to check if the policy was created.
 
+```mdx-code-block
+<Tabs>
+<TabItem value="aperturectl" label="aperturectl">
+```
+
+```bash
+aperturectl policies
+```
+
+
+```mdx-code-block
+</TabItem>
+<TabItem value="kubectl" label="kubectl">
+```
+
 ```bash
 kubectl get policies.fluxninja.com -n aperture-controller
 ```
 
-The policy runtime can be visualized in Grafana or any other Prometheus
-compatible analytics tool. Refer to the Prometheus compatible metrics available
-from the [controller][controller-metrics] and [agent][agent-metrics]. Some
-policy [blueprints][blueprints] come with recommended Grafana dashboards.
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+The policy runtime can be visualized in [FluxNinja ARC][], Grafana or any other
+Prometheus compatible analytics tool. Refer to the Prometheus compatible
+metrics available from the [controller][controller-metrics] and
+[agent][agent-metrics]. Some policy [blueprints][blueprints] come with
+recommended Grafana dashboards.
 
 ## Deleting Policies
 
 Run the following command to delete the above policy:
 
+```mdx-code-block
+<Tabs>
+<TabItem value="aperturectl" label="aperturectl">
+```
+
+```bash
+aperturectl delete policy --policy=rate-limiting
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="kubectl" label="kubectl">
+```
+
 ```bash
 kubectl delete policies.fluxninja.com rate-limiting -n aperture-controller
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 [controller-metrics]: /reference/observability/prometheus-metrics/controller.md
@@ -187,3 +232,5 @@ kubectl delete policies.fluxninja.com rate-limiting -n aperture-controller
 [blueprints]: /reference/blueprints/blueprints.md
 [policies]: /concepts/advanced/policy.md
 [grafana]: https://grafana.com/docs/grafana/latest/dashboards/
+[self-hosted]: /self-hosting/self-hosting.md
+[FluxNinja ARC]: /arc/introduction.md

--- a/docs/content/get-started/setting-up-application/setting-up-application.md
+++ b/docs/content/get-started/setting-up-application/setting-up-application.md
@@ -4,7 +4,7 @@ keywords:
   - setting up application
   - getting started
 sidebar_position: 1
-sidebar_label: Setting up your Application
+sidebar_label: Set up your Application
 ---
 
 ```mdx-code-block


### PR DESCRIPTION
### Description of change

* Show how to configure aperturectl
* Show how to list and delete policies with aperturectl

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

- **Documentation**: Updated and added new guides for configuring `aperturectl` with a FluxNinja ARC endpoint and using it with the cloud controller. The instructions cover policy management and visualization of policy runtime.
- **Bug fix**: Corrected the spelling of "aperturectl" in the documentation.
- **New Feature**: Removed the requirement for `api_key` in the configuration file for self-hosted setups.

> 🎉 Changes are here, no need to fear,
> Documentation clear, for all to hear.
> No more typo smear, that's a cheer!
> Self-hosted near, let's give a cheer! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->