### PR TITLE
[update docs] rename FluxNinja Extension to FluxNinja Aperture Cloud Extension

### DIFF
--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -52,7 +52,7 @@ export const CloudExtensionConfig = ({children, component}) => (
 );
 ```
 
-FluxNinja Aperture Cloud Extension enables [Aperture Cloud][aperture-cloud] integration for
+FluxNinja Aperture Cloud extension enables [Aperture Cloud][aperture-cloud] integration for
 Aperture Agents (and [self-hosted][self-hosting] Controllers). It enriches logs
 and traces collected by Aperture and sends them to Aperture Cloud. This data is
 batched and rolled up to optimize bandwidth usage. The extension also sends

--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -1,10 +1,12 @@
 ---
-title: FluxNinja Extension
-sidebar_label: FluxNinja Extension
+title: FluxNinja Aperture Cloud Extension
+sidebar_label: FluxNinja Aperture Cloud Extension
 sidebar_position: 8
 keywords:
   - cloud
   - extension
+  - fluxninja
+  - aperture-cloud
 ---
 
 ```mdx-code-block
@@ -50,7 +52,7 @@ export const CloudExtensionConfig = ({children, component}) => (
 );
 ```
 
-FluxNinja extension enables [Aperture Cloud][aperture-cloud] integration for
+FluxNinja Aperture Cloud Extension enables [Aperture Cloud][aperture-cloud] integration for
 Aperture Agents (and [self-hosted][self-hosting] Controllers). It enriches logs
 and traces collected by Aperture and sends them to Aperture Cloud. This data is
 batched and rolled up to optimize bandwidth usage. The extension also sends


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

**Documentation**: Updated the FluxNinja documentation to reflect the name change to "FluxNinja Aperture Cloud Extension". The title, sidebar label, and text throughout the documentation have been updated for consistency. Added new keywords "fluxninja" and "aperture-cloud" to the metadata.

> A toast to our code, so bright and clear, 🥂  
> FluxNinja now has a new moniker here. 🎉  
> With Aperture Cloud in its name, ☁️  
> Its purpose and power remain the same. 💪  
> So let's celebrate this change, so grand, 🎊  
> For FluxNinja's reach continues to expand! 🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->