### PR TITLE
docs: Split Architecture page into Cloud-first and Aperture-only

### DIFF
--- a/.github/styles/Vocab/FluxNinja/accept.txt
+++ b/.github/styles/Vocab/FluxNinja/accept.txt
@@ -88,3 +88,4 @@ reactively
 ALS
 AI
 Elon
+rollup

--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -13,10 +13,10 @@ keywords:
   - fluxninja
   - microservices
   - cloud
-  - TODO
+  # TODO
 ---
 
-The diagram belows shows interaction between main components of
+The diagram below shows interaction between main components of
 [Aperture][]-powered [FluxNinja][] platform: FluxNinja Cloud, Aperture Agents
 and various integrations.
 
@@ -79,6 +79,13 @@ disseminating the calculated adjustments to the Agents, the Controller ensures
 that the Agents take localized actions in line with the global state of the
 system.
 
+:::note
+
+Here the Aperture Controller is shown as part of FluxNinja Cloud Platform, but
+it's also possible to [self-host it][Self-Hosting].
+
+:::
+
 ## Aperture Agents
 
 Aperture Agents are the workhorses of the platform, providing powerful flow
@@ -99,10 +106,10 @@ example, a video streaming service might prioritize a request to play a movie by
 a customer over a recommended movies API. A SaaS product might prioritize
 features used by paid users over those being used by free users.
 
-Aperture Agents can be installed on a variety of infrastructure such as
-Kubernetes, VMs, or bare-metal. In addition to flow control capabilities, Agents
-work with auto-scaling APIs for platforms such as Kubernetes, to help scale
-infrastructure when needed.
+Aperture Agents can be [installed on a variety of
+infrastructure][Install Agents] such as Kubernetes, VMs, or bare-metal. In
+addition to flow control capabilities, Agents work with auto-scaling APIs for
+platforms such as Kubernetes, to help scale infrastructure when needed.
 
 ### Metrics
 
@@ -128,3 +135,5 @@ the exact databases, see [Architecture of Self-Hosted Aperture][].
 [integrations]: /integrations/integrations.md
 [Aperture SDKs]: /integrations/sdk/sdk.md
 [Metrics]: /integrations/metrics/metrics.md
+[Install Agents]: /get-started/installation/agent/agent.md
+[Self-Hosting]: /self-hosting/self-hosting.md

--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -116,8 +116,8 @@ platforms such as Kubernetes, to help scale infrastructure when needed.
 Aperture Agents use metrics to provide input signals to policies in the Aperture
 Controller. These metrics can either be defined based on existing traffic using
 [Flux Meters](/concepts/flux-meter.md) or using [any OpenTelemetry Collector
-receiver][Metrics]. These metrics can then be used in policies using PromQL
-syntax.
+receiver][Metrics]. These metrics can then be used in policies using [PromQL
+syntax][].
 
 :::info
 
@@ -137,3 +137,4 @@ and the exact databases, see [Architecture of Self-Hosted Aperture][].
 [Metrics]: /integrations/metrics/metrics.md
 [Install Agents]: /get-started/installation/agent/agent.md
 [Self-Hosting]: /self-hosting/self-hosting.md
+[PromQL syntax]: https://prometheus.io/docs/prometheus/latest/querying/basics/

--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -35,15 +35,15 @@ metrics and perform limited actions like auto-scaling, they need
 
 Aperture provides [integrations][] for service meshes and gateways. It's also
 possible to instrument your application directly with [Aperture SDKs][]. When
-integration is enabled, it will ask the Agent on local node to make a decisions
-for every request or flow. Note that this RPC call never leaves the node so its
+integration is enabled, it will ask the Agent on local node to make a decision
+for every request or flow. Note that this RPC call never leaves the node, so its
 overhead and impact on latency is minimized.
 
 ## FluxNinja Cloud
 
 FluxNinja Cloud is a centralized platform that provides tools for policy
-management and observability. There are two significants components of FluxNinja
-Cloud worth mentioning: The analycis database and Aperture Controller.
+management and observability. There are two significant components of FluxNinja
+Cloud worth mentioning: The analytics database and Aperture Controller.
 
 ### Analytics database
 

--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -16,8 +16,8 @@ keywords:
   # TODO
 ---
 
-The diagram below shows interaction between main components of
-[Aperture][]-powered [FluxNinja][] platform: FluxNinja Cloud, Aperture Agents
+The diagram below shows the interaction between the main components of
+[Aperture][]-powered [FluxNinja][] platform: FluxNinja Cloud, Aperture Agents,
 and various integrations.
 
 ![FluxNinja Architecture](../assets/img/FluxNinja-arc-dark.svg#gh-dark-mode-only)
@@ -28,30 +28,30 @@ evaluating policies. Policy evaluation is performed by Aperture Controller and
 results in high-level decisions, which are then sent down to Aperture Agents.
 
 Aperture Agents are part of the system that's much closer to the infrastructure
-– they're installed on every node. Agents are where actual execution of policies
-takes place. Note that while Agents by themselves are able to collect some
-metrics and perform limited actions like auto-scaling, they need
+– they're installed on every node. The Agents are where the actual execution of
+policies takes place. Note that while the Agents by themselves are able to
+collect some metrics and perform limited actions like auto-scaling, they need
 [integrations][] to actually control the traffic.
 
 Aperture provides [integrations][] for service meshes and gateways. It's also
 possible to instrument your application directly with [Aperture SDKs][]. When
-integration is enabled, it will ask the Agent on local node to make a decision
-for every request or flow. Note that this RPC call never leaves the node, so its
-overhead and impact on latency is minimized.
+integration is enabled, it will ask the Agent on the local node to make a
+decision for every request or flow. Note that this RPC call never leaves the
+node, so its overhead and impact on latency are minimized.
 
 ## FluxNinja Cloud
 
 FluxNinja Cloud is a centralized platform that provides tools for policy
 management and observability. There are two significant components of FluxNinja
-Cloud worth mentioning: The analytics database and Aperture Controller.
+Cloud worth mentioning: The analytics database and the Aperture Controller.
 
 ### Analytics database
 
 FluxNinja uses a real-time analytics database to support FluxNinja observability
 capabilities. All the logs and traces collected by Aperture Agents are batched
-and rolled up and sent to FluxNinja. Thanks to use of rollup, similar events are
-aggregated to reduce the traffic, but no data is lost (as it would with usage of
-sampling-based solutions).
+and rolled up and sent to FluxNinja. Thanks to the use of rollup, similar events
+are aggregated to reduce the traffic, but no data is lost (as it would with
+usage of sampling-based solutions).
 
 ### Aperture Controller
 
@@ -121,8 +121,8 @@ syntax.
 
 :::info
 
-For more details about interaction between Aperture Controller and Agents and
-the exact databases, see [Architecture of Self-Hosted Aperture][].
+For more details about the interaction between Aperture Controller and Agents
+and the exact databases, see [Architecture of Self-Hosted Aperture][].
 
 :::
 

--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -16,40 +16,61 @@ keywords:
   - TODO
 ---
 
-```mdx-code-block
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import Zoom from 'react-medium-image-zoom';
-```
+The diagram belows shows interaction between main components of
+[Aperture][]-powered [FluxNinja][] platform: FluxNinja Cloud, Aperture Agents
+and various integrations.
 
-Aperture is built on a distributed architecture that provides a unified
-observability and controllability platform for cloud-native applications. The
-architecture is designed to ensure high availability, scalability, and
-reliability.
+![FluxNinja Architecture](../assets/img/FluxNinja-arc-dark.svg#gh-dark-mode-only)
+![FluxNinja Architecture](../assets/img/FluxNinja-arc-light.svg#gh-light-mode-only)
 
-<Zoom>
+FluxNinja Cloud is the brain of the system and its role is collecting data and
+evaluating policies. Policy evaluation is performed by Aperture Controller and
+results in high-level decisions, which are then sent down to Aperture Agents.
 
-```mermaid
-{@include: ../assets/diagrams/architecture/architecture_simple.mmd}
-```
+Aperture Agents are part of the system that's much closer to the infrastructure
+– they're installed on every node. Agents are where actual execution of policies
+takes place. Note that while Agents by themselves are able to collect some
+metrics and perform limited actions like auto-scaling, they need
+[integrations][] to actually control the traffic.
 
-</Zoom>
+Aperture provides [integrations][] for service meshes and gateways. It's also
+possible to instrument your application directly with [Aperture SDKs][]. When
+integration is enabled, it will ask the Agent on local node to make a decisions
+for every request or flow. Note that this RPC call never leaves the node so its
+overhead and impact on latency is minimized.
 
-## Aperture Controller
+## FluxNinja Cloud
+
+FluxNinja Cloud is a centralized platform that provides tools for policy
+management and observability. There are two significants components of FluxNinja
+Cloud worth mentioning: The analycis database and Aperture Controller.
+
+### Analytics database
+
+FluxNinja uses a real-time analytics database to support FluxNinja observability
+capabilities. All the logs and traces collected by Aperture Agents are batched
+and rolled up and sent to FluxNinja. Thanks to use of rollup, similar events are
+aggregated to reduce the traffic, but no data is lost (as it would with usage of
+sampling-based solutions).
+
+### Aperture Controller
+
+FluxNinja Cloud [provides a per-project Aperture
+Controller][FluxNinja Cloud Controller] for every organization.
 
 The Aperture Controller is a centralized control system, equipped with a
-comprehensive global perspective. It is programmed using declarative policies
-that are stored in a policy database that can be managed using the Kubernetes
-Custom Resource Definition (CRD) API, allowing users to configure and modify
-policies as needed.
+comprehensive global perspective. It is programmed using declarative policies.
+Policies can be applied by configuring a [pre-defined blueprint][Use Cases].
+It's also possible to build a policy [from scratch from policy
+components][Policy].
 
 A policy represents a closed-loop control circuit that is executed periodically.
-The control circuit draws input signals from metrics aggregated across Aperture
-Agents, providing the Controller with a holistic view of the application's
-health and performance. Service-level objectives (SLOs) are defined against
-these health and performance signals. The policies continuously track deviations
-from SLOs and calculate recovery or escalation actions that are translated as
-adjustments to the Agents.
+The control circuit draws input signals from [metrics](#metrics) aggregated
+across Aperture Agents, providing the Controller with a holistic view of the
+application's health and performance. Service-level objectives (SLOs) are
+defined against these health and performance signals. The policies continuously
+track deviations from SLOs and calculate recovery or escalation actions that are
+translated as adjustments to the Agents.
 
 After computing the adjustments, the Aperture Controller synchronizes them with
 the relevant Aperture Agents. These adjustments encompass load throttling,
@@ -83,17 +104,27 @@ Kubernetes, VMs, or bare-metal. In addition to flow control capabilities, Agents
 work with auto-scaling APIs for platforms such as Kubernetes, to help scale
 infrastructure when needed.
 
-## Aperture Databases
+### Metrics
 
-Aperture uses two databases to store configuration, telemetry, and flow control
-information: [Prometheus](https://prometheus.io) and [etcd](https://etcd.io).
-Prometheus enables Aperture to monitor the system and detect deviations from the
-service-level objectives (SLOs) defined in the declarative policies. Aperture
-Controller uses etcd (distributed key-value store) to persist the declarative
-policies that define the control circuits and their components, as well as the
-adjustments synchronized between the Controller and Agents.
+Aperture Agents use metrics to provide input signals to policies in the Aperture
+Controller. These metrics can either be defined based on existing traffic using
+[Flux Meters](/concepts/flux-meter.md) or using [any OpenTelemetry Collector
+receiver][Metrics]. These metrics can then be used in policies using PromQL
+syntax.
 
-Users can optionally reuse their existing etcd and
-[scalable Prometheus](https://promlabs.com/blog/2021/10/14/promql-vendor-compatibility-round-three)
-installations to minimize operational overhead and use their existing monitoring
-infrastructure.
+:::info
+
+For more details about interaction between Aperture Controller and Agents and
+the exact databases, see [Architecture of Self-Hosted Aperture][].
+
+:::
+
+[FluxNinja]: /introduction.md
+[Aperture]: https://github.com/fluxninja/aperture
+[FluxNinja Cloud Controller]: /reference/fluxninja.md#cloud-controller
+[Architecture of Self-Hosted Aperture]: /self-hosting/architecture.md
+[Use Cases]: /use-cases/use-cases.md
+[Policy]: /concepts/advanced/policy.md
+[integrations]: /integrations/integrations.md
+[Aperture SDKs]: /integrations/sdk/sdk.md
+[Metrics]: /integrations/metrics/metrics.md

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -86,7 +86,8 @@ existing services.
 ### Can the Aperture Controller run in a non-containerized environment?
 
 No, as for now, we only support deploying [Aperture Controller][] on a
-Kubernetes cluster.
+Kubernetes cluster. Remember that it's also possible to use [FluxNinja Cloud
+Controller] instead of deploying your own.
 
 ### Can the Aperture Agent run in a non-containerized environment?
 
@@ -124,3 +125,4 @@ We have observed the following performance numbers:
 [Classifier]: /concepts/classifier.md
 [Flow Label]: /concepts/flow-label.md
 [Aperture Controller]: /architecture/architecture.md#aperture-controller
+[FluxNinja Cloud Controller]: /reference/fluxninja.md#cloud-controller

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -85,8 +85,8 @@ existing services.
 
 ### Can the Aperture Controller run in a non-containerized environment?
 
-No, as for now, we only support deploying [Aperture
-Controller][Aperture Controller] on a Kubernetes cluster.
+No, as for now, we only support deploying [Aperture Controller][] on a
+Kubernetes cluster.
 
 ### Can the Aperture Agent run in a non-containerized environment?
 
@@ -94,7 +94,7 @@ Yes, the Aperture Agent can be deployed in a non-containerized environment. The
 Aperture Agent is a binary that can be run on the
 [Supported Linux platforms](/get-started/installation/supported-platforms.md).
 The installation steps are available
-[here](/get-started/installation/agent/bare_metal.md).
+[here](/get-started/installation/agent/bare-metal.md).
 
 ### What are Aperture Agent's performance numbers?
 
@@ -123,4 +123,4 @@ We have observed the following performance numbers:
 [Flux Meter]: /concepts/flux-meter.md
 [Classifier]: /concepts/classifier.md
 [Flow Label]: /concepts/flow-label.md
-[Aperture Controller]: /self-hosting/controller/controller.md
+[Aperture Controller]: /architecture/architecture.md#aperture-controller

--- a/docs/content/get-started/installation/agent/agent.md
+++ b/docs/content/get-started/installation/agent/agent.md
@@ -63,7 +63,7 @@ and can result in unpredictable behavior.
       The Aperture Agent can also be installed with only namespace-scoped
       resources.
 
-2. [**Bare Metal or VM**](bare_metal.md)
+2. [**Bare Metal or VM**](bare-metal.md)
 
    The Aperture Agent can be installed as a system service on any Linux system
    that is [supported](../supported-platforms.md).

--- a/docs/content/get-started/installation/agent/bare-metal.md
+++ b/docs/content/get-started/installation/agent/bare-metal.md
@@ -20,7 +20,7 @@ import {apertureVersion, apertureVersionWithOutV} from '../../../apertureVersion
 ```
 
 The Aperture Agent can be installed as a system service on any Linux system that
-is [supported](../supported-platforms.md)).
+is [supported](../supported-platforms.md).
 
 ## Download {#agent-download}
 

--- a/docs/content/get-started/installation/aperture-cli/aperture-cli.md
+++ b/docs/content/get-started/installation/aperture-cli/aperture-cli.md
@@ -11,7 +11,7 @@ import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {apertureVersion, apertureVersionWithOutV} from '../../../apertureVersion.js';
-import {DownloadScript} from '../../installation/agent/bare_metal.md';
+import {DownloadScript} from '../../installation/agent/bare-metal.md';
 ```
 
 ```mdx-code-block

--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -8,6 +8,8 @@ keywords:
   - cloud
   - enterprise
   - platform
+  - fluxninja
+  - aperture
 ---
 
 [FluxNinja][] is a load management platform powered by the open source project
@@ -22,6 +24,9 @@ Aperture can seamlessly integrate with existing control points such as gateways,
 service meshes, and application middlewares. Moreover, it offers SDKs for
 developers who need to establish control points around specific features or code
 sections inside applications.
+
+Here's a simplified diagram how FluxNinja Cloud interacts with your
+infrastructure. Visit [Architecture][] page for more details.
 
 ![FluxNinja Architecture](./assets/img/FluxNinja-arc-dark.svg#gh-dark-mode-only)
 ![FluxNinja Architecture](./assets/img/FluxNinja-arc-light.svg#gh-light-mode-only)
@@ -139,3 +144,4 @@ beneficial.
 
 [fluxninja]: https://www.fluxninja.com/product
 [sign-up]: https://app.fluxninja.com/sign-up
+[Architecture]: /architecture/architecture.md

--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -114,4 +114,4 @@ How various components interact with the extension:
 
 [Self-Hosting]: /self-hosting/self-hosting.md
 [FluxNinja Cloud]: /introduction.md
-[Aperture Controller]: /self-hosting/controller/controller.md
+[Aperture Controller]: /architecture/architecture.md#aperture-controller

--- a/docs/content/self-hosting/agent.md
+++ b/docs/content/self-hosting/agent.md
@@ -1,5 +1,6 @@
 ---
 title: Agent Configuration
+sidebar_position: 3
 ---
 
 ```mdx-code-block

--- a/docs/content/self-hosting/architecture.md
+++ b/docs/content/self-hosting/architecture.md
@@ -1,0 +1,54 @@
+---
+title: Architecture of Self-Hosted Aperture
+sidebar_label: Architecture
+sidebar_position: 0
+keywords:
+  - aperture
+  - controller
+  - self-hosted
+  - open-source
+---
+
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Zoom from 'react-medium-image-zoom';
+```
+
+Architecture of the self-hosted Aperture solution differs slightly from the
+regular [FluxNinja Cloud + Aperture combination](/architecture/architecture.md).
+The main difference is that the Aperture Controller is no longer part of
+FluxNinja Cloud and is deployed separately. Aperture Controller also needs its
+supporting databases.
+
+Aperture uses two databases to store configuration, telemetry, and flow control
+information: [Prometheus][] and [etcd][]. Prometheus enables Aperture to monitor
+the system and detect deviations from the service-level objectives (SLOs)
+defined in the declarative policies. Aperture Controller uses etcd (distributed
+key-value store) to persist the declarative policies that define the control
+circuits and their components, as well as the adjustments synchronized between
+the Controller and Agents.
+
+Existing etcd and
+[scalable Prometheus](https://promlabs.com/blog/2021/10/14/promql-vendor-compatibility-round-three)
+installations can be reused to minimize operational overhead and to integrate
+into existing monitoring infrastructure.
+
+<Zoom>
+
+```mermaid
+{@include: ../assets/diagrams/architecture/architecture_simple.mmd}
+```
+
+:::info
+
+The roles of Aperture Agent and Aperture Controller are described on the
+[Architecture][] page.
+
+:::
+
+</Zoom>
+
+[Architecture]: /architecture/architecture.md
+[Prometheus]: https://prometheus.io
+[etcd]: https://etcd.io

--- a/docs/content/self-hosting/controller/controller.md
+++ b/docs/content/self-hosting/controller/controller.md
@@ -1,5 +1,5 @@
 ---
-title: Aperture Controller
+title: Self-Hosted Aperture Controller
 description: Install Aperture Controller
 keywords:
   - install

--- a/docs/content/self-hosting/k8s-objects.md
+++ b/docs/content/self-hosting/k8s-objects.md
@@ -1,0 +1,27 @@
+---
+title: Managing Policies Using Kubernetes Objects
+sidebar_position: 4
+sidebar_label: Kubernetes Objects
+keywords:
+  - kubectl
+  - k8s
+  - crd
+  - resource
+  - custom
+  - apply
+---
+
+With the self-hosted controller deployed on Kubernetes, you gain the possibility
+to manage policies using Kubernetes Objects (in addition to usual way via
+`aperturectl`). Aperture Controller installation includes the Policy Custom
+Resource Definition.
+
+Such Policy objects can be prepared from blueprints via
+[`aperturectl blueprints generate`][generate] command ([Generating Policies and
+Dashboards][] contains an example how to run this command). [Take a look here,
+how a Policy object could look like][Example] (look for "Generated Policy").
+
+[generate]: /reference/aperturectl/blueprints/generate/generate.md
+[Generating Policies and Dashboards]:
+  /get-started/policies/policies.md#generating-policies-and-dashboards
+[Example]: /use-cases/adaptive-service-protection/average-latency-feedback.md

--- a/docs/content/self-hosting/k8s-objects.md
+++ b/docs/content/self-hosting/k8s-objects.md
@@ -12,17 +12,20 @@ keywords:
 ---
 
 With the self-hosted controller deployed on Kubernetes, you gain the possibility
-to manage policies using Kubernetes Objects (in addition to usual way via
+to manage policies using Kubernetes Objects (in addition to the usual way via
 `aperturectl`). Aperture Controller installation includes the Policy Custom
 Resource Definition.
 
-Policy objects can be created by hand or prepared from blueprints via
+Policy objects can be created manually or prepared from blueprints via
 [`aperturectl blueprints generate`][generate] command ([Generating Policies and
 Dashboards][] contains an example how to run this command). [Take a look here,
 how a Policy object could look like][Example] (look for "Generated Policy").
 Such a Policy can be then applied with regular `kubectl apply`.
 
+<!-- prettier-ignore-start -->
+
 [generate]: /reference/aperturectl/blueprints/generate/generate.md
-[Generating Policies and Dashboards]:
-  /get-started/policies/policies.md#generating-policies-and-dashboards
+[Generating Policies and Dashboards]: /get-started/policies/policies.md#generating-policies-and-dashboards
 [Example]: /use-cases/adaptive-service-protection/average-latency-feedback.md
+
+<!-- prettier-ignore-end -->

--- a/docs/content/self-hosting/k8s-objects.md
+++ b/docs/content/self-hosting/k8s-objects.md
@@ -16,10 +16,11 @@ to manage policies using Kubernetes Objects (in addition to usual way via
 `aperturectl`). Aperture Controller installation includes the Policy Custom
 Resource Definition.
 
-Such Policy objects can be prepared from blueprints via
+Policy objects can be created by hand or prepared from blueprints via
 [`aperturectl blueprints generate`][generate] command ([Generating Policies and
 Dashboards][] contains an example how to run this command). [Take a look here,
 how a Policy object could look like][Example] (look for "Generated Policy").
+Such a Policy can be then applied with regular `kubectl apply`.
 
 [generate]: /reference/aperturectl/blueprints/generate/generate.md
 [Generating Policies and Dashboards]:


### PR DESCRIPTION
* Added mention of FluxNinja Cloud on Architecture page.
* Used new simplified architecture diagram on Architecture page (the same as in Introduction).
* Added some "TLDR" introduction at the beginning of Architecture page.
* Moved old diagram to a new Self-Hosting/Architecture page, which explains differences between FluxNinja Cloud Controller-based and self-hosted Controller setups.
* Moved Aperture Databases out of Architecture page to Self-Hosting/Architecture.
* Removed mentions about managing policies using CRDs from Architecture page and moved them to a new page under Self-Hosting.
* Added some details about metrics on Architecture page.
* Added one-sentence introduction to the simplified architecture diagram in Introduction, so it has some context.
* Fixed some links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### Documentation:
- Added a new page "Managing Policies Using Kubernetes Objects" for managing policies using Kubernetes objects when the self-hosted controller is deployed on Kubernetes.
- Updated the Architecture page with a simplified diagram, TLDR introduction, and details about FluxNinja Cloud and metrics.
- Moved old diagrams and information about self-hosting to a new Self-Hosting/Architecture page.
- Changed the title of a page from "Aperture Controller" to "Self-Hosted Aperture Controller".

> 🎉 Here's to the docs that guide our way,  
> To the updates we've made today.  
> With FluxNinja Cloud in sight,  
> And architecture shining bright.  
> Metrics explained, diagrams new,  
> For users, a clearer view. 🎉
<!-- end of auto-generated comment: release notes by coderabbit.ai -->