### PR TITLE
docs: Document .aperturectl/config better

### DIFF
--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -36,12 +36,14 @@ var controllerNs string
 
 // ControllerConfig is the config file structure for FluxNinja Cloud Controller.
 type ControllerConfig struct {
+	// When changing fields, remember to update docs/content/reference/configuration/aperturectl.md.
 	URL    string `toml:"url"`
 	APIKey string `toml:"api_key"`
 }
 
 // Config is the config file structure for Aperture.
 type Config struct {
+	// When changing fields, remember to update docs/content/reference/configuration/aperturectl.md.
 	Controller *ControllerConfig `toml:"controller"`
 }
 
@@ -111,7 +113,7 @@ func (c *ControllerConn) InitFlags(flags *flag.FlagSet) {
 		&c.config,
 		"config",
 		"",
-		"Path to the Aperture config file",
+		"Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG",
 	)
 }
 

--- a/docs/content/get-started/installation/configure-cli.md
+++ b/docs/content/get-started/installation/configure-cli.md
@@ -14,10 +14,12 @@ url = "ORGANIZATION_NAME.app.fluxninja.com:443"
 api_key = "API_KEY"
 ```
 
-:::tip
+Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja organization
+name and api key created for your project.
 
-You can create multiple configuration files and use `APERTURE_CONFIG`
-environment variable to switch between them.
+:::info
+
+See also [aperturectl configuration file format reference][].
 
 :::
 
@@ -26,9 +28,12 @@ environment variable to switch between them.
 With a [Self-Hosted][self-hosted] Aperture Controller, if the Controller is at
 the cluster pointed at by `~/.kube/config` or `KUBECONFIG`, no configuration
 file nor flags are needed at all. Otherwise, you need the `--controller` flag.
-See [aperturectl][] reference for details.
 
 :::
 
+<!-- prettier-ignore-start -->
+
 [self-hosted]: /self-hosting/self-hosting.md
-[aperturectl]: /reference/aperturectl/aperturectl.md
+[aperturectl configuration file format reference]: /reference/configuration/aperturectl.md
+
+<!-- prettier-ignore-end -->

--- a/docs/content/reference/aperturectl/agents/agents.md
+++ b/docs/content/reference/aperturectl/agents/agents.md
@@ -24,7 +24,7 @@ aperturectl agents [flags]
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for agents

--- a/docs/content/reference/aperturectl/aperturectl.md
+++ b/docs/content/reference/aperturectl/aperturectl.md
@@ -12,6 +12,12 @@ keywords:
 
 For installation instructions, see [installing aperturectl](/get-started/installation/aperture-cli/aperture-cli.md).
 
+:::
+
+:::info
+
+See also [aperturectl configuration file format reference](/reference/configuration/aperturectl.md).
+
 :::## aperturectl
 
 aperturectl - CLI tool to interact with Aperture

--- a/docs/content/reference/aperturectl/apply/apply.md
+++ b/docs/content/reference/aperturectl/apply/apply.md
@@ -20,7 +20,7 @@ Use this command to apply the Aperture Policies.
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for apply

--- a/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
+++ b/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
@@ -38,7 +38,7 @@ aperturectl apply dynamic-config --policy=rate-limiting --file=dynamic-config.ya
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/apply/policy/policy.md
+++ b/docs/content/reference/aperturectl/apply/policy/policy.md
@@ -42,7 +42,7 @@ aperturectl apply policy --dir=policies
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/auto-scale/auto-scale.md
+++ b/docs/content/reference/aperturectl/auto-scale/auto-scale.md
@@ -20,7 +20,7 @@ Use this command to query information about active AutoScale integrations
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for auto-scale

--- a/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
@@ -36,7 +36,7 @@ aperturectl auto-scale control-points
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/blueprints/generate/generate.md
+++ b/docs/content/reference/aperturectl/blueprints/generate/generate.md
@@ -33,7 +33,7 @@ aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-lim
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
       --apply                  Apply generated policies on the Kubernetes cluster in the namespace where Aperture Controller is installed
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -f, --force                  Force apply policy even if it already exists

--- a/docs/content/reference/aperturectl/decisions/decisions.md
+++ b/docs/content/reference/aperturectl/decisions/decisions.md
@@ -33,7 +33,7 @@ aperturectl decisions [flags]
 ```
       --all                    Get all decisions
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --decision-type string   Type of the decision to get (load_scheduler, rate_limiter, quota_scheduler, pod_scaler, sampler)

--- a/docs/content/reference/aperturectl/delete/delete.md
+++ b/docs/content/reference/aperturectl/delete/delete.md
@@ -20,7 +20,7 @@ Use this command to delete the Aperture Policies.
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for delete

--- a/docs/content/reference/aperturectl/delete/policy/policy.md
+++ b/docs/content/reference/aperturectl/delete/policy/policy.md
@@ -36,7 +36,7 @@ aperturectl delete policy --policy=rate-limiting
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/discovery/discovery.md
+++ b/docs/content/reference/aperturectl/discovery/discovery.md
@@ -20,7 +20,7 @@ Use this command to query information about active Discovery integrations
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for discovery

--- a/docs/content/reference/aperturectl/discovery/entities/entities.md
+++ b/docs/content/reference/aperturectl/discovery/entities/entities.md
@@ -41,7 +41,7 @@ aperturectl discovery entities --find-by=“ip=10.244.1.24”
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
@@ -36,7 +36,7 @@ aperturectl flow-control control-points
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/flow-control/flow-control.md
+++ b/docs/content/reference/aperturectl/flow-control/flow-control.md
@@ -20,7 +20,7 @@ Use this command to query information about active Flow Control integrations
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for flow-control

--- a/docs/content/reference/aperturectl/flow-control/preview/preview.md
+++ b/docs/content/reference/aperturectl/flow-control/preview/preview.md
@@ -33,7 +33,7 @@ aperturectl flow-control preview [--http] SERVICE CONTROL_POINT [flags]
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
       --insecure               Allow connection to controller running without TLS

--- a/docs/content/reference/aperturectl/policies/policies.md
+++ b/docs/content/reference/aperturectl/policies/policies.md
@@ -24,7 +24,7 @@ aperturectl policies [flags]
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for policies

--- a/docs/content/reference/aperturectl/status/status.md
+++ b/docs/content/reference/aperturectl/status/status.md
@@ -32,7 +32,7 @@ aperturectl status [flags]
 
 ```
       --api-key string         FluxNinja API Key to be used when using Cloud Controller
-      --config string          Path to the Aperture config file
+      --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running
   -h, --help                   help for status

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -1,7 +1,7 @@
 ---
 title: aperturectl Configuration File Format Reference
 sidebar_position: 5
-sidebar_label: .aperturectl/config
+sidebar_label: ".aperturectl/config"
 ---
 
 <!-- If our config grows, would be nice to automatically generate it from

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -1,0 +1,48 @@
+---
+title: aperturectl Configuration File Format Reference
+sidebar_position: 5
+sidebar_label: .aperturectl/config
+---
+
+<!-- If our config grows, would be nice to automatically generate it from
+corresponding go structs from cmd/aperturectl/cmd/utils/controller.go -->
+
+## Location
+
+To avoid specifying `--controller` and `--api-key` in every `aperturectl` invocation,
+aperturectl can use a configuration file located in `~/.aperturectl/config`.
+
+Location of this file can be overridden by `APERTURE_CONFIG` environment
+variable and `--config` option (with the commandline option having higher
+precedence).
+
+Config file is ignored when any explicit flag related to controller
+location (such as `--kube`, `--controller` or `--api-key`) is passed.
+
+If the config file is not specified nor present at the default location,
+aperturectl will try to find the controller at the local kubernetes cluster (as
+if `--kube` flag was passed).
+
+## Format
+
+The aperturectl configuration file uses following [TOML][] syntax:
+
+```toml
+[controller]
+url = "controller hostname:port"
+api_key = "api key for the controller"
+```
+
+All the fields are required. See [Configuring aperturectl][] for an example
+how to configure aperturectl with [FluxNinja Cloud Controller][].
+
+:::tip
+
+You can create multiple configuration files and use `APERTURE_CONFIG`
+environment variable to switch between different projects and organizations.
+
+:::
+
+[TOML]: https://toml.io/
+[Configuring aperturectl]: /get-started/installation/configure-cli.md
+[FluxNinja Cloud Controller]: /reference/fluxninja.md#cloud-controller

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -20,7 +20,7 @@ When any explicit flag related to controller location (e.g., --kube,
 --controller, or --api-key) is used, the _entire_ configuration file is
 ignored.
 
-If the config file is not specified nor present at the default location,
+If the configuration file is not specified nor present at the default location,
 aperturectl will try to find the controller at the local Kubernetes cluster (as
 if the `--kube` flag were passed).
 

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -1,7 +1,9 @@
 ---
+# <!-- vale off -->
 title: aperturectl Configuration File Format Reference
 sidebar_position: 5
 sidebar_label: ".aperturectl/config"
+# <!-- vale on -->
 ---
 
 <!-- If our config grows, would be nice to automatically generate it from

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -1,13 +1,11 @@
 ---
-# <!-- vale off -->
 title: aperturectl Configuration File Format Reference
 sidebar_position: 5
 sidebar_label: ".aperturectl/config"
-# <!-- vale on -->
 ---
 
-<!-- If our config grows, would be nice to automatically generate it from
-corresponding go structs from cmd/aperturectl/cmd/utils/controller.go -->
+<!-- If our configuration file grows, would be nice to automatically generate
+it from corresponding go structs from cmd/aperturectl/cmd/utils/controller.go -->
 
 ## Location
 

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -13,19 +13,20 @@ To avoid specifying `--controller` and `--api-key` in every `aperturectl` invoca
 aperturectl can use a configuration file located in `~/.aperturectl/config`.
 
 Location of this file can be overridden by `APERTURE_CONFIG` environment
-variable and `--config` option (with the commandline option having higher
+variable and `--config` option (with the command-line option having higher
 precedence).
 
-Config file is ignored when any explicit flag related to controller
-location (such as `--kube`, `--controller` or `--api-key`) is passed.
+When any explicit flag related to controller location (e.g., --kube,
+--controller, or --api-key) is used, the _entire_ configuration file is
+ignored.
 
 If the config file is not specified nor present at the default location,
-aperturectl will try to find the controller at the local kubernetes cluster (as
-if `--kube` flag was passed).
+aperturectl will try to find the controller at the local Kubernetes cluster (as
+if the `--kube` flag were passed).
 
 ## Format
 
-The aperturectl configuration file uses following [TOML][] syntax:
+The aperturectl configuration file uses the following [TOML][] syntax:
 
 ```toml
 [controller]
@@ -33,8 +34,9 @@ url = "controller hostname:port"
 api_key = "api key for the controller"
 ```
 
-All the fields are required. See [Configuring aperturectl][] for an example
-how to configure aperturectl with [FluxNinja Cloud Controller][].
+All the fields are required (although the file itself is not). See [Configuring
+aperturectl][] for an example on how to configure aperturectl with [FluxNinja
+Cloud Controller][].
 
 :::tip
 

--- a/docs/tools/aperturectl/generate-docs/generate-docs.go
+++ b/docs/tools/aperturectl/generate-docs/generate-docs.go
@@ -124,6 +124,12 @@ keywords:
 
 For installation instructions, see [installing aperturectl](/get-started/installation/aperture-cli/aperture-cli.md).
 
+:::
+
+:::info
+
+See also [aperturectl configuration file format reference](/reference/configuration/aperturectl.md).
+
 :::`
 	}
 


### PR DESCRIPTION
Resolves: #2420 

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### Documentation:
- Updated the `--config` flag across various commands in `aperturectl` to include a default value of `'~/.aperturectl/config'` or `$APERTURE_CONFIG`.
- Added comprehensive documentation for the `.aperturectl/config` configuration file, including its location, format, usage, and an example in TOML syntax.

> 🎉 Here's to the code that's ever so bright,
> With docs updated, it's now light as light.
> No more confusion, no more fright,
> For the `--config` flag is set just right! 🥳

<!-- end of auto-generated comment: release notes by coderabbit.ai -->