### PR TITLE
Changed default branch for latest environment on argo-manifests

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -919,7 +919,7 @@ jobs:
         description: ArgoCD manifests repository to update
       manifests-branch:
         type: string
-        default: tests
+        default: environments/latest
         description: Branch to use when pushing deployment changes
       environment-path:
         type: string


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Chore:**
- Updated the default value of the `manifests-branch` parameter in `.circleci/continue-workflows.yml` from "tests" to "environments/latest". This change will affect the branch that is used when the `manifests-branch` parameter is not explicitly provided.

> 🐇💻
>
> In the world of code, changes are a delight,
>
> With every pull request, we strive to get it right.
>
> From "tests" to "environments/latest", we hop and leap,
>
> Ensuring our software's quality, we promise to keep.
>
> So here's to the coder, with their carrots and tea,
>
> Making the world better, one commit at a time, you see! 🥕🎉
<!-- end of auto-generated comment: release notes by coderabbit.ai -->