### PR TITLE
Export parsing group status function

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,10 +1,15 @@
 package status
 
 import (
+	"fmt"
+
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	monitoringv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/monitoring/v1"
 	statusv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/status/v1"
 )
 
@@ -29,4 +34,55 @@ func NewStatus(d proto.Message, e error) *statusv1.Status {
 	}
 
 	return s
+}
+
+// ParseGroupStatus parses GroupStatus response and returns a map of status path to value.
+func ParseGroupStatus(statusMap map[string]string, parent string, resp *statusv1.GroupStatus) (map[string]string, error) {
+	if resp.Groups == nil && resp.GetStatus() != nil {
+		if respErr := resp.Status.GetError(); respErr != nil {
+			statusMap[fmt.Sprintf("Error for %s", parent)] = respErr.Message
+		}
+		if respMsg := resp.Status.GetMessage(); respMsg != nil {
+			value := respMsg.String()
+
+			if respMsg.MessageIs(new(wrapperspb.StringValue)) {
+				stringVal := &wrapperspb.StringValue{}
+				err := respMsg.UnmarshalTo(stringVal)
+				if err != nil {
+					return nil, fmt.Errorf("error unmarshalling string value for key %s: %s", parent, err)
+				}
+				value = stringVal.Value
+			}
+			if respMsg.MessageIs(new(wrapperspb.DoubleValue)) {
+				doubleVal := &wrapperspb.DoubleValue{}
+				err := respMsg.UnmarshalTo(doubleVal)
+				if err != nil {
+					return nil, fmt.Errorf("error unmarshalling double value for key %s: %s", parent, err)
+				}
+				value = fmt.Sprintf("%v", doubleVal.Value)
+			}
+			if respMsg.MessageIs(new(monitoringv1.SignalMetricsInfo)) {
+				signalMetricsVal := &monitoringv1.SignalMetricsInfo{}
+				err := respMsg.UnmarshalTo(signalMetricsVal)
+				if err != nil {
+					return nil, fmt.Errorf("error unmarshalling signal metrics value for key %s: %s", parent, err)
+				}
+				value = fmt.Sprintf("%v", signalMetricsVal)
+			}
+			if respMsg.MessageIs(new(emptypb.Empty)) {
+				value = ""
+			}
+
+			statusMap[fmt.Sprintf("Status for %s", parent)] = value
+		}
+	}
+
+	for k, v := range resp.Groups {
+		newParent := fmt.Sprintf("%s/%s", parent, k)
+		_, err := ParseGroupStatus(statusMap, newParent, v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return statusMap, nil
 }


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

# Release Notes

**Refactor:**
- Removed the `printLeafStatus` function in `cmd/aperturectl/cmd/status/root.go` and replaced it with a call to `status.ParseGroupStatus`. This change simplifies the code and improves modularity.

**New Feature:**
- Introduced a new function `ParseGroupStatus` in `pkg/status/status.go`. This function parses a `GroupStatus` response and returns a map of status paths to values, improving the handling of different message types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->