### PR TITLE
docs: Fix links to Aperture Controller section

### DIFF
--- a/docs/content/architecture/architecture.md
+++ b/docs/content/architecture/architecture.md
@@ -34,7 +34,7 @@ offering:
 3. Traffic analytics dashboard
 4. Alerting system to notify about actions taken by Aperture Agents
 
-## Aperture Controller (hosted in Aperture Cloud)
+## Aperture Controller (hosted in Aperture Cloud) {#aperture-controller}
 
 :::note
 


### PR DESCRIPTION
This section is directly linked from some other places in docs, and our link checker doesn't dive into url fragments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

### Release Notes

**Documentation**: Improved navigation in the architecture documentation by adding an anchor tag to the "Aperture Controller" section. This change enhances user experience by allowing direct linking to this specific section.

> 📚 In the realm of code, where logic intertwines,
> 
> A tiny change emerges, as a beacon it shines.
> 
> To the Aperture Controller, a path we add,
> 
> Making navigation smoother, making users glad. 😊

<!-- end of auto-generated comment: release notes by coderabbit.ai -->