### PR TITLE
Removed the duplicate name of the manifests repo ref and base branch

### DIFF
--- a/.circleci/scripts/update_environment.sh
+++ b/.circleci/scripts/update_environment.sh
@@ -10,7 +10,6 @@ args=(
     --release-train "${RELEASE_TRAIN:-latest}"
     --manifests-repo-url "${MANIFESTS_REPO}"
     --manifests-base-branch "${MANIFESTS_BRANCH}"
-    --manifests-repo-ref "${MANIFESTS_BRANCH}"
     --push
 )
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Chore:**
- Removed the `--manifests-repo-ref` argument from the `args` list in `.circleci/scripts/update_environment.sh`.

> 🐇
> 
> "Hippity hop, code doesn't stop,
> 
> With every change, we rise to the top.
> 
> No more `--manifests-repo-ref`, it's gone away,
> 
> Simplifying scripts, making our day! 🎉"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->