### PR TITLE
Add sane default resources to controller init containers

### DIFF
--- a/manifests/charts/aperture-agent/README.md
+++ b/manifests/charts/aperture-agent/README.md
@@ -103,6 +103,8 @@
 | `operator.hooks.kubectl.image.repository`                    | kubectl image repository                                                                                               | `kubectl`             |
 | `operator.hooks.kubectl.image.tag`                           | kubectl image tag (immutable tags are recommended)                                                                     | `latest`              |
 | `operator.hooks.kubectl.image.pullPolicy`                    | kubectl image pull policy                                                                                              | `Always`              |
+| `operator.hooks.kubectl.image.resources.limits`              | kubectl container resource limits                                                                                      | `{}`                  |
+| `operator.hooks.kubectl.image.resources.requests`            | kubectl container resource requests                                                                                    | `{}`                  |
 
 ### Agent Custom Resource Parameters
 

--- a/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
@@ -34,6 +34,9 @@ spec:
       - name: pre-delete-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
+        {{- if .Values.operator.hooks.kubectl.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
+        {{- end }}
         command:
           - "/bin/bash"
           - "-xc"

--- a/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
@@ -34,11 +34,11 @@ spec:
       - name: pre-delete-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
-        {{- if .Values.operator.hooks.kubectl.resources }}
-        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
+        {{- if .Values.operator.hooks.kubectl.image.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.image.resources | nindent 10 }}
         {{- end }}
         command:
-          - "/bin/bash"
+          - "/bin/sh"
           - "-xc"
           - "kubectl delete agent {{ .Release.Name }} -n {{ template "common.names.namespace" . }}; while (kubectl get agent {{ .Release.Name }} -n {{ template "common.names.namespace" . }}); ret=$?; [ $ret -eq 0 ]; do echo deleting; sleep 2; done"
 {{- end }}

--- a/manifests/charts/aperture-agent/values.yaml
+++ b/manifests/charts/aperture-agent/values.yaml
@@ -322,6 +322,8 @@ operator:
       ## @param operator.hooks.kubectl.image.repository kubectl image repository
       ## @param operator.hooks.kubectl.image.tag kubectl image tag (immutable tags are recommended)
       ## @param operator.hooks.kubectl.image.pullPolicy kubectl image pull policy
+      ## @param operator.hooks.kubectl.image.resources.limits kubectl container resource limits
+      ## @param operator.hooks.kubectl.image.resources.requests kubectl container resource requests
       ##
       image:
         registry: docker.io/bitnami
@@ -332,6 +334,9 @@ operator:
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##
         pullPolicy: Always
+        resources:
+          limits: {}
+          requests: {}
 
 ## @section Agent Custom Resource Parameters
 ## @skip agent.createUninstallHook

--- a/manifests/charts/aperture-controller/README.md
+++ b/manifests/charts/aperture-controller/README.md
@@ -103,6 +103,8 @@
 | `operator.hooks.kubectl.image.repository`                    | kubectl image repository                                                                                               | `kubectl`             |
 | `operator.hooks.kubectl.image.tag`                           | kubectl image tag (immutable tags are recommended)                                                                     | `latest`              |
 | `operator.hooks.kubectl.image.pullPolicy`                    | kubectl image pull policy                                                                                              | `Always`              |
+| `operator.hooks.kubectl.image.resources.limits`              | kubectl container resource limits                                                                                      | `{}`                  |
+| `operator.hooks.kubectl.image.resources.requests`            | kubectl container resource requests                                                                                    | `{}`                  |
 
 ### Controller Custom Resource Parameters
 
@@ -178,27 +180,31 @@
 
 ### etcd
 
-| Name                                  | Description                                                                               | Value                |
-| ------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| `etcd.enabled`                        | Whether to deploy a small etcd cluster as part of this chart                              | `true`               |
-| `etcd.auth.rbac.create`               | specifies whether to create the RBAC resources for Etcd                                   | `false`              |
-| `etcd.auth.token.type`                | specifies the type of token to use                                                        | `simple`             |
-| `etcd.autoCompactionMode`             | Auto compaction mode, by default periodic. Valid values: "periodic", "revision".          | `periodic`           |
-| `etcd.autoCompactionRetention`        | Auto compaction retention for mvcc key value store in hour, by default 0, means disabled. | `24`                 |
-| `etcd.initContainer.enabled`          | Create init container to check the health of Etcd before starting Aperture Controller.    | `true`               |
-| `etcd.initContainer.image.registry`   | Init container image registry.                                                            | `docker.io/bitnami`  |
-| `etcd.initContainer.image.repository` | Init container image repository.                                                          | `etcd`               |
-| `etcd.initContainer.image.tag`        | Init container image tag.                                                                 | `3.5.8-debian-11-r0` |
-| `etcd.initContainer.image.pullPolicy` | Init container image pull policy.                                                         | `IfNotPresent`       |
-| `etcd.pdb.create`                     | Whether to create a Pod Disruption Budget for Etcd                                        | `false`              |
+| Name                                    | Description                                                                               | Value                |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
+| `etcd.enabled`                          | Whether to deploy a small etcd cluster as part of this chart                              | `true`               |
+| `etcd.auth.rbac.create`                 | specifies whether to create the RBAC resources for Etcd                                   | `false`              |
+| `etcd.auth.token.type`                  | specifies the type of token to use                                                        | `simple`             |
+| `etcd.autoCompactionMode`               | Auto compaction mode, by default periodic. Valid values: "periodic", "revision".          | `periodic`           |
+| `etcd.autoCompactionRetention`          | Auto compaction retention for mvcc key value store in hour, by default 0, means disabled. | `24`                 |
+| `etcd.initContainer.enabled`            | Create init container to check the health of Etcd before starting Aperture Controller.    | `true`               |
+| `etcd.initContainer.resources.limits`   | Resources limits for the init containers                                                  | `{}`                 |
+| `etcd.initContainer.resources.requests` | Resources requests for the init containers                                                | `{}`                 |
+| `etcd.initContainer.image.registry`     | Init container image registry.                                                            | `docker.io/bitnami`  |
+| `etcd.initContainer.image.repository`   | Init container image repository.                                                          | `etcd`               |
+| `etcd.initContainer.image.tag`          | Init container image tag.                                                                 | `3.5.8-debian-11-r0` |
+| `etcd.initContainer.image.pullPolicy`   | Init container image pull policy.                                                         | `IfNotPresent`       |
+| `etcd.pdb.create`                       | Whether to create a Pod Disruption Budget for Etcd                                        | `false`              |
 
 ### prometheus
 
-| Name                                        | Description                                                                                     | Value                   |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------- |
-| `prometheus.enabled`                        | specifies whether to deploy embedded prometheus                                                 | `true`                  |
-| `prometheus.initContainer.enabled`          | Create init container to check the readiness of Prometheus before starting Aperture Controller. | `true`                  |
-| `prometheus.initContainer.image.registry`   | Init container image registry.                                                                  | `docker.io/linuxserver` |
-| `prometheus.initContainer.image.repository` | Init container image repository.                                                                | `yq`                    |
-| `prometheus.initContainer.image.tag`        | Init container image tag.                                                                       | `3.1.0`                 |
-| `prometheus.initContainer.image.pullPolicy` | Init container image pull policy.                                                               | `IfNotPresent`          |
+| Name                                          | Description                                                                                     | Value                   |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------- |
+| `prometheus.enabled`                          | specifies whether to deploy embedded prometheus                                                 | `true`                  |
+| `prometheus.initContainer.enabled`            | Create init container to check the readiness of Prometheus before starting Aperture Controller. | `true`                  |
+| `prometheus.initContainer.resources.limits`   | Resources limits for the init containers                                                        | `{}`                    |
+| `prometheus.initContainer.resources.requests` | Resources requests for the init containers                                                      | `{}`                    |
+| `prometheus.initContainer.image.registry`     | Init container image registry.                                                                  | `docker.io/linuxserver` |
+| `prometheus.initContainer.image.repository`   | Init container image repository.                                                                | `yq`                    |
+| `prometheus.initContainer.image.tag`          | Init container image tag.                                                                       | `3.1.0`                 |
+| `prometheus.initContainer.image.pullPolicy`   | Init container image pull policy.                                                               | `IfNotPresent`          |

--- a/manifests/charts/aperture-controller/templates/controller-cr.yaml
+++ b/manifests/charts/aperture-controller/templates/controller-cr.yaml
@@ -134,13 +134,6 @@ spec:
       {{- if .Values.etcd.initContainer.resources }}
       resources: {{- toYaml .Values.etcd.initContainer.resources | nindent 8 }}
       {{- end }}
-      resources:
-        limits:
-          cpu: 100m
-          memory: 200Mi
-        requests:
-          cpu: 50m
-          memory: 100Mi
       command:
         - 'sh'
         - '-c'

--- a/manifests/charts/aperture-controller/templates/controller-cr.yaml
+++ b/manifests/charts/aperture-controller/templates/controller-cr.yaml
@@ -131,6 +131,9 @@ spec:
     - name: wait-for-etcd
       image: {{ include "common.images.image" (dict "imageRoot" .Values.etcd.initContainer.image "global" .Values.global) }}
       imagePullPolicy: {{ .Values.etcd.initContainer.image.pullPolicy }}
+      {{- if .Values.etcd.initContainer.resources }}
+      resources: {{- toYaml .Values.etcd.initContainer.resources | nindent 8 }}
+      {{- end }}
       resources:
         limits:
           cpu: 100m
@@ -156,13 +159,9 @@ spec:
     - name: wait-for-prometheus
       image: {{ include "common.images.image" (dict "imageRoot" .Values.prometheus.initContainer.image "global" .Values.global) }}
       imagePullPolicy: {{ .Values.prometheus.initContainer.image.pullPolicy }}
-      resources:
-        limits:
-          cpu: 100m
-          memory: 200Mi
-        requests:
-          cpu: 50m
-          memory: 100Mi
+      {{- if .Values.etcd.initContainer.resources }}
+      resources: {{- toYaml .Values.prometheus.initContainer.resources | nindent 8 }}
+      {{- end }}
       command:
         - 'sh'
         - '-c'

--- a/manifests/charts/aperture-controller/templates/controller-cr.yaml
+++ b/manifests/charts/aperture-controller/templates/controller-cr.yaml
@@ -131,6 +131,13 @@ spec:
     - name: wait-for-etcd
       image: {{ include "common.images.image" (dict "imageRoot" .Values.etcd.initContainer.image "global" .Values.global) }}
       imagePullPolicy: {{ .Values.etcd.initContainer.image.pullPolicy }}
+      resources:
+        limits:
+          cpu: 100m
+          memory: 200Mi
+        requests:
+          cpu: 50m
+          memory: 100Mi
       command:
         - 'sh'
         - '-c'
@@ -149,6 +156,13 @@ spec:
     - name: wait-for-prometheus
       image: {{ include "common.images.image" (dict "imageRoot" .Values.prometheus.initContainer.image "global" .Values.global) }}
       imagePullPolicy: {{ .Values.prometheus.initContainer.image.pullPolicy }}
+      resources:
+        limits:
+          cpu: 100m
+          memory: 200Mi
+        requests:
+          cpu: 50m
+          memory: 100Mi
       command:
         - 'sh'
         - '-c'

--- a/manifests/charts/aperture-controller/templates/controller-deployment.yaml
+++ b/manifests/charts/aperture-controller/templates/controller-deployment.yaml
@@ -61,13 +61,9 @@ spec:
         - name: wait-for-etcd
           image: {{ include "common.images.image" (dict "imageRoot" .Values.etcd.initContainer.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.etcd.initContainer.image.pullPolicy }}
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 50m
-              memory: 100Mi
+          {{- if .Values.etcd.initContainer.resources }}
+          resources: {{- toYaml .Values.etcd.initContainer.resources | nindent 12 }}
+          {{- end }}
           command:
             - 'sh'
             - '-c'
@@ -84,13 +80,9 @@ spec:
         - name: wait-for-prometheus
           image: {{ include "common.images.image" (dict "imageRoot" .Values.prometheus.initContainer.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.prometheus.initContainer.image.pullPolicy }}
-          resources:
-            limits:
-              cpu: 100m
-              memory: 200Mi
-            requests:
-              cpu: 50m
-              memory: 100Mi
+          {{- if .Values.prometheus.initContainer.resources }}
+          resources: {{- toYaml .Values.prometheus.initContainer.resources | nindent 12 }}
+          {{- end }}
           command:
             - 'sh'
             - '-c'

--- a/manifests/charts/aperture-controller/templates/controller-deployment.yaml
+++ b/manifests/charts/aperture-controller/templates/controller-deployment.yaml
@@ -61,6 +61,13 @@ spec:
         - name: wait-for-etcd
           image: {{ include "common.images.image" (dict "imageRoot" .Values.etcd.initContainer.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.etcd.initContainer.image.pullPolicy }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
           command:
             - 'sh'
             - '-c'
@@ -77,6 +84,13 @@ spec:
         - name: wait-for-prometheus
           image: {{ include "common.images.image" (dict "imageRoot" .Values.prometheus.initContainer.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.prometheus.initContainer.image.pullPolicy }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
           command:
             - 'sh'
             - '-c'

--- a/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
@@ -35,6 +35,9 @@ spec:
       - name: pre-delete-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
+        {{- if .Values.operator.hooks.kubectl.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
+        {{- end }}
         command:
           - "/bin/bash"
           - "-xc"

--- a/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
@@ -35,11 +35,11 @@ spec:
       - name: pre-delete-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
-        {{- if .Values.operator.hooks.kubectl.resources }}
-        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
+        {{- if .Values.operator.hooks.kubectl.image.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.image.resources | nindent 10 }}
         {{- end }}
         command:
-          - "/bin/bash"
+          - "/bin/sh"
           - "-xc"
           - "kubectl delete controller {{ .Release.Name }} -n {{ template "common.names.namespace" . }}; while (kubectl get controller {{ .Release.Name }} -n {{ template "common.names.namespace" . }}); ret=$?; [ $ret -eq 0 ]; do echo deleting; sleep 2; done"
 {{- end }}

--- a/manifests/charts/aperture-controller/templates/post-install-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/post-install-hook.yaml
@@ -33,8 +33,11 @@ spec:
       - name: post-install-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
+        {{- if .Values.operator.hooks.kubectl.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
+        {{- end }}
         command:
-          - "/bin/bash"
+          - "/bin/sh"
           - "-xc"
           - |
             kubectl delete service,deployment --selector=app.kubernetes.io/name=kube-state-metrics,app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/managed-by=Helm -n {{ template "common.names.namespace" . }}

--- a/manifests/charts/aperture-controller/templates/post-install-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/post-install-hook.yaml
@@ -33,8 +33,8 @@ spec:
       - name: post-install-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
-        {{- if .Values.operator.hooks.kubectl.resources }}
-        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
+        {{- if .Values.operator.hooks.kubectl.image.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.image.resources | nindent 10 }}
         {{- end }}
         command:
           - "/bin/sh"

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -322,6 +322,8 @@ operator:
       ## @param operator.hooks.kubectl.image.repository kubectl image repository
       ## @param operator.hooks.kubectl.image.tag kubectl image tag (immutable tags are recommended)
       ## @param operator.hooks.kubectl.image.pullPolicy kubectl image pull policy
+      ## @param operator.hooks.kubectl.image.resources.limits kubectl container resource limits
+      ## @param operator.hooks.kubectl.image.resources.requests kubectl container resource requests
       ##
       image:
         registry: docker.io/bitnami
@@ -332,6 +334,9 @@ operator:
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##
         pullPolicy: Always
+        resources:
+          limits: {}
+          requests: {}
 
 ## @section Controller Custom Resource Parameters
 ## @skip controller.createUninstallHook
@@ -573,6 +578,8 @@ ingress:
 ## @param etcd.autoCompactionMode Auto compaction mode, by default periodic. Valid values: "periodic", "revision".
 ## @param etcd.autoCompactionRetention Auto compaction retention for mvcc key value store in hour, by default 0, means disabled.
 ## @param etcd.initContainer.enabled Create init container to check the health of Etcd before starting Aperture Controller.
+## @param etcd.initContainer.resources.limits Resources limits for the init containers
+## @param etcd.initContainer.resources.requests Resources requests for the init containers
 ## @param etcd.initContainer.image.registry Init container image registry.
 ## @param etcd.initContainer.image.repository Init container image repository.
 ## @param etcd.initContainer.image.tag Init container image tag.
@@ -586,6 +593,9 @@ etcd:
   autoCompactionRetention: 24
   initContainer:
     enabled: true
+    resources:
+      limits: {}
+      requests: {}
     image:
       registry: docker.io/bitnami
       repository: etcd
@@ -602,6 +612,8 @@ etcd:
 ## @section prometheus
 ## @param prometheus.enabled specifies whether to deploy embedded prometheus
 ## @param prometheus.initContainer.enabled Create init container to check the readiness of Prometheus before starting Aperture Controller.
+## @param prometheus.initContainer.resources.limits Resources limits for the init containers
+## @param prometheus.initContainer.resources.requests Resources requests for the init containers
 ## @param prometheus.initContainer.image.registry Init container image registry.
 ## @param prometheus.initContainer.image.repository Init container image repository.
 ## @param prometheus.initContainer.image.tag Init container image tag.
@@ -618,6 +630,9 @@ prometheus:
   enabled: true
   initContainer:
     enabled: true
+    resources:
+      limits: {}
+      requests: {}
     image:
       registry: docker.io/linuxserver
       repository: yq


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced resource limit and request parameters for the `kubectl` container in both `aperture-agent` and `aperture-controller` charts. This allows users to specify resource constraints, improving cluster resource management.
- New Feature: Added resource limit and request parameters for the `etcd` and `Prometheus` init containers in the `aperture-controller` chart. This enhancement provides better control over resource allocation, leading to more efficient utilization of cluster resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->