### PR TITLE
Changed default etcd log level to error

### DIFF
--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1428,7 +1428,7 @@ Lease time-to-live
 
 (string, format: `empty | empty`, one of:
 `debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL`,
-default: `"warn"`)
+default: `"error"`)
 
 <!-- vale on -->
 

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -874,7 +874,7 @@ Lease time-to-live
 
 (string, format: `empty | empty`, one of:
 `debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL`,
-default: `"warn"`)
+default: `"error"`)
 
 <!-- vale on -->
 

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -494,7 +494,7 @@ definitions:
                 x-go-tag-json: lease_ttl
                 x-go-tag-validate: gte=1s
             log_level:
-                default: warn
+                default: error
                 description: LogLevel of logs coming from inside the etcd client
                 enum:
                     - debug
@@ -514,7 +514,7 @@ definitions:
                 pattern: (^$)|(^$)
                 type: string
                 x-go-name: LogLevel
-                x-go-tag-default: warn
+                x-go-tag-default: error
                 x-go-tag-json: log_level,omitempty
                 x-go-tag-validate: omitempty,oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL,omitempty
                 x-oneof: debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL

--- a/docs/gen/config/controller/config-swagger.yaml
+++ b/docs/gen/config/controller/config-swagger.yaml
@@ -280,7 +280,7 @@ definitions:
                 x-go-tag-json: lease_ttl
                 x-go-tag-validate: gte=1s
             log_level:
-                default: warn
+                default: error
                 description: LogLevel of logs coming from inside the etcd client
                 enum:
                     - debug
@@ -300,7 +300,7 @@ definitions:
                 pattern: (^$)|(^$)
                 type: string
                 x-go-name: LogLevel
-                x-go-tag-default: warn
+                x-go-tag-default: error
                 x-go-tag-json: log_level,omitempty
                 x-go-tag-validate: omitempty,oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL,omitempty
                 x-oneof: debug | DEBUG | info | INFO | warn | WARN | error | ERROR | dpanic | DPANIC | panic | PANIC | fatal | FATAL

--- a/operator/controllers/agent/config_test.tpl
+++ b/operator/controllers/agent/config_test.tpl
@@ -40,7 +40,7 @@ etcd:
     key_file: ""
     key_log_file: ""
   username: ""
-  log_level: warn
+  log_level: error
 flow_control:
   preview_service:
     enabled: true

--- a/operator/controllers/controller/config_test.tpl
+++ b/operator/controllers/controller/config_test.tpl
@@ -15,7 +15,7 @@ etcd:
     key_file: ""
     key_log_file: ""
   username: ""
-  log_level: warn
+  log_level: error
 fluxninja:
   api_key: ""
   client:

--- a/pkg/etcd/config.go
+++ b/pkg/etcd/config.go
@@ -22,5 +22,5 @@ type EtcdConfig struct {
 	// List of etcd server endpoints
 	Endpoints []string `json:"endpoints,omitempty" validate:"omitempty,dive,hostname_port|url|fqdn,omitempty"`
 	// LogLevel of logs coming from inside the etcd client
-	LogLevel string `json:"log_level,omitempty" validate:"omitempty,oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL,omitempty" default:"warn"`
+	LogLevel string `json:"log_level,omitempty" validate:"omitempty,oneof=debug DEBUG info INFO warn WARN error ERROR dpanic DPANIC panic PANIC fatal FATAL,omitempty" default:"error"`
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```
**Configuration Update:**
- Changed the default log level from "warn" to "error" in `EtcdConfig` struct, affecting the logging behavior of the `etcd` component across the system. This change is reflected in both agent and controller configurations.

> 🐇
> 
> In the land of code, where logic intertwines,
> A rabbit hops, making changes in lines.
> From "warn" to "error", we elevate our sight,
> To catch only errors in our log's light.
> 🎉 Celebrate this shift, for it brings clarity,
> In our quest for flawless software parity! 🥕
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->