### PR TITLE
Fix docs

### DIFF
--- a/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
@@ -168,7 +168,7 @@ Kubernetes Objects which will be created by following steps are listed
    </TabItem>
    <TabItem value="Helm" label="Helm">
    <CodeBlock language="bash">
-   {`helm install agent aperture/aperture-agent -f values.yaml --namespacen aperture-agent --create-namespace`}
+   {`helm install agent aperture/aperture-agent -f values.yaml --namespace aperture-agent --create-namespace`}
    </CodeBlock>
    </TabItem>
    </Tabs>

--- a/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
@@ -228,7 +228,7 @@ Kubernetes Objects which will be created by following steps are listed
    </TabItem>
    <TabItem value="Helm" label="Helm">
    <CodeBlock language="bash">
-   {`helm install agent aperture/aperture-agent -f values.yaml --namespacen aperture-agent --create-namespace`}
+   {`helm install agent aperture/aperture-agent -f values.yaml --namespace aperture-agent --create-namespace`}
    </CodeBlock>
    </TabItem>
    </Tabs>


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

**Documentation**: Fixed typos in the installation commands for the Helm chart in the Kubernetes operator documentation. The incorrect `--namespacen` flag has been corrected to `--namespace` in both the daemonset and sidecar setup instructions.

> 🎉 A typo once stood, causing some despair,
> 
> In our docs, it was a sneaky snare.
> 
> But fear no more, the fix is here,
> 
> Making our instructions crystal clear! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->