### PR TITLE
Change elasticsearch blueprint's promql query

### DIFF
--- a/blueprints/load-scheduling/elasticsearch/config.libsonnet
+++ b/blueprints/load-scheduling/elasticsearch/config.libsonnet
@@ -5,7 +5,7 @@ promqlDefaults {
     /**
     * @param (policy.promql_query: string) PromQL query to detect ElasticSearch overload.
     */
-    promql_query: 'elasticsearch_node_thread_pool_tasks_queued{thread_pool_name="search"}',
+    promql_query: 'avg(avg_over_time(elasticsearch_node_thread_pool_tasks_queued{thread_pool_name="search"}[30s]))',
 
     /**
     * @param (policy.elasticsearch: elasticsearch) Configuration for Elasticsearch OpenTelemetry receiver. Refer https://docs.fluxninja.com/integrations/metrics/elasticsearch for more information.

--- a/blueprints/load-scheduling/elasticsearch/gen/definitions.json
+++ b/blueprints/load-scheduling/elasticsearch/gen/definitions.json
@@ -98,7 +98,7 @@
         },
         "promql_query": {
           "description": "PromQL query to detect ElasticSearch overload.",
-          "default": "elasticsearch_node_thread_pool_tasks_queued{thread_pool_name=\"search\"}",
+          "default": "avg(avg_over_time(elasticsearch_node_thread_pool_tasks_queued{thread_pool_name=\"search\"}[30s]))",
           "type": "string"
         },
         "setpoint": {

--- a/docs/content/reference/blueprints/load-scheduling/elasticsearch.md
+++ b/docs/content/reference/blueprints/load-scheduling/elasticsearch.md
@@ -109,7 +109,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/load-schedu
     description='PromQL query to detect ElasticSearch overload.'
     type='string'
     reference=''
-    value='"elasticsearch_node_thread_pool_tasks_queued{thread_pool_name=\"search\"}"'
+    value='"avg(avg_over_time(elasticsearch_node_thread_pool_tasks_queued{thread_pool_name=\"search\"}[30s]))"'
 />
 
 <!-- vale on -->

--- a/playground/scenarios/elasticsearch-overload/policies/service1-demoapp-elasticsearch-overload-cr.yaml
+++ b/playground/scenarios/elasticsearch-overload/policies/service1-demoapp-elasticsearch-overload-cr.yaml
@@ -44,7 +44,7 @@ spec:
           out_ports:
             output:
               signal_name: SIGNAL
-          query_string: elasticsearch_node_thread_pool_tasks_queued{thread_pool_name="search"}
+          query_string: avg(avg_over_time(elasticsearch_node_thread_pool_tasks_queued{thread_pool_name="search"}[30s]))
     - variable:
         constant_output:
           value: 250


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the `promql_query` parameter in the `promqlDefaults` object within the `blueprints/load-scheduling/elasticsearch/config.libsonnet` file. The query now uses the `avg_over_time` function to calculate averages over a 30-second window, enhancing the accuracy of ElasticSearch overload detection.
- Documentation: Updated the code snippet in `docs/content/reference/blueprints/load-scheduling/elasticsearch.md` to reflect the changes made to the PromQL query. This change provides users with more accurate information on monitoring ElasticSearch overload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->