### PR TITLE
Added support to run agent with cloud-controller in playground

### DIFF
--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -270,7 +270,6 @@ DEP_TREE = {
     APERTURE_ISTIO_NS: {
         "istio": {
             "labels": ["Istio"],
-            "needs": ["controller", "agent"],
             "tkenv": TANKA_ROOT + "/apps/istio",
             "child_resources": [
                 {
@@ -502,7 +501,7 @@ def wrapped_k8s_yaml(yaml, allow_duplicates=False):
     k8s_yaml(yaml, allow_duplicates)
 
 
-def render_tanka(environment, env_vars, base_dir, namespace, enable_cloud_extension, values):
+def render_tanka(environment, env_vars, base_dir, namespace, cloud_extension, values):
     print(
         "Rendering tanka environment",
         environment,
@@ -525,15 +524,13 @@ def render_tanka(environment, env_vars, base_dir, namespace, enable_cloud_extens
         TANKA_DEPS_HANDLED.append(base_dir)
 
     trace("Rendering tanka with env: %s" % env_vars)
-
-    enable_cloud_extension = str(enable_cloud_extension)
     # Generate manifests with tanka
     rendered = local(
         quiet=True,
         command=[
             TANKA,
             "--ext-str=projectRoot=" + base_dir,
-            "--ext-str=ENABLE_CLOUD_EXTENSION=" + enable_cloud_extension,
+            "--ext-str=CLOUD_EXTENSION={}".format(str(encode_yaml(cloud_extension if cloud_extension.get('enabled') or cloud_extension.get('cloud_controller') else {}))),
             "--ext-str=VALUES=" + values,
             "show",
             # Allow dumping the templates to stdout,
@@ -568,7 +565,17 @@ def render_dashboards(policies):
     return dashboards
 
 
-def render_aperturectl(policies, namespace):
+def render_aperturectl(policies, namespace, cloud_extension):
+    api_key = ""
+    endpoint = ""
+    agent_group = ""
+    action = ""
+    if cloud_extension.get('cloud_controller'):
+        api_key = cloud_extension.get("api_key", "").lower()
+        endpoint = cloud_extension.get("endpoint", "").lower()
+        agent_group = cloud_extension.get("agent_group", "default").lower()
+        action = "apply" if config.tilt_subcommand == "up" else "delete"
+
     aperturectl_bin = str(local(command=["../scripts/build_aperturectl.sh"], quiet=True))
 
     blueprints_uri = os.path.join(GIT_ROOT, "blueprints")
@@ -578,11 +585,12 @@ def render_aperturectl(policies, namespace):
         policy_name = policy["policy_name"]
         values_file = policy["values_file"]
         rendered = local(command=["./scripts/render-policy.sh", base_dir, aperturectl_bin, blueprints_uri,
-                                  blueprint_name, policy_name, values_file], quiet=True)
+                                  blueprint_name, policy_name, values_file, api_key, endpoint, agent_group, action], quiet=True)
 
-        if namespace:
-            rendered = namespace_inject(rendered, namespace)
-        wrapped_k8s_yaml(rendered)
+        if rendered:
+            if namespace:
+                rendered = namespace_inject(rendered, namespace)
+            wrapped_k8s_yaml(rendered)
 
 
 def print_available_resources(dep_tree):
@@ -626,7 +634,7 @@ def invert_dep_tree(dep_tree):
     return inverted
 
 
-def get_resource_list_to_deploy(names, run_only_listed, dep_tree, inv_dep_tree):
+def get_resource_list_to_deploy(names, run_only_listed, dep_tree, inv_dep_tree, cloud_controller):
     """
     Recursively convert list of NS and service names to set of required services
     If a given name is both a name of resource and namespace, it is assumed to be resource
@@ -639,7 +647,7 @@ def get_resource_list_to_deploy(names, run_only_listed, dep_tree, inv_dep_tree):
     for name in names:
         if name in inv_dep_tree:  # It's resource name
             resources.append(name)
-            if not run_only_listed:
+            if not run_only_listed or (cloud_controller and name != 'agent'):
                 # We could recursively resolve dependencies, but then we risk getting in a dependency loop
                 resource_info = inv_dep_tree[name]
                 dependencies = resource_info.get("needs", [])
@@ -651,7 +659,7 @@ def get_resource_list_to_deploy(names, run_only_listed, dep_tree, inv_dep_tree):
         elif name in dep_tree:  # It's a namespace
             resource_names = dep_tree[name].keys()
             resources.extend(
-                get_resource_list_to_deploy(resource_names, run_only_listed, dep_tree, inv_dep_tree)
+                get_resource_list_to_deploy(resource_names, run_only_listed, dep_tree, inv_dep_tree, cloud_controller)
             )
         else:
             fail("Unable to find " + name + " as neither resource nor namespace name")
@@ -922,14 +930,14 @@ def process_aperture_scenario(scenario_path):
         "namespace": APERTURE_DEMOAPP_NS,
         "labels": "TestScenarioApplication",
         "manifests_path": PLAYGROUND_ROOT + "/" + "resources/wavepool-generator",
-        "resource_deps": ["scenario-policies", "cluster-bootstrap"],
+        "resource_deps": ["agent", "cluster-bootstrap"],
         "env_vars": {
             "NINJA_WAVEPOOL_JS": wavepool_js
         },
         "child_resources": [
             {
                 "workload": "wavepool-generator",
-                "resource_deps": ["scenario-policies"] if aperture_policies else [],
+                "resource_deps": ["scenario-policies", "agent"] if aperture_policies else ["agent"],
                 "extra_objects": [
                     "wavepool-config:configmap"
                 ]
@@ -968,7 +976,7 @@ def get_agent_version():
     val = str(local("git tag -l --sort='-version:refname' v* | head -n 1")).strip().strip("v")
     return val
 
-def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_extension, scenario):
+def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, cloud_extension, scenario):
     """
     Declares resource-specific actions (images, ports, etc)
     Generating manifests with tanka is done separately, in order to speed up builds
@@ -1047,7 +1055,7 @@ def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_
             namespace = app_config.get("namespace", None)
             if tkenv:
                 base_dir = app_config.get("base_dir")
-                render_tanka(tkenv, env_vars, base_dir, namespace, enable_cloud_extension, values)
+                render_tanka(tkenv, env_vars, base_dir, namespace, cloud_extension, values)
             elif renderer == "yaml":
                 render_yaml(manifests_path, env_vars)
             elif renderer == "jsonnet":
@@ -1057,7 +1065,7 @@ def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_
             elif renderer == "aperturectl":
                 namespace = app_config.get("namespace", None)
                 policies = app_config.get("aperture_policies", None)
-                render_aperturectl(policies, namespace)
+                render_aperturectl(policies, namespace, cloud_extension)
             else:
                 fail("Tanka app is not found for %s." % app)
 
@@ -1101,6 +1109,8 @@ def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, enable_cloud_
 
             child["labels"] = resource_labels
             verbose("Registering child", child)
+            if cloud_extension.get('cloud_controller') and child.get('new_name') == 'scenario-policies':
+                continue
             k8s_resource(**child)
         for kind in resource_info.get("kinds", []):
             k8s_kind(**kind)
@@ -1196,7 +1206,10 @@ config.define_string("scenario", usage="Demo scenario to execute")
 config.define_string_list("dockerhub-image", usage="A list of images to pull directly from docker.io/fluxninja")
 config.define_bool("race",usage="Enable race detector for agent and controller")
 config.define_bool("skip-extensions", usage="Skip extension building")
-config.define_bool("enable-cloud-extension",usage="Enable FluxNinja API key authentication, which will send the data to FluxNinja Cloud")
+config.define_bool("enable-cloud-extension", usage="Enable FluxNinja API key authentication, which will send the data to FluxNinja Cloud")
+config.define_bool("cloud-controller", usage="Uses FluxNinja Controller instead of Self-Hosted Controller")
+config.define_bool("api-key", usage="FluxNinja API key")
+config.define_string("fluxninja-endpoint", usage="FluxNinja Endpoint")
 cfg = config.parse()
 # Enable all resources, as calling `config.parse()` by default disables all
 config.set_enabled_resources([])
@@ -1209,10 +1222,23 @@ if cfg.get("list-resources", False):
 if cfg.get("manual", False):
     trigger_mode(TRIGGER_MODE_MANUAL)
 
+cloud_controller = cfg.get("cloud-controller", False)
+run_only_listed = cfg.get("only", cloud_controller)
 get_race = cfg.get("race",False)
-enable_cloud_extension = cfg.get("enable-cloud-extension",False)
+enable_cloud_extension = cfg.get("enable-cloud-extension", False)
+fluxninja_endpoint = ''
+api_key = ''
+if cloud_controller or enable_cloud_extension:
+    fluxninja_endpoint = cfg.get("fluxninja-endpoint", "aperture.latest.dev.fluxninja.com:443")
+    api_key = cfg.get("api-key", "2b97802cf7984791919758a537c05ad0")
 
-run_only_listed = cfg.get("only", False)
+cloud_extension = {
+    'enabled': enable_cloud_extension,
+    'endpoint': fluxninja_endpoint,
+    'api_key': api_key,
+    'agent_group': str(local('hostname')).strip(),
+    'cloud_controller': cloud_controller,
+}
 
 # Optionally, process a list of images that should be pulled from dockerhub instead of being
 # built locally. This is mostly meant for aperture-agent, aperture-controller and aperture-operator.
@@ -1222,7 +1248,7 @@ if dockerhub_images:
 
 to_run = cfg.get("to-run", ["agent"])
 
-scenario = cfg.get("scenario", DEFAULT_TEST_SCENARIO if not run_only_listed else None)
+scenario = cfg.get("scenario", DEFAULT_TEST_SCENARIO if not run_only_listed or cloud_controller else None)
 if scenario:
     # If this is a relative path, it's relative to Tiltfile (PLAYGROUND_ROOT_PATH)
     if scenario[0] != "/":
@@ -1231,10 +1257,12 @@ if scenario:
     to_run += ["scenario-app", "scenario-wavepool"]
     # Not all scenarios have policies, so only load policies if they were generated based on the scenario.
     if "scenario-policies" in DEP_TREE[APERTURE_DEMOAPP_NS]:
-        to_run += ["scenario-policies", "aperture-grafana"]
+        to_run += ["scenario-policies"]
+        if not cloud_controller:
+            to_run += ["aperture-grafana"]
 
     for resource in DEP_TREE[APERTURE_CONTROLLER_NS]:
-        if "scenario-dashboard" in resource:
+        if "scenario-dashboard" in resource and not cloud_controller:
             to_run += [resource]
 
 cfg_trace = cfg.get("trace", os.getenv("NINJA_TILT_TRACE", "false"))
@@ -1248,7 +1276,7 @@ if cfg.get("skip-extensions", os.getenv("SKIP_EXTENSIONS", "false").lower() == "
     DEP_TREE[APERTURE_AGENT_NS]["agent"]["images"][0]["target"] = "agent-base"
 
 inverted_dep_tree = invert_dep_tree(DEP_TREE)
-resources = get_resource_list_to_deploy(to_run, run_only_listed, DEP_TREE, inverted_dep_tree)
+resources = get_resource_list_to_deploy(to_run, run_only_listed, DEP_TREE, inverted_dep_tree, cloud_controller)
 
 print("Will deploy resources:", ", ".join(resources))
 
@@ -1315,4 +1343,4 @@ cmd_button('aperture-java-trigger',
         icon_name='ads_click',
         text='Trigger library example',
 )
-declare_resources(resources, DEP_TREE, inverted_dep_tree,get_race, enable_cloud_extension, scenario)
+declare_resources(resources, DEP_TREE, inverted_dep_tree,get_race, cloud_extension, scenario)

--- a/playground/ctlptl-kind-config.yaml
+++ b/playground/ctlptl-kind-config.yaml
@@ -4,7 +4,7 @@
 apiVersion: ctlptl.dev/v1alpha1
 kind: Registry
 name: ctlptl-registry
-port: 5005
+port: 5001
 ---
 # Creates a cluster with 3 nodes.
 apiVersion: ctlptl.dev/v1alpha1
@@ -12,7 +12,7 @@ kind: Cluster
 product: kind
 registry: ctlptl-registry
 kindV1Alpha4Cluster:
-  name: aperture-playground
+  name: kind-kind
   nodes:
     - role: control-plane
     - role: worker

--- a/playground/ctlptl-kind-config.yaml
+++ b/playground/ctlptl-kind-config.yaml
@@ -4,7 +4,7 @@
 apiVersion: ctlptl.dev/v1alpha1
 kind: Registry
 name: ctlptl-registry
-port: 5001
+port: 5005
 ---
 # Creates a cluster with 3 nodes.
 apiVersion: ctlptl.dev/v1alpha1
@@ -12,7 +12,7 @@ kind: Cluster
 product: kind
 registry: ctlptl-registry
 kindV1Alpha4Cluster:
-  name: kind-kind
+  name: aperture-playground
   nodes:
     - role: control-plane
     - role: worker

--- a/playground/scenarios/basic-service-protection/policies/basic-service-protection-cr.yaml
+++ b/playground/scenarios/basic-service-protection/policies/basic-service-protection-cr.yaml
@@ -34,7 +34,8 @@ spec:
             load_multiplier_linear_increment: 0.025
             load_scheduler:
               selectors:
-              - control_point: ingress
+              - agent_group: default
+                control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
             max_load_multiplier: 2
     - query:
@@ -73,6 +74,7 @@ spec:
       flux_meters:
         basic-service-protection:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/basic-service-protection/policies/basic-service-protection.yaml
+++ b/playground/scenarios/basic-service-protection/policies/basic-service-protection.yaml
@@ -14,7 +14,8 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
   latency_baseliner:
     latency_tolerance_multiplier: 1.1
@@ -23,5 +24,6 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
@@ -62,9 +62,11 @@ spec:
                   parameters:
                     priority: 50
               selectors:
-              - control_point: egress
+              - agent_group: default
+                control_point: egress
                 service: service1-demo-app.demoapp.svc.cluster.local
-              - control_point: egress
+              - agent_group: default
+                control_point: egress
                 service: service2-demo-app.demoapp.svc.cluster.local
             max_load_multiplier: 2
     - query:
@@ -103,6 +105,7 @@ spec:
       flux_meters:
         weighted-service-protection:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service3-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
@@ -12,9 +12,11 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - control_point: egress
+          - agent_group: default
+            control_point: egress
             service: service1-demo-app.demoapp.svc.cluster.local
-          - control_point: egress
+          - agent_group: default
+            control_point: egress
             service: service2-demo-app.demoapp.svc.cluster.local
         scheduler:
           workloads:
@@ -51,5 +53,6 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service3-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/feature-rollout/policies/load-ramping-cr.yaml
+++ b/playground/scenarios/feature-rollout/policies/load-ramping-cr.yaml
@@ -134,7 +134,8 @@ spec:
             sampler:
               label_key: ""
               selectors:
-              - control_point: ingress
+              - agent_group: default
+                control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
             steps:
             - duration: 0s
@@ -148,6 +149,7 @@ spec:
       flux_meters:
         load-ramping/average_latency/0:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/feature-rollout/policies/load-ramping.yaml
+++ b/playground/scenarios/feature-rollout/policies/load-ramping.yaml
@@ -15,7 +15,8 @@ policy:
   drivers:
     average_latency_drivers:
       - selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
         criteria:
           forward:
@@ -27,7 +28,8 @@ policy:
   load_ramp:
     sampler:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local
       label_key: ""
     steps:

--- a/playground/scenarios/graceful-js/policies/load-ramping-cr.yaml
+++ b/playground/scenarios/graceful-js/policies/load-ramping-cr.yaml
@@ -134,7 +134,8 @@ spec:
             sampler:
               label_key: ""
               selectors:
-              - control_point: ingress
+              - agent_group: default
+                control_point: ingress
                 label_matcher:
                   match_labels:
                     http.path: /api/load-ramp
@@ -151,7 +152,8 @@ spec:
       flux_meters:
         load-ramping/average_latency/0:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             label_matcher:
               match_labels:
                 http.path: /api/load-ramp

--- a/playground/scenarios/graceful-js/policies/load-ramping.yaml
+++ b/playground/scenarios/graceful-js/policies/load-ramping.yaml
@@ -15,7 +15,8 @@ policy:
   drivers:
     average_latency_drivers:
       - selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
             label_matcher:
               match_labels:
@@ -30,7 +31,8 @@ policy:
   load_ramp:
     sampler:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local
           label_matcher:
             match_labels:

--- a/playground/scenarios/graceful-js/policies/rate-limiting-cr.yaml
+++ b/playground/scenarios/graceful-js/policies/rate-limiting-cr.yaml
@@ -20,7 +20,8 @@ spec:
             interval: 60s
             label_key: http.request.header.user_id
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             label_matcher:
               match_labels:
                 http.path: /api/rate-limit

--- a/playground/scenarios/graceful-js/policies/rate-limiting.yaml
+++ b/playground/scenarios/graceful-js/policies/rate-limiting.yaml
@@ -8,7 +8,8 @@ policy:
     bucket_capacity: 30
     fill_amount: 2
     selectors:
-      - service: service1-demo-app.demoapp.svc.cluster.local
+      - agent_group: default
+        service: service1-demo-app.demoapp.svc.cluster.local
         control_point: ingress
         label_matcher:
           match_labels:

--- a/playground/scenarios/graceful-js/policies/workload-prioritization-cr.yaml
+++ b/playground/scenarios/graceful-js/policies/workload-prioritization-cr.yaml
@@ -48,7 +48,8 @@ spec:
                   parameters:
                     priority: 250
               selectors:
-              - control_point: ingress
+              - agent_group: default
+                control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
             max_load_multiplier: 2
     - query:
@@ -89,11 +90,13 @@ spec:
             extractor:
               from: request.http.headers.user-type
         selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local
       flux_meters:
         workload-prioritization:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/graceful-js/policies/workload-prioritization.yaml
+++ b/playground/scenarios/graceful-js/policies/workload-prioritization.yaml
@@ -13,7 +13,8 @@ policy:
     flow_control:
       classifiers:
         - selectors:
-            - service: service1-demo-app.demoapp.svc.cluster.local
+            - agent_group: default
+              service: service1-demo-app.demoapp.svc.cluster.local
               control_point: ingress
           rules:
             user_type:
@@ -26,7 +27,8 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
         scheduler:
           workloads:
@@ -49,5 +51,6 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
@@ -46,7 +46,8 @@ spec:
                   parameters:
                     priority: 200
               selectors:
-              - control_point: awesomeFeature
+              - agent_group: default
+                control_point: awesomeFeature
                 service: service1-demo-app.demoapp.svc.cluster.local
             max_load_multiplier: 2
     - decider:
@@ -85,7 +86,8 @@ spec:
             interval: 1s
             label_key: user_id
           selectors:
-          - control_point: awesomeFeature
+          - agent_group: default
+            control_point: awesomeFeature
             label_matcher:
               match_labels:
                 user_type: crawler
@@ -128,11 +130,13 @@ spec:
             extractor:
               from: request.http.headers.user-type
         selectors:
-        - control_point: awesomeFeature
+        - agent_group: default
+          control_point: awesomeFeature
           service: service1-demo-app.demoapp.svc.cluster.local
       flux_meters:
         service-protection:
           selectors:
-          - control_point: awesomeFeature
+          - agent_group: default
+            control_point: awesomeFeature
             service: service3-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/java-service-protection/policies/service-protection.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection.yaml
@@ -43,7 +43,8 @@ policy:
             fill_amount:
               signal_name: RATE_LIMIT
           selectors:
-            - service: service1-demo-app.demoapp.svc.cluster.local
+            - agent_group: default
+              service: service1-demo-app.demoapp.svc.cluster.local
               control_point: awesomeFeature
               label_matcher:
                 match_labels:
@@ -57,7 +58,8 @@ policy:
     flow_control:
       classifiers:
         - selectors:
-            - service: service1-demo-app.demoapp.svc.cluster.local
+            - agent_group: default
+              service: service1-demo-app.demoapp.svc.cluster.local
               control_point: awesomeFeature
           rules:
             user_type:
@@ -71,7 +73,8 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - service: service1-demo-app.demoapp.svc.cluster.local
+          - agent_group: default
+            service: service1-demo-app.demoapp.svc.cluster.local
             control_point: awesomeFeature
         # Scheduler parameters.
         # Type: aperture.spec.v1.SchedulerParameters
@@ -98,5 +101,6 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: awesomeFeature
+        - agent_group: default
+          control_point: awesomeFeature
           service: service3-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization-cr.yaml
+++ b/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization-cr.yaml
@@ -46,7 +46,8 @@ spec:
                   parameters:
                     priority: 200
               selectors:
-              - control_point: ingress
+              - agent_group: default
+                control_point: ingress
                 label_matcher:
                   match_labels:
                     http.path: /api/v1/write
@@ -122,6 +123,7 @@ spec:
       flux_meters:
         prometheus-workload-prioritization:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: controller-prometheus-server.aperture-controller.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization.yaml
+++ b/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization.yaml
@@ -50,7 +50,8 @@ policy:
       # Required: True
       load_scheduler:
         selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: controller-prometheus-server.aperture-controller.svc.cluster.local
             label_matcher:
               match_labels:
@@ -75,5 +76,6 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: controller-prometheus-server.aperture-controller.svc.cluster.local

--- a/playground/scenarios/quota-scheduler/policies/quota-scheduler-cr.yaml
+++ b/playground/scenarios/quota-scheduler/policies/quota-scheduler-cr.yaml
@@ -37,7 +37,8 @@ spec:
               parameters:
                 priority: 200
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
     evaluation_interval: 1s
   resources:

--- a/playground/scenarios/quota-scheduler/policies/quota-scheduler.yaml
+++ b/playground/scenarios/quota-scheduler/policies/quota-scheduler.yaml
@@ -8,7 +8,8 @@ policy:
     bucket_capacity: 500
     fill_amount: 25
     selectors:
-      - service: service1-demo-app.demoapp.svc.cluster.local
+      - agent_group: default
+        service: service1-demo-app.demoapp.svc.cluster.local
         control_point: ingress
     rate_limiter:
       label_key: http.request.header.api_key

--- a/playground/scenarios/rate-limiting/policies/rate-limiting-cr.yaml
+++ b/playground/scenarios/rate-limiting/policies/rate-limiting-cr.yaml
@@ -20,7 +20,8 @@ spec:
             interval: 1s
             label_key: http.request.header.user_id
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
     evaluation_interval: 1s
   resources:

--- a/playground/scenarios/rate-limiting/policies/rate-limiting.yaml
+++ b/playground/scenarios/rate-limiting/policies/rate-limiting.yaml
@@ -15,7 +15,8 @@ policy:
     bucket_capacity: 40
     fill_amount: 2
     selectors:
-      - service: service1-demo-app.demoapp.svc.cluster.local
+      - agent_group: default
+        service: service1-demo-app.demoapp.svc.cluster.local
         control_point: ingress
     parameters:
       label_key: http.request.header.user_id

--- a/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale-cr.yaml
+++ b/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale-cr.yaml
@@ -114,6 +114,7 @@ spec:
       flux_meters:
         load-based-auto-scale:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale.yaml
+++ b/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale.yaml
@@ -24,7 +24,8 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local
   components:
     - auto_scale:

--- a/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app-cr.yaml
@@ -48,7 +48,8 @@ spec:
                   parameters:
                     priority: 200
               selectors:
-              - control_point: service1-demo-app
+              - agent_group: default
+                control_point: service1-demo-app
                 label_matcher:
                   match_labels:
                     http.target: /service1/request
@@ -90,7 +91,8 @@ spec:
             interval: 1s
             label_key: http.request.header.user_id
           selectors:
-          - control_point: service1-demo-app
+          - agent_group: default
+            control_point: service1-demo-app
             label_matcher:
               match_labels:
                 http.request.header.user_type: crawler
@@ -132,7 +134,8 @@ spec:
             extractor:
               from: request.http.headers.user-type
         selectors:
-        - control_point: service1-demo-app
+        - agent_group: default
+          control_point: service1-demo-app
           label_matcher:
             match_labels:
               http.target: /service1/request
@@ -140,7 +143,8 @@ spec:
       flux_meters:
         service1-demo-app:
           selectors:
-          - control_point: service3-demo-app
+          - agent_group: default
+            control_point: service3-demo-app
             label_matcher:
               match_labels:
                 http.target: /service3

--- a/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app.yaml
@@ -38,7 +38,8 @@ policy:
     - flow_control:
         rate_limiter:
           selectors:
-            - control_point: service1-demo-app
+            - agent_group: default
+              control_point: service1-demo-app
               label_matcher:
                 match_labels:
                   "http.request.header.user_type": "crawler"
@@ -56,7 +57,8 @@ policy:
     flow_control:
       classifiers:
         - selectors:
-            - control_point: service1-demo-app
+            - agent_group: default
+              control_point: service1-demo-app
               service: kong-server.demoapp.svc.cluster.local
               label_matcher:
                 match_labels:
@@ -73,7 +75,8 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - control_point: service1-demo-app
+          - agent_group: default
+            control_point: service1-demo-app
             service: kong-server.demoapp.svc.cluster.local
             label_matcher:
               match_labels:
@@ -105,7 +108,8 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: service3-demo-app
+        - agent_group: default
+          control_point: service3-demo-app
           service: kong-server.demoapp.svc.cluster.local
           label_matcher:
             match_labels:

--- a/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app-cr.yaml
@@ -48,7 +48,8 @@ spec:
                   parameters:
                     priority: 200
               selectors:
-              - control_point: service1-demo-app
+              - agent_group: default
+                control_point: service1-demo-app
                 label_matcher:
                   match_labels:
                     http.target: /service1
@@ -90,7 +91,8 @@ spec:
             interval: 1s
             label_key: http.request.header.user_id
           selectors:
-          - control_point: service1-demo-app
+          - agent_group: default
+            control_point: service1-demo-app
             label_matcher:
               match_labels:
                 http.request.header.user_type: crawler
@@ -132,7 +134,8 @@ spec:
             extractor:
               from: request.http.headers.user-type
         selectors:
-        - control_point: service1-demo-app
+        - agent_group: default
+          control_point: service1-demo-app
           label_matcher:
             match_labels:
               http.target: /service1
@@ -140,7 +143,8 @@ spec:
       flux_meters:
         service1-demo-app:
           selectors:
-          - control_point: service3-demo-app
+          - agent_group: default
+            control_point: service3-demo-app
             label_matcher:
               match_labels:
                 http.target: /service3

--- a/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app.yaml
@@ -38,7 +38,8 @@ policy:
     - flow_control:
         rate_limiter:
           selectors:
-            - control_point: service1-demo-app
+            - agent_group: default
+              control_point: service1-demo-app
               label_matcher:
                 match_labels:
                   "http.request.header.user_type": "crawler"
@@ -56,7 +57,8 @@ policy:
     flow_control:
       classifiers:
         - selectors:
-            - control_point: service1-demo-app
+            - agent_group: default
+              control_point: service1-demo-app
               service: nginx-server.demoapp.svc.cluster.local
               label_matcher:
                 match_labels:
@@ -73,7 +75,8 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - control_point: service1-demo-app
+          - agent_group: default
+            control_point: service1-demo-app
             service: nginx-server.demoapp.svc.cluster.local
             label_matcher:
               match_labels:
@@ -105,7 +108,8 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: service3-demo-app
+        - agent_group: default
+          control_point: service3-demo-app
           service: nginx-server.demoapp.svc.cluster.local
           label_matcher:
             match_labels:

--- a/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app-cr.yaml
@@ -50,7 +50,8 @@ spec:
                     priority: 200
                     queue_timeout: 2s
               selectors:
-              - control_point: ingress
+              - agent_group: default
+                control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
             max_load_multiplier: 2
     - decider:
@@ -92,7 +93,8 @@ spec:
               enabled: true
               num_sync: 4
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             label_matcher:
               match_labels:
                 http.request.header.user_type: crawler
@@ -135,11 +137,13 @@ spec:
             extractor:
               from: request.http.headers.user-type
         selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local
       flux_meters:
         service1-demo-app:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service3-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app.yaml
+++ b/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app.yaml
@@ -38,7 +38,8 @@ policy:
     - flow_control:
         rate_limiter:
           selectors:
-            - service: service1-demo-app.demoapp.svc.cluster.local
+            - agent_group: default
+              service: service1-demo-app.demoapp.svc.cluster.local
               control_point: ingress
               label_matcher:
                 match_labels:
@@ -60,7 +61,8 @@ policy:
     flow_control:
       classifiers:
         - selectors:
-            - service: service1-demo-app.demoapp.svc.cluster.local
+            - agent_group: default
+              service: service1-demo-app.demoapp.svc.cluster.local
               control_point: ingress
           rules:
             user_type:
@@ -74,7 +76,8 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - service: service1-demo-app.demoapp.svc.cluster.local
+          - agent_group: default
+            service: service1-demo-app.demoapp.svc.cluster.local
             control_point: ingress
         # Scheduler parameters.
         # Type: aperture.spec.v1.SchedulerParameters
@@ -105,5 +108,6 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service3-demo-app.demoapp.svc.cluster.local

--- a/playground/scenarios/workload-prioritization/policies/workload-prioritization-cr.yaml
+++ b/playground/scenarios/workload-prioritization/policies/workload-prioritization-cr.yaml
@@ -48,7 +48,8 @@ spec:
                   parameters:
                     priority: 200
               selectors:
-              - control_point: ingress
+              - agent_group: default
+                control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
             max_load_multiplier: 2
     - query:
@@ -89,11 +90,13 @@ spec:
             extractor:
               from: request.http.headers.user-type
         selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local
       flux_meters:
         workload-prioritization:
           selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
     infra_meters: {}

--- a/playground/scenarios/workload-prioritization/policies/workload-prioritization.yaml
+++ b/playground/scenarios/workload-prioritization/policies/workload-prioritization.yaml
@@ -13,7 +13,8 @@ policy:
     flow_control:
       classifiers:
         - selectors:
-            - service: service1-demo-app.demoapp.svc.cluster.local
+            - agent_group: default
+              service: service1-demo-app.demoapp.svc.cluster.local
               control_point: ingress
           rules:
             user_type:
@@ -26,7 +27,8 @@ policy:
         # Type: []aperture.spec.v1.Selector
         # Required: True
         selectors:
-          - control_point: ingress
+          - agent_group: default
+            control_point: ingress
             service: service1-demo-app.demoapp.svc.cluster.local
         scheduler:
           workloads:
@@ -49,5 +51,6 @@ policy:
     # Required: True
     flux_meter:
       selectors:
-        - control_point: ingress
+        - agent_group: default
+          control_point: ingress
           service: service1-demo-app.demoapp.svc.cluster.local

--- a/playground/scripts/render-policy.sh
+++ b/playground/scripts/render-policy.sh
@@ -7,6 +7,10 @@ blueprints_uri=$3
 blueprint_name=$4
 policy_name=$5
 values_file=$6
+api_key=${7:-}
+endpoint=${8:-}
+agent_group=${9:-default}
+action=${10:-apply}
 
 SED="sed"
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -14,16 +18,33 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 _GEN_DIR="${base_dir}/_gen"
+mkdir -p "${_GEN_DIR}"
 trap 'rm -rf -- "$_GEN_DIR"' EXIT
 
-"${aperturectl}" blueprints generate --name "${blueprint_name}" --uri "${blueprints_uri}" \
-	--values-file "${values_file}" --output-dir "${_GEN_DIR}" >&2
+if [[ "$api_key" != '' && "$endpoint" != '' ]]; then
+	cp "${values_file}" "${_GEN_DIR}/values.yaml"
+	new_policy_name=${policy_name}-${agent_group}
+	$SED -i "s/\bagent_group: .*/agent_group: ${agent_group}/g" "${_GEN_DIR}/values.yaml"
+	$SED -i "s/\bpolicy_name: .*/policy_name: ${new_policy_name}/g" "${_GEN_DIR}/values.yaml"
 
-rendered_policy="${_GEN_DIR}/policies/${policy_name}-cr.yaml"
-if [ ! -f "${rendered_policy}" ]; then
-	echo >&2 "Could not find policy file: ${rendered_policy}"
-	exit 1
+	"${aperturectl}" blueprints generate --name "${blueprint_name}" --uri "${blueprints_uri}" \
+		--values-file "${_GEN_DIR}/values.yaml" --output-dir "${_GEN_DIR}" --overwrite >&2
+
+	rendered_policy="${_GEN_DIR}/policies/${new_policy_name}-cr.yaml"
+	if [[ "${action}" == "apply" ]]; then
+		"${aperturectl}" apply policy --file "${rendered_policy}" --controller "${endpoint}" --api-key "${api_key}" -f -s >&2
+	else
+		"${aperturectl}" delete policy --policy "${new_policy_name}" --controller "${endpoint}" --api-key "${api_key}" >&2
+	fi
+else
+	"${aperturectl}" blueprints generate --name "${blueprint_name}" --uri "${blueprints_uri}" \
+		--values-file "${values_file}" --output-dir "${_GEN_DIR}" --overwrite >&2
+
+	rendered_policy="${_GEN_DIR}/policies/${policy_name}-cr.yaml"
+	if [ ! -f "${rendered_policy}" ]; then
+		echo >&2 "Could not find policy file: ${rendered_policy}"
+		exit 1
+	fi
+	head -n 1 "${rendered_policy}" | grep -q '^#' && $SED -i '1d' "${rendered_policy}"
+	cat "${rendered_policy}"
 fi
-
-head -n 1 "${rendered_policy}" | grep -q '^#' && $SED -i '1d' "${rendered_policy}"
-cat "${rendered_policy}"

--- a/playground/tanka/apps/aperture-controller/mixins.libsonnet
+++ b/playground/tanka/apps/aperture-controller/mixins.libsonnet
@@ -1,6 +1,10 @@
 local apertureControllerApp = import 'apps/aperture-controller/main.libsonnet';
 
-local extensionEnv = std.extVar('ENABLE_CLOUD_EXTENSION');
+local extensionEnvStr = std.extVar('CLOUD_EXTENSION');
+local extensionEnv = if extensionEnvStr != '' then std.parseYaml(extensionEnvStr) else {};
+local apiKey = if std.objectHas(extensionEnv, 'api_key') then extensionEnv.api_key else '';
+local endpoint = if std.objectHas(extensionEnv, 'endpoint') then extensionEnv.endpoint else '';
+local enabled = if std.objectHas(extensionEnv, 'enabled') then extensionEnv.enabled else false;
 local valuesStr = std.extVar('VALUES');
 local values = if valuesStr != '' then std.parseYaml(valuesStr) else {};
 local controllerValues = if std.objectHas(values, 'controller') then values.controller else {};
@@ -21,7 +25,7 @@ local apertureControllerMixin =
 
         config+: {
           fluxninja+: {
-            endpoint: 'aperture.latest.dev.fluxninja.com' + ':443',
+            endpoint: if enabled then endpoint else '',
             client+: {
               grpc+: {
                 insecure: false,
@@ -50,8 +54,8 @@ local apertureControllerMixin =
         },
         secrets+: {
           fluxNinjaExtension+: {
-            create: extensionEnv,
-            value: '2b97802cf7984791919758a537c05ad0',
+            create: enabled,
+            value: if enabled then apiKey else '',
           },
         },
         image: {

--- a/scripts/precommit/check_tanka_show.sh
+++ b/scripts/precommit/check_tanka_show.sh
@@ -26,7 +26,7 @@ tk tool charts vendor
 exit_code=0
 while read -r app; do
 	env_dir=$(dirname "$app")
-	tk show --ext-str=ENABLE_CLOUD_EXTENSION=false --ext-str=VALUES="" --dangerous-allow-redirect --ext-str=projectRoot="${TOP_LEVEL}"/playground/tanka/ "$env_dir" >/dev/null || {
+	tk show --ext-str=CLOUD_EXTENSION="" --ext-str=VALUES="" --dangerous-allow-redirect --ext-str=projectRoot="${TOP_LEVEL}"/playground/tanka/ "$env_dir" >/dev/null || {
 		exit_code="$?"
 		printf '\n##########\nFAILED SHOWING ENV %s\n##########\n' "${env_dir}" >&2
 	}


### PR DESCRIPTION
Command to use cloud-controller:
```
tilt up -- --cloud-controller
```

##### Checklist

- [x] Tested in playground or other setup
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

**New Feature**: Added support for running the agent with a cloud controller in the playground. This includes:

- Modifications to flag handling and configuration loading.
- Changes to generate, apply, and delete policies based on provided parameters.
- Updates to handle cloud controller configurations such as API key, endpoint, and agent group.

> 🎉 With flags unfurled and settings tweaked,  
> In the playground, new paths we've seeked.  
> The cloud controller now takes the stage,  
> A new chapter begins, turn the page! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->