### PR TITLE
Add ability to add tags for kubectl images in pre-delete and post-install hooks

### DIFF
--- a/manifests/charts/aperture-agent/README.md
+++ b/manifests/charts/aperture-agent/README.md
@@ -99,6 +99,10 @@
 | `operator.serviceAccount.name`                               | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""`                  |
 | `operator.serviceAccount.annotations`                        | Add annotations                                                                                                        | `{}`                  |
 | `operator.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                                                       | `true`                |
+| `operator.hooks.kubectl.image.registry`                      | kubectl image registry                                                                                                 | `docker.io/bitnami`   |
+| `operator.hooks.kubectl.image.repository`                    | kubectl image repository                                                                                               | `kubectl`             |
+| `operator.hooks.kubectl.image.tag`                           | kubectl image tag (immutable tags are recommended)                                                                     | `latest`              |
+| `operator.hooks.kubectl.image.pullPolicy`                    | kubectl image pull policy                                                                                              | `Always`              |
 
 ### Agent Custom Resource Parameters
 

--- a/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
@@ -32,7 +32,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: pre-delete-job
-        image: "bitnami/kubectl"
+        image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
+        imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
         command:
           - "/bin/bash"
           - "-xc"

--- a/manifests/charts/aperture-agent/values.yaml
+++ b/manifests/charts/aperture-agent/values.yaml
@@ -314,6 +314,24 @@ operator:
     ## @param operator.serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
     ##
     automountServiceAccountToken: true
+  ## Hooks
+  hooks:
+    kubectl:
+      ## Image to use for kubectl in pre-delete and post-install hooks.
+      ## @param operator.hooks.kubectl.image.registry kubectl image registry
+      ## @param operator.hooks.kubectl.image.repository kubectl image repository
+      ## @param operator.hooks.kubectl.image.tag kubectl image tag (immutable tags are recommended)
+      ## @param operator.hooks.kubectl.image.pullPolicy kubectl image pull policy
+      ##
+      image:
+        registry: docker.io/bitnami
+        repository: kubectl
+        tag: latest
+        ## Specify a imagePullPolicy
+        ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+        ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+        ##
+        pullPolicy: Always
 
 ## @section Agent Custom Resource Parameters
 ## @skip agent.createUninstallHook

--- a/manifests/charts/aperture-controller/README.md
+++ b/manifests/charts/aperture-controller/README.md
@@ -99,6 +99,10 @@
 | `operator.serviceAccount.name`                               | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""`                  |
 | `operator.serviceAccount.annotations`                        | Add annotations                                                                                                        | `{}`                  |
 | `operator.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                                                       | `true`                |
+| `operator.hooks.kubectl.image.registry`                      | kubectl image registry                                                                                                 | `docker.io/bitnami`   |
+| `operator.hooks.kubectl.image.repository`                    | kubectl image repository                                                                                               | `kubectl`             |
+| `operator.hooks.kubectl.image.tag`                           | kubectl image tag (immutable tags are recommended)                                                                     | `latest`              |
+| `operator.hooks.kubectl.image.pullPolicy`                    | kubectl image pull policy                                                                                              | `Always`              |
 
 ### Controller Custom Resource Parameters
 

--- a/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
@@ -33,7 +33,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: pre-delete-job
-        image: "bitnami/kubectl"
+        image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
+        imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
         command:
           - "/bin/bash"
           - "-xc"

--- a/manifests/charts/aperture-controller/templates/post-install-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/post-install-hook.yaml
@@ -31,7 +31,8 @@ spec:
       restartPolicy: Never
       containers:
       - name: post-install-job
-        image: "bitnami/kubectl"
+        image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
+        imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
         command:
           - "/bin/bash"
           - "-xc"

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -314,6 +314,24 @@ operator:
     ## @param operator.serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
     ##
     automountServiceAccountToken: true
+  ## Hooks
+  hooks:
+    kubectl:
+      ## Image to use for kubectl in pre-delete and post-install hooks.
+      ## @param operator.hooks.kubectl.image.registry kubectl image registry
+      ## @param operator.hooks.kubectl.image.repository kubectl image repository
+      ## @param operator.hooks.kubectl.image.tag kubectl image tag (immutable tags are recommended)
+      ## @param operator.hooks.kubectl.image.pullPolicy kubectl image pull policy
+      ##
+      image:
+        registry: docker.io/bitnami
+        repository: kubectl
+        tag: latest
+        ## Specify a imagePullPolicy
+        ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+        ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+        ##
+        pullPolicy: Always
 
 ## @section Controller Custom Resource Parameters
 ## @skip controller.createUninstallHook
@@ -611,7 +629,7 @@ prometheus:
     image:
       tag: v2.33.5
     extraFlags:
-    - web.enable-remote-write-receiver
+      - web.enable-remote-write-receiver
   alertmanager:
     enabled: false
   nodeExporter:


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced new configuration options for the Aperture Agent and Aperture Controller operators. Users can now customize the `kubectl` image used by the hooks, including the image registry, repository, tag, and pull policy. This enhancement provides more flexibility in managing the operator's environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->