### PR TITLE
Minor corrections in the aperture helm charts

### DIFF
--- a/manifests/charts/aperture-agent/README.md
+++ b/manifests/charts/aperture-agent/README.md
@@ -103,8 +103,8 @@
 | `operator.hooks.kubectl.image.repository`                    | kubectl image repository                                                                                               | `kubectl`             |
 | `operator.hooks.kubectl.image.tag`                           | kubectl image tag (immutable tags are recommended)                                                                     | `latest`              |
 | `operator.hooks.kubectl.image.pullPolicy`                    | kubectl image pull policy                                                                                              | `Always`              |
-| `operator.hooks.kubectl.image.resources.limits`              | kubectl container resource limits                                                                                      | `{}`                  |
-| `operator.hooks.kubectl.image.resources.requests`            | kubectl container resource requests                                                                                    | `{}`                  |
+| `operator.hooks.kubectl.resources.limits`                    | kubectl container resource limits                                                                                      | `{}`                  |
+| `operator.hooks.kubectl.resources.requests`                  | kubectl container resource requests                                                                                    | `{}`                  |
 
 ### Agent Custom Resource Parameters
 

--- a/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-agent/templates/operator-pre-delete-hook.yaml
@@ -34,8 +34,8 @@ spec:
       - name: pre-delete-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
-        {{- if .Values.operator.hooks.kubectl.image.resources }}
-        resources: {{- toYaml .Values.operator.hooks.kubectl.image.resources | nindent 10 }}
+        {{- if .Values.operator.hooks.kubectl.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
         {{- end }}
         command:
           - "/bin/sh"

--- a/manifests/charts/aperture-agent/values.yaml
+++ b/manifests/charts/aperture-agent/values.yaml
@@ -322,8 +322,6 @@ operator:
       ## @param operator.hooks.kubectl.image.repository kubectl image repository
       ## @param operator.hooks.kubectl.image.tag kubectl image tag (immutable tags are recommended)
       ## @param operator.hooks.kubectl.image.pullPolicy kubectl image pull policy
-      ## @param operator.hooks.kubectl.image.resources.limits kubectl container resource limits
-      ## @param operator.hooks.kubectl.image.resources.requests kubectl container resource requests
       ##
       image:
         registry: docker.io/bitnami
@@ -334,9 +332,13 @@ operator:
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##
         pullPolicy: Always
-        resources:
-          limits: {}
-          requests: {}
+      ## Resource configuration for kubectl container
+      ## @param operator.hooks.kubectl.resources.limits kubectl container resource limits
+      ## @param operator.hooks.kubectl.resources.requests kubectl container resource requests
+      ##
+      resources:
+        limits: {}
+        requests: {}
 
 ## @section Agent Custom Resource Parameters
 ## @skip agent.createUninstallHook

--- a/manifests/charts/aperture-controller/README.md
+++ b/manifests/charts/aperture-controller/README.md
@@ -103,8 +103,8 @@
 | `operator.hooks.kubectl.image.repository`                    | kubectl image repository                                                                                               | `kubectl`             |
 | `operator.hooks.kubectl.image.tag`                           | kubectl image tag (immutable tags are recommended)                                                                     | `latest`              |
 | `operator.hooks.kubectl.image.pullPolicy`                    | kubectl image pull policy                                                                                              | `Always`              |
-| `operator.hooks.kubectl.image.resources.limits`              | kubectl container resource limits                                                                                      | `{}`                  |
-| `operator.hooks.kubectl.image.resources.requests`            | kubectl container resource requests                                                                                    | `{}`                  |
+| `operator.hooks.kubectl.resources.limits`                    | kubectl container resource limits                                                                                      | `{}`                  |
+| `operator.hooks.kubectl.resources.requests`                  | kubectl container resource requests                                                                                    | `{}`                  |
 
 ### Controller Custom Resource Parameters
 

--- a/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/operator-pre-delete-hook.yaml
@@ -35,8 +35,8 @@ spec:
       - name: pre-delete-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
-        {{- if .Values.operator.hooks.kubectl.image.resources }}
-        resources: {{- toYaml .Values.operator.hooks.kubectl.image.resources | nindent 10 }}
+        {{- if .Values.operator.hooks.kubectl.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
         {{- end }}
         command:
           - "/bin/sh"

--- a/manifests/charts/aperture-controller/templates/post-install-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/post-install-hook.yaml
@@ -33,8 +33,8 @@ spec:
       - name: post-install-job
         image: {{ include "common.images.image" (dict "imageRoot" .Values.operator.hooks.kubectl.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.operator.hooks.kubectl.image.pullPolicy }}
-        {{- if .Values.operator.hooks.kubectl.image.resources }}
-        resources: {{- toYaml .Values.operator.hooks.kubectl.image.resources | nindent 10 }}
+        {{- if .Values.operator.hooks.kubectl.resources }}
+        resources: {{- toYaml .Values.operator.hooks.kubectl.resources | nindent 10 }}
         {{- end }}
         command:
           - "/bin/sh"

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -322,8 +322,6 @@ operator:
       ## @param operator.hooks.kubectl.image.repository kubectl image repository
       ## @param operator.hooks.kubectl.image.tag kubectl image tag (immutable tags are recommended)
       ## @param operator.hooks.kubectl.image.pullPolicy kubectl image pull policy
-      ## @param operator.hooks.kubectl.image.resources.limits kubectl container resource limits
-      ## @param operator.hooks.kubectl.image.resources.requests kubectl container resource requests
       ##
       image:
         registry: docker.io/bitnami
@@ -334,9 +332,13 @@ operator:
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##
         pullPolicy: Always
-        resources:
-          limits: {}
-          requests: {}
+      ## Resource configuration for kubectl container
+      ## @param operator.hooks.kubectl.resources.limits kubectl container resource limits
+      ## @param operator.hooks.kubectl.resources.requests kubectl container resource requests
+      ##
+      resources:
+        limits: {}
+        requests: {}
 
 ## @section Controller Custom Resource Parameters
 ## @skip controller.createUninstallHook


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Refactor: 

- Updated configuration parameters for the `kubectl` image used by both the Aperture Agent and Aperture Controller operators. The resource limits and requests parameters have been renamed from `operator.hooks.kubectl.image.resources.limits` and `operator.hooks.kubectl.image.resources.requests` to `operator.hooks.kubectl.resources.limits` and `operator.hooks.kubectl.resources.requests`, respectively. This change simplifies the parameter naming structure and enhances readability."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->