### PR TITLE
Make ETCD Client log level configurable

### DIFF
--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1421,6 +1421,20 @@ List of etcd server endpoints
 Lease time-to-live
 
 </dd>
+<dt>log_level</dt>
+<dd>
+
+<!-- vale off -->
+
+(string, one of:
+`debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL`,
+default: `"warn"`)
+
+<!-- vale on -->
+
+LogLevel of logs coming from inside the ETCD Client
+
+</dd>
 <dt>namespace</dt>
 <dd>
 

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1432,7 +1432,7 @@ default: `"warn"`)
 
 <!-- vale on -->
 
-LogLevel of logs coming from inside the ETCD Client
+LogLevel of logs coming from inside the etcd client
 
 </dd>
 <dt>namespace</dt>

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -878,7 +878,7 @@ default: `"warn"`)
 
 <!-- vale on -->
 
-LogLevel of logs coming from inside the ETCD Client
+LogLevel of logs coming from inside the etcd client
 
 </dd>
 <dt>namespace</dt>

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -867,6 +867,20 @@ List of etcd server endpoints
 Lease time-to-live
 
 </dd>
+<dt>log_level</dt>
+<dd>
+
+<!-- vale off -->
+
+(string, one of:
+`debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL`,
+default: `"warn"`)
+
+<!-- vale on -->
+
+LogLevel of logs coming from inside the ETCD Client
+
+</dd>
 <dt>namespace</dt>
 <dd>
 

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -495,7 +495,7 @@ definitions:
                 x-go-tag-validate: gte=1s
             log_level:
                 default: warn
-                description: LogLevel of logs coming from inside the ETCD Client
+                description: LogLevel of logs coming from inside the etcd client
                 enum:
                     - debug
                     - DEBUG

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -493,6 +493,30 @@ definitions:
                 x-go-tag-default: 60s
                 x-go-tag-json: lease_ttl
                 x-go-tag-validate: gte=1s
+            log_level:
+                default: warn
+                description: LogLevel of logs coming from inside the ETCD Client
+                enum:
+                    - debug
+                    - DEBUG
+                    - info
+                    - INFO
+                    - warn
+                    - WARN
+                    - error
+                    - ERROR
+                    - dpanic
+                    - DPANIC
+                    - panic
+                    - PANIC
+                    - fatal
+                    - FATAL
+                type: string
+                x-go-name: LogLevel
+                x-go-tag-default: warn
+                x-go-tag-json: log_level
+                x-go-tag-validate: oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL
+                x-oneof: debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL
             namespace:
                 default: aperture
                 description: etcd namespace

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -281,7 +281,7 @@ definitions:
                 x-go-tag-validate: gte=1s
             log_level:
                 default: warn
-                description: LogLevel of logs coming from inside the ETCD Client
+                description: LogLevel of logs coming from inside the etcd client
                 enum:
                     - debug
                     - DEBUG

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -279,6 +279,30 @@ definitions:
                 x-go-tag-default: 60s
                 x-go-tag-json: lease_ttl
                 x-go-tag-validate: gte=1s
+            log_level:
+                default: warn
+                description: LogLevel of logs coming from inside the ETCD Client
+                enum:
+                    - debug
+                    - DEBUG
+                    - info
+                    - INFO
+                    - warn
+                    - WARN
+                    - error
+                    - ERROR
+                    - dpanic
+                    - DPANIC
+                    - panic
+                    - PANIC
+                    - fatal
+                    - FATAL
+                type: string
+                x-go-name: LogLevel
+                x-go-tag-default: warn
+                x-go-tag-json: log_level
+                x-go-tag-validate: oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL
+                x-oneof: debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL
             namespace:
                 default: aperture
                 description: etcd namespace

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1124,8 +1124,8 @@ spec:
                         description: Lease time-to-live
                         type: string
                       log_level:
-                        description: LogLevel of logs coming from inside the ETCD
-                          Client
+                        description: LogLevel of logs coming from inside the etcd
+                          client
                         type: string
                       namespace:
                         description: etcd namespace

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1123,6 +1123,10 @@ spec:
                       lease_ttl:
                         description: Lease time-to-live
                         type: string
+                      log_level:
+                        description: LogLevel of logs coming from inside the ETCD
+                          Client
+                        type: string
                       namespace:
                         description: etcd namespace
                         type: string

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -1019,8 +1019,8 @@ spec:
                         description: Lease time-to-live
                         type: string
                       log_level:
-                        description: LogLevel of logs coming from inside the ETCD
-                          Client
+                        description: LogLevel of logs coming from inside the etcd
+                          client
                         type: string
                       namespace:
                         description: etcd namespace

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -1018,6 +1018,10 @@ spec:
                       lease_ttl:
                         description: Lease time-to-live
                         type: string
+                      log_level:
+                        description: LogLevel of logs coming from inside the ETCD
+                          Client
+                        type: string
                       namespace:
                         description: etcd namespace
                         type: string

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1124,8 +1124,8 @@ spec:
                         description: Lease time-to-live
                         type: string
                       log_level:
-                        description: LogLevel of logs coming from inside the ETCD
-                          Client
+                        description: LogLevel of logs coming from inside the etcd
+                          client
                         type: string
                       namespace:
                         description: etcd namespace

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1123,6 +1123,10 @@ spec:
                       lease_ttl:
                         description: Lease time-to-live
                         type: string
+                      log_level:
+                        description: LogLevel of logs coming from inside the ETCD
+                          Client
+                        type: string
                       namespace:
                         description: etcd namespace
                         type: string

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1019,8 +1019,8 @@ spec:
                         description: Lease time-to-live
                         type: string
                       log_level:
-                        description: LogLevel of logs coming from inside the ETCD
-                          Client
+                        description: LogLevel of logs coming from inside the etcd
+                          client
                         type: string
                       namespace:
                         description: etcd namespace

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1018,6 +1018,10 @@ spec:
                       lease_ttl:
                         description: Lease time-to-live
                         type: string
+                      log_level:
+                        description: LogLevel of logs coming from inside the ETCD
+                          Client
+                        type: string
                       namespace:
                         description: etcd namespace
                         type: string

--- a/operator/controllers/agent/config_test.tpl
+++ b/operator/controllers/agent/config_test.tpl
@@ -40,6 +40,7 @@ etcd:
     key_file: ""
     key_log_file: ""
   username: ""
+  log_level: warn
 flow_control:
   preview_service:
     enabled: true

--- a/operator/controllers/controller/config_test.tpl
+++ b/operator/controllers/controller/config_test.tpl
@@ -15,6 +15,7 @@ etcd:
     key_file: ""
     key_log_file: ""
   username: ""
+  log_level: warn
 fluxninja:
   api_key: ""
   client:

--- a/pkg/etcd/config.go
+++ b/pkg/etcd/config.go
@@ -21,6 +21,6 @@ type EtcdConfig struct {
 	ClientTLSConfig tlsconfig.ClientTLSConfig `json:"tls"`
 	// List of etcd server endpoints
 	Endpoints []string `json:"endpoints,omitempty" validate:"omitempty,dive,hostname_port|url|fqdn,omitempty"`
-	// LogLevel of logs coming from inside the ETCD Client
+	// LogLevel of logs coming from inside the etcd client
 	LogLevel string `json:"log_level" validate:"oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL" default:"warn"`
 }

--- a/pkg/etcd/config.go
+++ b/pkg/etcd/config.go
@@ -21,4 +21,6 @@ type EtcdConfig struct {
 	ClientTLSConfig tlsconfig.ClientTLSConfig `json:"tls"`
 	// List of etcd server endpoints
 	Endpoints []string `json:"endpoints,omitempty" validate:"omitempty,dive,hostname_port|url|fqdn,omitempty"`
+	// LogLevel of logs coming from inside the ETCD Client
+	LogLevel string `json:"log_level" validate:"oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL" default:"warn"`
 }


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### New Feature
- Introduced a new configuration option `log_level` for the ETCD client in both agent and controller configurations. This allows users to control the verbosity of logs generated by the ETCD client, enhancing debugging capabilities. The log level can be set to values like `debug`, `info`, `warn`, etc., with the default being `warn`.

> 🎉 Here's to the code that now sings,
> With logs that tell us many things.
> Debug or warn, info or fatal,
> Choose your level, make it prattle! 🥳
<!-- end of auto-generated comment: release notes by coderabbit.ai -->