### PR TITLE
docs: Use quotes for endpoint value

### DIFF
--- a/docs/content/get-started/installation/agent/docker.md
+++ b/docs/content/get-started/installation/agent/docker.md
@@ -28,7 +28,7 @@ Below are the instructions to install the Aperture Agent on Docker.
    ```yaml
    fluxninja:
      enable_cloud_controller: true
-     endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+     endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
      api_key: API_KEY
    log:
      level: info

--- a/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/installation/agent/kubernetes/namespace-scoped/namespace-scoped.md
@@ -64,7 +64,7 @@ your cluster.
      config:
        fluxninja:
          enable_cloud_controller: true
-         endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+         endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
      secrets:
        fluxNinjaExtension:
          create: true
@@ -108,7 +108,7 @@ your cluster.
      config:
        fluxninja:
          enable_cloud_controller: true
-         endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+         endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
        log:
          level: debug
          pretty_console: true

--- a/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/daemonset.md
@@ -85,7 +85,7 @@ Kubernetes Objects which will be created by following steps are listed
      config:
        fluxninja:
          enable_cloud_controller: true
-         endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+         endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
      secrets:
        fluxNinjaExtension:
          create: true
@@ -128,7 +128,7 @@ Kubernetes Objects which will be created by following steps are listed
      config:
        fluxninja:
          enable_cloud_controller: true
-         endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+         endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
        log:
          level: debug
          pretty_console: true
@@ -212,7 +212,7 @@ Kubernetes Objects which will be created by following steps are listed
         config:
           fluxninja:
             enable_cloud_controller: true
-            endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+            endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
         secrets:
           fluxNinjaExtension:
             create: true

--- a/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
+++ b/docs/content/get-started/installation/agent/kubernetes/operator/sidecar.md
@@ -106,7 +106,7 @@ Kubernetes Objects which will be created by following steps are listed
      config:
        fluxninja:
          enable_cloud_controller: true
-         endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+         endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
      secrets:
        fluxNinjaExtension:
          create: true
@@ -154,7 +154,7 @@ Kubernetes Objects which will be created by following steps are listed
      config:
        fluxninja:
          enable_cloud_controller: true
-         endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+         endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
      secrets:
        fluxNinjaExtension:
          create: true
@@ -191,7 +191,7 @@ Kubernetes Objects which will be created by following steps are listed
      config:
        fluxninja:
          enable_cloud_controller: true
-         endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+         endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
        log:
          level: debug
          pretty_console: true
@@ -277,7 +277,7 @@ Kubernetes Objects which will be created by following steps are listed
         config:
           fluxninja:
             enable_cloud_controller: true
-            endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+            endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
         secrets:
           fluxNinjaExtension:
             create: true

--- a/docs/content/reference/fluxninja.md
+++ b/docs/content/reference/fluxninja.md
@@ -21,7 +21,7 @@ export const ExtensionConfig = ({children, component}) => (
 {`${component}:
   config:
     fluxninja:
-      endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+      endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
   secrets:
     fluxNinjaExtension:
       create: true
@@ -40,7 +40,7 @@ export const CloudExtensionConfig = ({children, component}) => (
   config:
     fluxninja:
       enable_cloud_controller: true
-      endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+      endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
   secrets:
     fluxNinjaExtension:
       create: true

--- a/docs/content/self-hosting/agent.md
+++ b/docs/content/self-hosting/agent.md
@@ -35,7 +35,7 @@ agent:
   config:
     fluxninja:
       enable_cloud_controller: false
-      endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+      endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
     etcd:
       endpoints: ["http://controller-etcd.default.svc.cluster.local:2379"]
     prometheus:
@@ -67,7 +67,7 @@ release name. If your setup is different, adjust these endpoints accordingly.
 ```yaml
 fluxninja:
   enable_cloud_controller: false
-  endpoint: ORGANIZATION_NAME.app.fluxninja.com:443
+  endpoint: "ORGANIZATION_NAME.app.fluxninja.com:443"
 etcd:
   endpoints: ["http://etcd:2379"]
 prometheus:


### PR DESCRIPTION
The port number after colon was highlighted in different color, which looked like a syntax error (it _is_ valid yaml – it was just prism's limitation).

![image](https://github.com/fluxninja/aperture/assets/3074996/661914ec-bb73-4e33-a865-1f37e6a08b76)
↓
![image](https://github.com/fluxninja/aperture/assets/3074996/94ba01bb-a3c8-4493-9136-37479b5ab556)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

**Documentation**: Updated the YAML configuration files across multiple documents. The `endpoint` values are now enclosed in double quotes to ensure they are treated as strings. This change affects the installation guides for Docker and Kubernetes, as well as the reference and self-hosting documentation.

> 🎉 Here's to the code that we tweak and refine,  
> Ensuring our docs are simply divine.  
> With each little quote, we make things align,  
> Now our endpoints as strings, will always shine! 🌟

<!-- end of auto-generated comment: release notes by coderabbit.ai -->