### PR TITLE
Skip PR when updating manifests post release

### DIFF
--- a/.circleci/post-release.yaml
+++ b/.circleci/post-release.yaml
@@ -224,6 +224,7 @@ jobs:
             ENVIRONMENT_PATH: << parameters.environment-path >>
             SKIP_COMPONENT: << parameters.skip-component >>
             RELEASE_TRAIN: << parameters.release-train >>
+            SKIP_PULL_REQUEST: "true"
           command: .circleci/scripts/update_environment.sh
       - asdf_save_cache:
           cache_name: update-environment


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated CI/CD pipeline to include a new environment variable `SKIP_PULL_REQUEST`. This change allows for the skipping of the pull request step during environment updates, streamlining the deployment process and reducing time-to-release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->