### PR TITLE
Update documentation to mention grpc/http2 endpoint address

### DIFF
--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1588,7 +1588,7 @@ Aperture Controller.
 
 Address to gRPC or HTTP(s) server listening in agent service. For connecting to
 FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For
-self-hosted controller, the HTTP protocol address must start with `http(s)://`.
+self-hosted controller, the HTTP protocol address can start with `http(s)://`.
 
 </dd>
 <dt>heartbeat_interval</dt>

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1586,8 +1586,9 @@ Aperture Controller.
 
 <!-- vale on -->
 
-Address to gRPC or HTTP(s) server listening in agent service. To use HTTP
-protocol, the address must start with `http(s)://`.
+Address to gRPC or HTTP(s) server listening in agent service. For connecting to
+FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For
+self-hosted controller, the HTTP protocol address must start with `http(s)://`.
 
 </dd>
 <dt>heartbeat_interval</dt>

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -1,7 +1,7 @@
 ---
 title: aperturectl Configuration File Format Reference
 sidebar_position: 5
-sidebar_label: ".aperturectl/config"
+sidebar_label: "Aperturectl"
 ---
 
 <!-- If our configuration file grows, would be nice to automatically generate
@@ -26,7 +26,7 @@ if the `--kube` flag were passed).
 
 ## Format
 
-The aperturectl configuration file uses the following [TOML][] syntax:
+The aperturectl configuration file uses the following [TOML][toml] syntax:
 
 ```toml
 [controller]
@@ -34,9 +34,7 @@ url = "controller hostname:port"
 api_key = "api key for the controller"
 ```
 
-All the fields are required (although the file itself is not). See [Configuring
-aperturectl][] for an example on how to configure aperturectl with [FluxNinja
-Cloud Controller][].
+All the fields are required (although the file itself is not). See [Configuring aperturectl][configure-aperturectl] for an example on how to configure aperturectl with [FluxNinja Cloud Controller][cloud-controller].
 
 :::tip
 
@@ -45,6 +43,6 @@ environment variable to switch between different projects and organizations.
 
 :::
 
-[TOML]: https://toml.io/
-[Configuring aperturectl]: /get-started/installation/configure-cli.md
-[FluxNinja Cloud Controller]: /reference/fluxninja.md#cloud-controller
+[toml]: https://toml.io/
+[configure-aperturectl]: /get-started/installation/configure-cli.md
+[cloud-controller]: /reference/fluxninja.md#cloud-controller

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -1007,8 +1007,9 @@ Aperture Controller.
 
 <!-- vale on -->
 
-Address to gRPC or HTTP(s) server listening in agent service. To use HTTP
-protocol, the address must start with `http(s)://`.
+Address to gRPC or HTTP(s) server listening in agent service. For connecting to
+FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For
+self-hosted controller, the HTTP protocol address must start with `http(s)://`.
 
 </dd>
 <dt>heartbeat_interval</dt>

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -1009,7 +1009,7 @@ Aperture Controller.
 
 Address to gRPC or HTTP(s) server listening in agent service. For connecting to
 FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For
-self-hosted controller, the HTTP protocol address must start with `http(s)://`.
+self-hosted controller, the HTTP protocol address can start with `http(s)://`.
 
 </dd>
 <dt>heartbeat_interval</dt>

--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -100,11 +100,11 @@ of the organization on FluxNinja Cloud and API Key generated on it.
 
 :::note
 
-For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. We are working on supporting `https` fallback.
+For connecting to FluxNinja Cloud Controller, the `endpoint` should be an `grpc/http2` address. We are working on supporting `https` fallback.
 
 :::
 
-More specific details about particular agent installation modes could be found
+More details about particular agent installation modes could be found
 in [Get Started: Installation](/get-started/installation/agent/agent.md).
 
 Configuration parameters for the FluxNinja Extension are as follows:

--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -98,6 +98,12 @@ installation of the Aperture Controller or Agent:
 Replace the values of `ORGANIZATION_NAME` and `API_KEY` with the actual values
 of the organization on FluxNinja Cloud and API Key generated on it.
 
+:::note
+
+For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. We are working on supporting `https` fallback.
+
+:::
+
 More specific details about particular agent installation modes could be found
 in [Get Started: Installation](/get-started/installation/agent/agent.md).
 

--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -100,7 +100,7 @@ of the organization on FluxNinja Cloud and API Key generated on it.
 
 :::note
 
-For connecting to FluxNinja Cloud Controller, the `endpoint` should be an `grpc/http2` address. We are working on supporting `https` fallback.
+For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. We are working on supporting `https` fallback.
 
 :::
 

--- a/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
+++ b/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
@@ -125,7 +125,7 @@ definitions:
                 x-go-tag-default: "false"
                 x-go-tag-json: enable_cloud_controller
             endpoint:
-                description: Address to gRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
+                description: Address to gRPC or HTTP(s) server listening in agent service. For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For self-hosted controller, the HTTP protocol address must start with `http(s)://`.
                 pattern: (((^$)|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$))|(^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,\'/\\\+&amp;%\$#\=~])*$))|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$)
                 type: string
                 x-go-name: Endpoint

--- a/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
+++ b/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
@@ -125,7 +125,10 @@ definitions:
                 x-go-tag-default: "false"
                 x-go-tag-json: enable_cloud_controller
             endpoint:
-                description: Address to gRPC or HTTP(s) server listening in agent service. For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For self-hosted controller, the HTTP protocol address must start with `http(s)://`.
+                description: |-
+                    Address to gRPC or HTTP(s) server listening in agent service.
+                    For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address.
+                    For self-hosted controller, the HTTP protocol address can start with `http(s)://`.
                 pattern: (((^$)|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]):[0-9]+$))|(^https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\-\._\?\,\'/\\\+&amp;%\$#\=~])*$))|(^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$)
                 type: string
                 x-go-name: Endpoint

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -22,7 +22,9 @@ const (
 // swagger:model
 // +kubebuilder:object:generate=true
 type FluxNinjaExtensionConfig struct {
-	// Address to gRPC or HTTP(s) server listening in agent service. For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For self-hosted controller, the HTTP protocol address must start with `http(s)://`.
+	// Address to gRPC or HTTP(s) server listening in agent service.
+	// For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address.
+	// For self-hosted controller, the HTTP protocol address can start with `http(s)://`.
 	Endpoint string `json:"endpoint" validate:"omitempty,hostname_port|url|fqdn"`
 	// API Key for this agent. If this key is not set, the extension won't be enabled.
 	APIKey string `json:"api_key"`
@@ -36,7 +38,6 @@ type FluxNinjaExtensionConfig struct {
 	//
 	// Disable this flag only if using [Self-Hosted](/self-hosting/self-hosting.md) Aperture Controller.
 	EnableCloudController bool `json:"enable_cloud_controller" default:"false"`
-
 	// Interval between each heartbeat.
 	HeartbeatInterval config.Duration `json:"heartbeat_interval" validate:"gte=0s" default:"5s"`
 	// Client configuration.

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -22,7 +22,7 @@ const (
 // swagger:model
 // +kubebuilder:object:generate=true
 type FluxNinjaExtensionConfig struct {
-	// Address to gRPC or HTTP(s) server listening in agent service. To use HTTP protocol, the address must start with `http(s)://`.
+	// Address to gRPC or HTTP(s) server listening in agent service. For connecting to FluxNinja Cloud Controller, the `endpoint` should be a `grpc/http2` address. For self-hosted controller, the HTTP protocol address must start with `http(s)://`.
 	Endpoint string `json:"endpoint" validate:"omitempty,hostname_port|url|fqdn"`
 	// API Key for this agent. If this key is not set, the extension won't be enabled.
 	APIKey string `json:"api_key"`

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1316,7 +1316,7 @@ spec:
                         description: Address to gRPC or HTTP(s) server listening in
                           agent service. For connecting to FluxNinja Cloud Controller,
                           the `endpoint` should be a `grpc/http2` address. For self-hosted
-                          controller, the HTTP protocol address must start with `http(s)://`.
+                          controller, the HTTP protocol address can start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1314,8 +1314,9 @@ spec:
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in
-                          agent service. To use HTTP protocol, the address must start
-                          with `http(s)://`.
+                          agent service. For connecting to FluxNinja Cloud Controller,
+                          the `endpoint` should be a `grpc/http2` address. For self-hosted
+                          controller, the HTTP protocol address must start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -1200,7 +1200,7 @@ spec:
                         description: Address to gRPC or HTTP(s) server listening in
                           agent service. For connecting to FluxNinja Cloud Controller,
                           the `endpoint` should be a `grpc/http2` address. For self-hosted
-                          controller, the HTTP protocol address must start with `http(s)://`.
+                          controller, the HTTP protocol address can start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.

--- a/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
+++ b/manifests/charts/aperture-controller/crds/fluxninja.com_controllers.yaml
@@ -1198,8 +1198,9 @@ spec:
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in
-                          agent service. To use HTTP protocol, the address must start
-                          with `http(s)://`.
+                          agent service. For connecting to FluxNinja Cloud Controller,
+                          the `endpoint` should be a `grpc/http2` address. For self-hosted
+                          controller, the HTTP protocol address must start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1316,7 +1316,7 @@ spec:
                         description: Address to gRPC or HTTP(s) server listening in
                           agent service. For connecting to FluxNinja Cloud Controller,
                           the `endpoint` should be a `grpc/http2` address. For self-hosted
-                          controller, the HTTP protocol address must start with `http(s)://`.
+                          controller, the HTTP protocol address can start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1314,8 +1314,9 @@ spec:
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in
-                          agent service. To use HTTP protocol, the address must start
-                          with `http(s)://`.
+                          agent service. For connecting to FluxNinja Cloud Controller,
+                          the `endpoint` should be a `grpc/http2` address. For self-hosted
+                          controller, the HTTP protocol address must start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1200,7 +1200,7 @@ spec:
                         description: Address to gRPC or HTTP(s) server listening in
                           agent service. For connecting to FluxNinja Cloud Controller,
                           the `endpoint` should be a `grpc/http2` address. For self-hosted
-                          controller, the HTTP protocol address must start with `http(s)://`.
+                          controller, the HTTP protocol address can start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.

--- a/operator/config/crd/bases/fluxninja.com_controllers.yaml
+++ b/operator/config/crd/bases/fluxninja.com_controllers.yaml
@@ -1198,8 +1198,9 @@ spec:
                         type: boolean
                       endpoint:
                         description: Address to gRPC or HTTP(s) server listening in
-                          agent service. To use HTTP protocol, the address must start
-                          with `http(s)://`.
+                          agent service. For connecting to FluxNinja Cloud Controller,
+                          the `endpoint` should be a `grpc/http2` address. For self-hosted
+                          controller, the HTTP protocol address must start with `http(s)://`.
                         type: string
                       heartbeat_interval:
                         description: Interval between each heartbeat.


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

**Documentation**: Updated the descriptions and instructions for connecting to FluxNinja Cloud Controller in various configuration files. The `endpoint` should now be a `grpc/http2` address for cloud connections, while self-hosted controllers can use `http(s)://`.

> 🎉 Here's to the code that we tweak and refine,
> To make our software truly divine.
> With each PR, we take a step,
> Towards goals that we have adeptly set.
> Today we've made our docs more clear,
> For FluxNinja users far and near.
> So raise your glasses, give a cheer,
> For another successful code review here! 🥂
<!-- end of auto-generated comment: release notes by coderabbit.ai -->