### PR TITLE
Add support for printing templated manifest files in aperturectl

### DIFF
--- a/docs/content/reference/aperturectl/install/agent/agent.md
+++ b/docs/content/reference/aperturectl/install/agent/agent.md
@@ -38,6 +38,7 @@ aperturectl install agent --values-file=values.yaml --namespace=aperture
 ### Options inherited from parent commands
 
 ```
+      --dry-run              If set to true, only the manifests will be generated and no installation will be performed
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")
       --values-file string   Values YAML file containing parameters to customize the installation

--- a/docs/content/reference/aperturectl/install/controller/controller.md
+++ b/docs/content/reference/aperturectl/install/controller/controller.md
@@ -39,6 +39,7 @@ aperturectl install controller --values-file=values.yaml --namespace=aperture
 ### Options inherited from parent commands
 
 ```
+      --dry-run              If set to true, only the manifests will be generated and no installation will be performed
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")
       --values-file string   Values YAML file containing parameters to customize the installation

--- a/docs/content/reference/aperturectl/install/install.md
+++ b/docs/content/reference/aperturectl/install/install.md
@@ -19,6 +19,7 @@ Use this command to install Aperture Controller and Agent on your Kubernetes clu
 ### Options
 
 ```
+      --dry-run              If set to true, only the manifests will be generated and no installation will be performed
   -h, --help                 help for install
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")

--- a/docs/content/reference/aperturectl/install/istioconfig/istioconfig.md
+++ b/docs/content/reference/aperturectl/install/istioconfig/istioconfig.md
@@ -38,6 +38,7 @@ aperturectl install istioconfig --values-file=values.yaml --namespace=istio-syst
 ### Options inherited from parent commands
 
 ```
+      --dry-run              If set to true, only the manifests will be generated and no installation will be performed
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")
       --values-file string   Values YAML file containing parameters to customize the installation


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a `--dry-run` flag to the `aperturectl install` command and its subcommands (`agent`, `controller`, `istioconfig`). This option allows users to generate and preview the installation manifests without actually executing the installation process. This feature enhances user control and predictability during the installation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->