### PR TITLE
docs: Remove accidental usage of shortcut-style links

### DIFF
--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -50,7 +50,7 @@ export const CloudExtensionConfig = ({children, component}) => (
 );
 ```
 
-FluxNinja extension enables [Aperture Cloud][aperture-cloud] integration for
+FluxNinja extension enables [Aperture Cloud][] integration for
 Aperture Agents (and [self-hosted][self-hosting] Controllers). It enriches logs
 and traces collected by Aperture and sends them to Aperture Cloud. This data is
 batched and rolled up to optimize bandwidth usage. The extension also sends
@@ -62,11 +62,11 @@ Controller.
 
 ## Aperture Cloud Controller {#cloud-controller}
 
-Without the [Aperture Controller][aperture-controller], Aperture Agents won't be
+Without the [Aperture Controller][], Aperture Agents won't be
 able to work. While it's possible to [self-host][self-hosting] Aperture
 Controller, Aperture Cloud Controller can be used instead.
 
-Aperture Cloud Controller is an [Aperture Controller] hosted by Aperture Cloud.
+Aperture Cloud Controller is an [Aperture Controller][] hosted by Aperture Cloud.
 The Cloud Controller is available for every Aperture Cloud Organization in the
 `default` project.
 
@@ -121,5 +121,5 @@ How various components interact with the extension:
 - [Flow labels](/concepts/flow-label.md#extension)
 
 [self-hosting]: /self-hosting/self-hosting.md
-[aperture-cloud]: /introduction.md
-[aperture-controller]: /architecture/architecture.md#aperture-controller
+[aperture cloud]: /introduction.md
+[aperture controller]: /architecture/architecture.md#aperture-controller

--- a/docs/content/reference/observability/flow-metrics/flow-metrics.md
+++ b/docs/content/reference/observability/flow-metrics/flow-metrics.md
@@ -77,30 +77,30 @@ and behavior. The stream can be stored and visualized in
 
 <!-- vale off -->
 
-| Name                                         | Type                    | Unit  | Description                                           |
-| -------------------------------------------- | ----------------------- | ----- | ----------------------------------------------------- |
-| workload_duration_ms_sum                     | float                   | ms    | Sum of duration of the workload                       |
-| workload_duration_ms_min                     | float                   | ms    | Min of duration of the workload                       |
-| workload_duration_ms_max                     | float                   | ms    | Max of duration of the workload                       |
-| workload_duration_ms_sumOfSquares            | float                   | ms    | Sum of squares of duration of the workload            |
-| workload_duration_ms_datasketch              | [quantilesDoubleSketch] | ms    | Datasktech of Duration of the workload                |
-| flow_duration_ms_sum                         | float                   | ms    | Sum of duration of the flow                           |
-| flow_duration_ms_min                         | float                   | ms    | Min of duration of the flow                           |
-| flow_duration_ms_max                         | float                   | ms    | Max of duration of the flow                           |
-| flow_duration_ms_sumOfSquares                | float                   | ms    | Sum of squares of duration of the flow                |
-| flow_duration_ms_datasketch                  | [quantilesDoubleSketch] | ms    | Sum of Aperture's processing duration                 |
-| aperture_processing_duration_ms_min          | float                   | ms    | Min of Aperture's processing duration                 |
-| aperture_processing_duration_ms_max          | float                   | ms    | Max of Aperture's processing duration                 |
-| aperture_processing_duration_ms_sumOfSquares | float                   | ms    | Sum of squares of Aperture's processing duration      |
-| aperture_processing_duration_ms_datasketch   | [quantilesDoubleSketch] | ms    | Datasktech of Aperture's processing duration          |
-| http.request_content_length_sum              | int                     | bytes | Sum of length of the HTTP request content             |
-| http.request_content_length_min              | int                     | bytes | Min of length of the HTTP request content             |
-| http.request_content_length_max              | int                     | bytes | Max of length of the HTTP request content             |
-| http.request_content_length_sumOfSquares     | int                     | bytes | Sum of squares of length of the HTTP request content  |
-| http.response_content_length_sum             | int                     | bytes | Sum of length of the HTTP response content            |
-| http.response_content_length_min             | int                     | bytes | Min of length of the HTTP response content            |
-| http.response_content_length_max             | int                     | bytes | Max of length of the HTTP response content            |
-| http.response_content_length_sumOfSquares    | int                     | bytes | Sum of squares of length of the HTTP response content |
+| Name                                         | Type                      | Unit  | Description                                           |
+| -------------------------------------------- | ------------------------- | ----- | ----------------------------------------------------- |
+| workload_duration_ms_sum                     | float                     | ms    | Sum of duration of the workload                       |
+| workload_duration_ms_min                     | float                     | ms    | Min of duration of the workload                       |
+| workload_duration_ms_max                     | float                     | ms    | Max of duration of the workload                       |
+| workload_duration_ms_sumOfSquares            | float                     | ms    | Sum of squares of duration of the workload            |
+| workload_duration_ms_datasketch              | [quantilesDoubleSketch][] | ms    | Datasktech of Duration of the workload                |
+| flow_duration_ms_sum                         | float                     | ms    | Sum of duration of the flow                           |
+| flow_duration_ms_min                         | float                     | ms    | Min of duration of the flow                           |
+| flow_duration_ms_max                         | float                     | ms    | Max of duration of the flow                           |
+| flow_duration_ms_sumOfSquares                | float                     | ms    | Sum of squares of duration of the flow                |
+| flow_duration_ms_datasketch                  | [quantilesDoubleSketch][] | ms    | Sum of Aperture's processing duration                 |
+| aperture_processing_duration_ms_min          | float                     | ms    | Min of Aperture's processing duration                 |
+| aperture_processing_duration_ms_max          | float                     | ms    | Max of Aperture's processing duration                 |
+| aperture_processing_duration_ms_sumOfSquares | float                     | ms    | Sum of squares of Aperture's processing duration      |
+| aperture_processing_duration_ms_datasketch   | [quantilesDoubleSketch][] | ms    | Datasktech of Aperture's processing duration          |
+| http.request_content_length_sum              | int                       | bytes | Sum of length of the HTTP request content             |
+| http.request_content_length_min              | int                       | bytes | Min of length of the HTTP request content             |
+| http.request_content_length_max              | int                       | bytes | Max of length of the HTTP request content             |
+| http.request_content_length_sumOfSquares     | int                       | bytes | Sum of squares of length of the HTTP request content  |
+| http.response_content_length_sum             | int                       | bytes | Sum of length of the HTTP response content            |
+| http.response_content_length_min             | int                       | bytes | Min of length of the HTTP response content            |
+| http.response_content_length_max             | int                       | bytes | Max of length of the HTTP response content            |
+| http.response_content_length_sumOfSquares    | int                       | bytes | Sum of squares of length of the HTTP response content |
 
 <!-- vale on -->
 


### PR DESCRIPTION
(Aperture Controller link was broken)

We should use either `[foo][]` or `[foo][bar]` syntax, not `[foo]`.
See https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

**Documentation:**
- Updated the documentation in `fluxninja.md` with improved hyperlink references and capitalization corrections.
- Modified the table structure in `flow-metrics.md` to use array notation for `datasketch` fields.

> 🎉 Here's to the docs that we've refined,  
> With hyperlinks neatly aligned.  
> In tables wide and fields arrayed,  
> A clearer path for users laid. 🥂📚
<!-- end of auto-generated comment: release notes by coderabbit.ai -->