### PR TITLE
add srecon video to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ To install the Aperture system, please follow the
 
 ## 🎥 Videos
 
+- [SREcon 23 APAC - Mastering Chaos: Achieving Fault Tolerance with Observability-Driven Prioritized Load Shedding](https://www.youtube.com/watch?v=ws9__JjaJsE)
 - [Chaos Carnival 2023-Graceful Degradation:Keeping The Lights On When Everything Goes Wrong](https://www.youtube.com/watch?v=yHKPXsZOc5I)
 - [Graceful Degradation: When All Goes Wrong | Tanveer Gill | Conf42 Chaos Engineering 2023](https://www.youtube.com/watch?v=nm62d2gYqNk)
 - [How Concurrency Limits Help Protect Against Cascading Failures](https://youtu.be/m070bAvrDHM)


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```
**Documentation:**
- Added a new educational resource in README.md. The link titled "SREcon 23 APAC - Mastering Chaos: Achieving Fault Tolerance with Observability-Driven Prioritized Load Shedding" directs to an informative YouTube video.

> 🐇🎉
> 
> Hoppity hop, there's no need to stop,
> A new link we drop, to the knowledge shop.
> Learn and adapt, with chaos unwrapped,
> In our doc's map, it's now aptly capped! 📚💡
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->