### PR TITLE
Aperture JS SDK: Handle failOpen scenarios

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.1",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "aperture-js is an SDK to interact with Aperture Agent.",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -97,14 +97,22 @@ export class ApertureClient {
           span.setAttribute(WORKLOAD_START_TIMESTAMP_LABEL, Date.now());
 
           if (err) {
-            if (err.code === grpc.status.UNAVAILABLE) {
-              console.log(`Aperture server unavailable. Accepting request.`);
-              resolve(flow);
+            if (flow.failOpen) {
+              // Accept the request if failOpen is true even if we encounter an error
+              console.log(
+                `Aperture server unavailable due to ${JSON.stringify(
+                  err
+                )}. Accepting request.`
+              );
+              flow.checkResponse = null;
+            } else {
+              // Reject the request if failOpen is false if we encounter an error
+              reject(err);
             }
-            reject(err);
+          } else {
+            flow.checkResponse = response;
           }
 
-          flow.checkResponse = response;
           resolve(flow);
         }
       );


### PR DESCRIPTION
### Description of change
 - If failOpen is true (Default is true) and an errors occurs, we still allow requests to go through with an null response.
 - If failOpen is false and an error occurs, we reject the request with the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Bug Fix: Enhanced error handling in the `ApertureClient` class. The client now checks the `failOpen` property of the `flow` object to decide whether to accept or reject a request when an error occurs. This change improves the robustness of the client and provides better control over its behavior during error scenarios.
- Refactor: The `checkResponse` property is now consistently set to the server response, ensuring that it always reflects the most recent server interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->