### PR TITLE
Add logger for http server ErrorLogs

### DIFF
--- a/pkg/net/http/server.go
+++ b/pkg/net/http/server.go
@@ -95,7 +95,7 @@ type apertureLogger struct {
 }
 
 func (al *apertureLogger) Write(p []byte) (n int, err error) {
-	al.logger.Error().Msg(string(p))
+	al.logger.Debug().Msg(string(p))
 	return len(p), nil
 }
 
@@ -155,7 +155,7 @@ func (constructor ServerConstructor) provideServer(
 
 	router := mux.NewRouter()
 
-	logger := stdlog.New(&apertureLogger{log.GetGlobalLogger()}, "httpserver", stdlog.Llongfile|stdlog.Ldate|stdlog.Ltime|stdlog.LUTC)
+	logger := stdlog.New(&apertureLogger{log.GetGlobalLogger()}, "", 0)
 	server := &http.Server{
 		Handler:           router,
 		MaxHeaderBytes:    config.MaxHeaderBytes,

--- a/pkg/net/http/server.go
+++ b/pkg/net/http/server.go
@@ -90,6 +90,15 @@ func (constructor ServerConstructor) Annotate() fx.Option {
 	)
 }
 
+type apertureLogger struct {
+	logger *log.Logger
+}
+
+func (al *apertureLogger) Write(p []byte) (n int, err error) {
+	al.logger.Error().Msg(string(p))
+	return len(p), nil
+}
+
 // Server holds fields for custom HTTP server.
 type Server struct {
 	Server    *http.Server
@@ -146,7 +155,7 @@ func (constructor ServerConstructor) provideServer(
 
 	router := mux.NewRouter()
 
-	logger := stdlog.New(log.GetPrettyConsoleWriter(), "httpserver", stdlog.Llongfile|stdlog.Ldate|stdlog.Ltime|stdlog.LUTC)
+	logger := stdlog.New(&apertureLogger{log.GetGlobalLogger()}, "httpserver", stdlog.Llongfile|stdlog.Ldate|stdlog.Ltime|stdlog.LUTC)
 	server := &http.Server{
 		Handler:           router,
 		MaxHeaderBytes:    config.MaxHeaderBytes,

--- a/pkg/net/http/server.go
+++ b/pkg/net/http/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	stdlog "log"
 	"net/http"
 	"time"
 
@@ -145,6 +146,7 @@ func (constructor ServerConstructor) provideServer(
 
 	router := mux.NewRouter()
 
+	logger := stdlog.New(log.GetPrettyConsoleWriter(), "httpserver", stdlog.Llongfile|stdlog.Ldate|stdlog.Ltime|stdlog.LUTC)
 	server := &http.Server{
 		Handler:           router,
 		MaxHeaderBytes:    config.MaxHeaderBytes,
@@ -153,6 +155,7 @@ func (constructor ServerConstructor) provideServer(
 		ReadTimeout:       config.ReadTimeout.AsDuration(),
 		WriteTimeout:      config.WriteTimeout.AsDuration(),
 		TLSConfig:         tlsConfig,
+		ErrorLog:          logger,
 	}
 
 	httpServer := &Server{


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

# Release Notes

### New Feature
- Introduced `apertureLogger`, a new type that implements the `io.Writer` interface. This feature redirects log output from the standard library logger to the global logger provided by the `log` package, ensuring all server errors are captured effectively.
- Updated `provideServer` function to use `apertureLogger` as the `ErrorLog` for the HTTP server, enhancing error logging capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->