### PR TITLE
docs: Rename FluxNinja to FluxNinja Cloud

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -627,8 +627,8 @@ message Rule {
   // :::caution
   //
   // When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-  // labels are sent to FluxNinja for observability. Telemetry should be disabled for
-  // sensitive labels.
+  // labels are sent to FluxNinja Cloud for observability. Telemetry should be
+  // disabled for sensitive labels.
   //
   // :::
   bool telemetry = 3; // @gotags: default:"true"
@@ -674,8 +674,8 @@ message Rego {
     // :::caution
     //
     // When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-    // labels are sent to FluxNinja for observability. Telemetry should be disabled for
-    // sensitive labels.
+    // labels are sent to FluxNinja Cloud for observability. Telemetry should
+    // be disabled for sensitive labels.
     //
     // :::
     bool telemetry = 1; // @gotags: default:"true"

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -1169,8 +1169,8 @@ type Rule struct {
 	// :::caution
 	//
 	// When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-	// labels are sent to FluxNinja for observability. Telemetry should be disabled for
-	// sensitive labels.
+	// labels are sent to FluxNinja Cloud for observability. Telemetry should be
+	// disabled for sensitive labels.
 	//
 	// :::
 	Telemetry bool `protobuf:"varint,3,opt,name=telemetry,proto3" json:"telemetry,omitempty" default:"true"` // @gotags: default:"true"
@@ -3312,8 +3312,8 @@ type Rego_LabelProperties struct {
 	// :::caution
 	//
 	// When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-	// labels are sent to FluxNinja for observability. Telemetry should be disabled for
-	// sensitive labels.
+	// labels are sent to FluxNinja Cloud for observability. Telemetry should
+	// be disabled for sensitive labels.
 	//
 	// :::
 	Telemetry bool `protobuf:"varint,1,opt,name=telemetry,proto3" json:"telemetry,omitempty" default:"true"` // @gotags: default:"true"

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -2533,7 +2533,7 @@
       "properties": {
         "telemetry": {
           "default": true,
-          "description": ":::note\n\nThe flow label is always accessible in Aperture Policies regardless of this setting.\n\n:::\n\n:::caution\n\nWhen using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled\nlabels are sent to FluxNinja for observability. Telemetry should be disabled for\nsensitive labels.\n\n:::\n\n",
+          "description": ":::note\n\nThe flow label is always accessible in Aperture Policies regardless of this setting.\n\n:::\n\n:::caution\n\nWhen using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled\nlabels are sent to FluxNinja Cloud for observability. Telemetry should\nbe disabled for sensitive labels.\n\n:::\n\n",
           "title": "Decides if the created flow label should be available as an attribute in OLAP telemetry and\npropagated in [baggage](/concepts/flow-label.md#baggage)",
           "type": "boolean",
           "x-go-tag-default": "true"
@@ -2578,7 +2578,7 @@
         },
         "telemetry": {
           "default": true,
-          "description": ":::note\n\nThe flow label is always accessible in Aperture Policies regardless of this setting.\n\n:::\n\n:::caution\n\nWhen using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled\nlabels are sent to FluxNinja for observability. Telemetry should be disabled for\nsensitive labels.\n\n:::\n\n",
+          "description": ":::note\n\nThe flow label is always accessible in Aperture Policies regardless of this setting.\n\n:::\n\n:::caution\n\nWhen using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled\nlabels are sent to FluxNinja Cloud for observability. Telemetry should be\ndisabled for sensitive labels.\n\n:::\n\n",
           "title": "Decides if the created flow label should be available as an attribute in OLAP telemetry and\npropagated in [baggage](/concepts/flow-label.md#baggage)",
           "type": "boolean",
           "x-go-tag-default": "true"

--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -107,7 +107,7 @@ func (c *ControllerConn) InitFlags(flags *flag.FlagSet) {
 		&c.apiKey,
 		"api-key",
 		"",
-		"FluxNinja API Key to be used when using Cloud Controller",
+		"FluxNinja Cloud API Key to be used when using Cloud Controller",
 	)
 	flags.StringVar(
 		&c.config,

--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -51,11 +51,11 @@ Cloud worth mentioning: The analytics database and the Aperture Controller.
 
 ### Analytics database
 
-FluxNinja uses a real-time analytics database to support FluxNinja observability
-capabilities. All the logs and traces collected by Aperture Agents are batched
-and rolled up and sent to FluxNinja. Thanks to the use of rollup, similar events
-are aggregated to reduce the traffic, but no data is lost (as it would with
-usage of sampling-based solutions).
+FluxNinja uses a real-time analytics database to support FluxNinja Cloud
+observability capabilities. All the logs and traces collected by Aperture Agents
+are batched and rolled up and sent to FluxNinja. Thanks to the use of rollup,
+similar events are aggregated to reduce the traffic, but no data is lost (as it
+would with usage of sampling-based solutions).
 
 ### Aperture Controller
 

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2728,8 +2728,8 @@ definitions:
                     :::caution
 
                     When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-                    labels are sent to FluxNinja for observability. Telemetry should be disabled for
-                    sensitive labels.
+                    labels are sent to FluxNinja Cloud for observability. Telemetry should
+                    be disabled for sensitive labels.
 
                     :::
 
@@ -2823,8 +2823,8 @@ definitions:
                     :::caution
 
                     When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-                    labels are sent to FluxNinja for observability. Telemetry should be disabled for
-                    sensitive labels.
+                    labels are sent to FluxNinja Cloud for observability. Telemetry should be
+                    disabled for sensitive labels.
 
                     :::
 

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -3301,8 +3301,8 @@ definitions:
                     :::caution
 
                     When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-                    labels are sent to FluxNinja for observability. Telemetry should be disabled for
-                    sensitive labels.
+                    labels are sent to FluxNinja Cloud for observability. Telemetry should
+                    be disabled for sensitive labels.
 
                     :::
 
@@ -3457,8 +3457,8 @@ definitions:
                     :::caution
 
                     When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-                    labels are sent to FluxNinja for observability. Telemetry should be disabled for
-                    sensitive labels.
+                    labels are sent to FluxNinja Cloud for observability. Telemetry should be
+                    disabled for sensitive labels.
 
                     :::
 

--- a/docs/content/concepts/flow-label.md
+++ b/docs/content/concepts/flow-label.md
@@ -203,7 +203,7 @@ order:
 ## Interaction with FluxNinja Extension {#extension}
 
 All the flow Labels are used as labels of flow events. These events are rolled
-up and sent to the analytics database in the FluxNinja. This allows:
+up and sent to the analytics database in the FluxNinja Cloud. This allows:
 
 - For the _Flow Labels_ to be used as filters or group-by
 - To see analytics for each _Flow Label_, for example: distribution of its

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -3,7 +3,8 @@ title: FAQ
 slug: faq
 sidebar_label: FAQ
 sidebar_position: 9
-description: Frequently asked questions about FluxNinja Aperture.
+description:
+  Frequently asked questions about FluxNinja Aperture and FluxNinja Cloud.
 image: /assets/img/aperture_logo.png
 keywords:
   - reliability

--- a/docs/content/get-started/installation/agent/docker.md
+++ b/docs/content/get-started/installation/agent/docker.md
@@ -45,7 +45,7 @@ Below are the instructions to install the Aperture Agent on Docker.
        enabled: false
    ```
 
-   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja
+   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja Cloud
    organization name and api key created for your project.
 
    :::note

--- a/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
@@ -74,7 +74,7 @@ your cluster.
          value: API_KEY
    ```
 
-   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja
+   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja Cloud
    organization name and api key created for your project.
 
    :::note

--- a/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
@@ -94,7 +94,7 @@ Kubernetes Objects which will be created by following steps are listed
          value: API_KEY
    ```
 
-   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja
+   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja Cloud
    organization name and api key created for your project.
 
    :::note
@@ -220,7 +220,7 @@ Kubernetes Objects which will be created by following steps are listed
             value: API_KEY
       ```
 
-      Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja
+      Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja Cloud
       organization name and api key created for your project.
 
       :::note

--- a/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
@@ -116,7 +116,7 @@ Kubernetes Objects which will be created by following steps are listed
          value: API_KEY
    ```
 
-   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja
+   Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja Cloud
    organization name and api key created for your project.
 
    :::note
@@ -286,7 +286,7 @@ Kubernetes Objects which will be created by following steps are listed
             value: API_KEY
       ```
 
-      Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja
+      Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja Cloud
       organization name and api key created for your project.
 
       :::note

--- a/docs/content/get-started/installation/configure-cli.md
+++ b/docs/content/get-started/installation/configure-cli.md
@@ -5,8 +5,8 @@ keywords:
 sidebar_position: 2
 ---
 
-Configure aperturectl to point to your FluxNinja endpoint: Save the following as
-`~/.aperturectl/config`:
+Configure aperturectl to point to your FluxNinja Cloud endpoint: Save the
+following as `~/.aperturectl/config`:
 
 ```toml
 [controller]
@@ -14,8 +14,8 @@ url = "ORGANIZATION_NAME.app.fluxninja.com:443"
 api_key = "API_KEY"
 ```
 
-Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja organization
-name and api key created for your project.
+Replace the `ORGANIZATION_NAME` and `API_KEY` with your FluxNinja Cloud
+organization name and api key created for your project.
 
 :::info
 

--- a/docs/content/get-started/installation/installation.md
+++ b/docs/content/get-started/installation/installation.md
@@ -6,15 +6,15 @@ sidebar_position: 2
 sidebar_label: Install Aperture
 ---
 
-To deploy Aperture with FluxNinja, it's enough to install Aperture Agents.
+To deploy Aperture with FluxNinja Cloud, it's enough to install Aperture Agents.
 
 We also recommend installing aperturectl CLI. It can help with installation of
 Agents, and also will be needed to manage the policies.
 
 :::note
 
-If _not_ using FluxNinja, a [Self-Hosted][Self-Hosting] Aperture Controller also
-needs to be installed.
+If _not_ using FluxNinja Cloud, a [Self-Hosted][Self-Hosting] Aperture
+Controller also needs to be installed.
 
 :::
 

--- a/docs/content/get-started/policies/policies.md
+++ b/docs/content/get-started/policies/policies.md
@@ -194,10 +194,11 @@ kubectl get policies.fluxninja.com -n aperture-controller
 </Tabs>
 ```
 
-The policy runtime can be visualized in [FluxNinja][], Grafana or any other
-Prometheus compatible analytics tool. Refer to the Prometheus compatible metrics
-available from the [controller][controller-metrics] and [agent][agent-metrics].
-Some policy [blueprints][blueprints] come with recommended Grafana dashboards.
+The policy runtime can be visualized in [FluxNinja Cloud][], Grafana or any
+other Prometheus compatible analytics tool. Refer to the Prometheus compatible
+metrics available from the [controller][controller-metrics] and
+[agent][agent-metrics]. Some policy [blueprints][blueprints] come with
+recommended Grafana dashboards.
 
 ## Deleting Policies
 
@@ -232,4 +233,4 @@ kubectl delete policies.fluxninja.com rate-limiting -n aperture-controller
 [policies]: /concepts/advanced/policy.md
 [grafana]: https://grafana.com/docs/grafana/latest/dashboards/
 [self-hosted]: /self-hosting/self-hosting.md
-[FluxNinja]: /introduction.md
+[FluxNinja Cloud]: /introduction.md

--- a/docs/content/integrations/auto-scale/kubernetes/kubernetes.md
+++ b/docs/content/integrations/auto-scale/kubernetes/kubernetes.md
@@ -22,10 +22,10 @@ Once the Aperture Agent is installed, it starts discovering control points,
 which represent the Kubernetes Resources that can be scaled. This would include
 Deployments, StatefulSets and any Custom Resources which are scalable.
 
-The discovered control points can be viewed in the [FluxNinja](/introduction.md)
-UI. Navigate to the **Control Points** page and select the **Kubernetes** tab.
-You should see a list of discovered control points. Alternatively, you can use
-the
+The discovered control points can be viewed in the
+[FluxNinja Cloud](/introduction.md) UI. Navigate to the **Control Points** page
+and select the **Kubernetes** tab. You should see a list of discovered control
+points. Alternatively, you can use the
 [introspection API](/reference/api/agent/auto-scale-kubernetes-control-points-service-get-control-points.api.mdx)
 or
 [aperturectl](/reference/aperturectl/auto-scale/control-points/control-points.md)

--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -16,8 +16,8 @@ keywords:
 import Zoom from 'react-medium-image-zoom';
 ```
 
-[FluxNinja][] is a load management platform powered by the open source project
-[**Aperture**](https://github.com/fluxninja/aperture). It's designed for
+[FluxNinja Cloud][] is a load management platform powered by the open source
+project [**Aperture**](https://github.com/fluxninja/aperture). It's designed for
 classifying, scheduling, and rate-limiting API traffic in cloud applications.
 Built upon a foundation of observability and a global control plane, it offers a
 comprehensive suite of load management capabilities. These capabilities enhance
@@ -146,6 +146,6 @@ beneficial.
 
 <!-- vale on -->
 
-[fluxninja]: https://www.fluxninja.com/product
+[FluxNinja Cloud]: https://www.fluxninja.com/product
 [sign-up]: https://app.fluxninja.com/sign-up
 [Architecture]: /architecture/architecture.md

--- a/docs/content/reference/aperturectl/agents/agents.md
+++ b/docs/content/reference/aperturectl/agents/agents.md
@@ -23,7 +23,7 @@ aperturectl agents [flags]
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/apply/apply.md
+++ b/docs/content/reference/aperturectl/apply/apply.md
@@ -19,7 +19,7 @@ Use this command to apply the Aperture Policies.
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
+++ b/docs/content/reference/aperturectl/apply/dynamic-config/dynamic-config.md
@@ -37,7 +37,7 @@ aperturectl apply dynamic-config --policy=rate-limiting --file=dynamic-config.ya
 ### Options inherited from parent commands
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/apply/policy/policy.md
+++ b/docs/content/reference/aperturectl/apply/policy/policy.md
@@ -41,7 +41,7 @@ aperturectl apply policy --dir=policies
 ### Options inherited from parent commands
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/auto-scale/auto-scale.md
+++ b/docs/content/reference/aperturectl/auto-scale/auto-scale.md
@@ -19,7 +19,7 @@ Use this command to query information about active AutoScale integrations
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/auto-scale/control-points/control-points.md
@@ -35,7 +35,7 @@ aperturectl auto-scale control-points
 ### Options inherited from parent commands
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/blueprints/generate/generate.md
+++ b/docs/content/reference/aperturectl/blueprints/generate/generate.md
@@ -31,7 +31,7 @@ aperturectl blueprints generate --name=rate-limiting/base --values-file=rate-lim
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --apply                  Apply generated policies on the Kubernetes cluster in the namespace where Aperture Controller is installed
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller

--- a/docs/content/reference/aperturectl/decisions/decisions.md
+++ b/docs/content/reference/aperturectl/decisions/decisions.md
@@ -32,7 +32,7 @@ aperturectl decisions [flags]
 
 ```
       --all                    Get all decisions
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/delete/delete.md
+++ b/docs/content/reference/aperturectl/delete/delete.md
@@ -19,7 +19,7 @@ Use this command to delete the Aperture Policies.
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/delete/policy/policy.md
+++ b/docs/content/reference/aperturectl/delete/policy/policy.md
@@ -35,7 +35,7 @@ aperturectl delete policy --policy=rate-limiting
 ### Options inherited from parent commands
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/discovery/discovery.md
+++ b/docs/content/reference/aperturectl/discovery/discovery.md
@@ -19,7 +19,7 @@ Use this command to query information about active Discovery integrations
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/discovery/entities/entities.md
+++ b/docs/content/reference/aperturectl/discovery/entities/entities.md
@@ -40,7 +40,7 @@ aperturectl discovery entities --find-by=“ip=10.244.1.24”
 ### Options inherited from parent commands
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
+++ b/docs/content/reference/aperturectl/flow-control/control-points/control-points.md
@@ -35,7 +35,7 @@ aperturectl flow-control control-points
 ### Options inherited from parent commands
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/flow-control/flow-control.md
+++ b/docs/content/reference/aperturectl/flow-control/flow-control.md
@@ -19,7 +19,7 @@ Use this command to query information about active Flow Control integrations
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/flow-control/preview/preview.md
+++ b/docs/content/reference/aperturectl/flow-control/preview/preview.md
@@ -32,7 +32,7 @@ aperturectl flow-control preview [--http] SERVICE CONTROL_POINT [flags]
 ### Options inherited from parent commands
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/policies/policies.md
+++ b/docs/content/reference/aperturectl/policies/policies.md
@@ -23,7 +23,7 @@ aperturectl policies [flags]
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/aperturectl/status/status.md
+++ b/docs/content/reference/aperturectl/status/status.md
@@ -31,7 +31,7 @@ aperturectl status [flags]
 ### Options
 
 ```
-      --api-key string         FluxNinja API Key to be used when using Cloud Controller
+      --api-key string         FluxNinja Cloud API Key to be used when using Cloud Controller
       --config string          Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
       --controller string      Address of Aperture Controller
       --controller-ns string   Namespace in which the Aperture Controller is running

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -6303,8 +6303,8 @@ setting.
 :::caution
 
 When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-labels are sent to FluxNinja for observability. Telemetry should be disabled for
-sensitive labels.
+labels are sent to FluxNinja Cloud for observability. Telemetry should be
+disabled for sensitive labels.
 
 :::
 
@@ -6454,8 +6454,8 @@ setting.
 :::caution
 
 When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-labels are sent to FluxNinja for observability. Telemetry should be disabled for
-sensitive labels.
+labels are sent to FluxNinja Cloud for observability. Telemetry should be
+disabled for sensitive labels.
 
 :::
 

--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -66,8 +66,8 @@ Without [Aperture Controller][], Aperture Agents won't be able to work.
 While it's possible to [self-host][Self-Hosting] Aperture Controller,
 FluxNinja Cloud Controller can be used instead.
 
-FluxNinja Cloud Controller is an [Aperture Controller] hosted by FluxNinja.
-The Cloud Controller is available for every FluxNinja Organization in the
+FluxNinja Cloud Controller is an [Aperture Controller] hosted by FluxNinja Cloud.
+The Cloud Controller is available for every FluxNinja Cloud Organization in the
 `default` project.
 
 ## Configuration
@@ -96,7 +96,7 @@ installation of the Aperture Controller or Agent:
 </Tabs>
 
 Replace the values of `ORGANIZATION_NAME` and `API_KEY` with the actual values
-of the organization on FluxNinja and API Key generated on it.
+of the organization on FluxNinja Cloud and API Key generated on it.
 
 More specific details about particular agent installation modes could be found
 in [Get Started: Installation](/get-started/installation/agent/agent.md).

--- a/docs/content/reference/observability/flow-metrics/flow-metrics.md
+++ b/docs/content/reference/observability/flow-metrics/flow-metrics.md
@@ -12,7 +12,7 @@ comprehensive view of individual requests or features within services. This
 stream contains high-cardinality attributes that represent key attributes of the
 requests and features, allowing for a detailed analysis of system performance
 and behavior. The stream can be stored and visualized in
-[FluxNinja](/introduction.md), or ingested into popular OLAP databases such as
+[FluxNinja Cloud](/introduction.md), or ingested into popular OLAP databases such as
 [Apache Druid](https://druid.apache.org/).
 
 ## Dimension Columns

--- a/docs/content/self-hosting/agent.md
+++ b/docs/content/self-hosting/agent.md
@@ -85,8 +85,8 @@ You may need to adjust the endpoints, depending on your exact setup.
 
 :::info
 
-If you're not using [FluxNinja][] at all, simply remove the `fluxninja` and
-`secrets` sections.
+If you're not using [FluxNinja Cloud][] at all, simply remove the `fluxninja`
+and `secrets` sections.
 
 :::
 
@@ -97,5 +97,5 @@ commands (like `flow-control`) won't work.
 
 :::
 
-[FluxNinja]: /introduction.md
+[FluxNinja Cloud]: /introduction.md
 [install-agent]: /get-started/installation/agent/agent.md

--- a/docs/content/self-hosting/self-hosting.md
+++ b/docs/content/self-hosting/self-hosting.md
@@ -6,17 +6,17 @@ keywords:
 ---
 
 The easiest way to install Aperture is to install just Aperture Agents and point
-them to [FluxNinja][], which also [provides the Aperture
+them to [FluxNinja Cloud][], which also [provides the Aperture
 Controller][Cloud Controller].
 
 If you want to have control over the infrastructure and data, it's also possible
 to self-host your own Aperture Controller. In such a setup, Agents and
 Controller comprise a fully functional Aperture system.
 
-Note that [FluxNinja can integrate][extension-config] with Self-Hosted
+Note that [FluxNinja Cloud can integrate][extension-config] with Self-Hosted
 Controller too, providing an easy way to manage policies and a holistic view of
 the infrastructure, along with tools for OLAP analysis of traffic.
 
-[FluxNinja]: /introduction.md
+[FluxNinja Cloud]: /introduction.md
 [Cloud Controller]: /reference/fluxninja.md#cloud-controller
 [extension-config]: /reference/fluxninja.md#configuration

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -2655,8 +2655,8 @@ definitions:
                     :::caution
 
                     When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-                    labels are sent to FluxNinja for observability. Telemetry should be disabled for
-                    sensitive labels.
+                    labels are sent to FluxNinja Cloud for observability. Telemetry should
+                    be disabled for sensitive labels.
 
                     :::
 
@@ -2750,8 +2750,8 @@ definitions:
                     :::caution
 
                     When using [FluxNinja extension](/reference/fluxninja.md), telemetry enabled
-                    labels are sent to FluxNinja for observability. Telemetry should be disabled for
-                    sensitive labels.
+                    labels are sent to FluxNinja Cloud for observability. Telemetry should be
+                    disabled for sensitive labels.
 
                     :::
 


### PR DESCRIPTION
Some renames were done earlier, but in few places the product was still called "FluxNinja".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

### Release Notes

**Documentation**: 
- Updated all instances of "FluxNinja" to "FluxNinja Cloud" across the entire codebase and documentation. This change ensures consistency in product naming throughout our platform.

> 🎉 Celebrating the name, we've made a switch,
> From FluxNinja to FluxNinja Cloud, without a glitch.
> In docs and code, the change is now done,
> For clarity and consistency, a victory won! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->