### PR TITLE
Patched the aperture-js SDK version

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aperture-js",
-  "version": "2.4.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aperture-js",
-      "version": "2.4.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@grpc/grpc-js": "1.7.1",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "aperture-js is an SDK to interact with Aperture Agent.",
   "exports": "./lib/example/example.js",
   "scripts": {


### PR DESCRIPTION
While testing, I accidently unpublished v1.0.0 and now it is not allowing me to re-publish it so have to release a new version.