### PR TITLE
Removed defaults for 'tokens_label_key' and 'priorities_label_key'

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -93,7 +93,7 @@ message RateLimiter {
     // This is an optional parameter and takes highest precedence
     // when assigning tokens to a request.
     // The label value must be a valid uint64 number.
-    string tokens_label_key = 2; // @gotags: default:"tokens"
+    string tokens_label_key = 2;
 
     // Interval defines the time interval in which the token bucket
     // will fill tokens specified by `fill_amount` signal.
@@ -303,12 +303,12 @@ message Scheduler {
   // * Key for a flow label that can be used to override the default number of tokens for this flow.
   // * The value associated with this key must be a valid uint64 number.
   // * If this parameter is not provided, the number of tokens for the flow will be determined by the matched workload's token count.
-  string tokens_label_key = 7; // @gotags: default:"tokens"
+  string tokens_label_key = 7;
 
   // * Key for a flow label that can be used to override the default priority for this flow.
   // * The value associated with this key must be a valid uint64 number. Higher numbers means higher priority.
   // * If this parameter is not provided, the priority for the flow will be determined by the matched workload's priority.
-  string priorities_label_key = 8; // @gotags: default:"priorities"
+  string priorities_label_key = 8;
 
   // This field allows you to override the default HTTP status code (`503 Service Unavailable`) that is returned when a request is denied.
   flowcontrol.check.v1.StatusCode denied_response_status_code = 9 [(validate.rules).enum = {defined_only: true}];

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -544,11 +544,11 @@ type Scheduler struct {
 	// * Key for a flow label that can be used to override the default number of tokens for this flow.
 	// * The value associated with this key must be a valid uint64 number.
 	// * If this parameter is not provided, the number of tokens for the flow will be determined by the matched workload's token count.
-	TokensLabelKey string `protobuf:"bytes,7,opt,name=tokens_label_key,json=tokensLabelKey,proto3" json:"tokens_label_key,omitempty" default:"tokens"` // @gotags: default:"tokens"
+	TokensLabelKey string `protobuf:"bytes,7,opt,name=tokens_label_key,json=tokensLabelKey,proto3" json:"tokens_label_key,omitempty"`
 	// * Key for a flow label that can be used to override the default priority for this flow.
 	// * The value associated with this key must be a valid uint64 number. Higher numbers means higher priority.
 	// * If this parameter is not provided, the priority for the flow will be determined by the matched workload's priority.
-	PrioritiesLabelKey string `protobuf:"bytes,8,opt,name=priorities_label_key,json=prioritiesLabelKey,proto3" json:"priorities_label_key,omitempty" default:"priorities"` // @gotags: default:"priorities"
+	PrioritiesLabelKey string `protobuf:"bytes,8,opt,name=priorities_label_key,json=prioritiesLabelKey,proto3" json:"priorities_label_key,omitempty"`
 	// This field allows you to override the default HTTP status code (`503 Service Unavailable`) that is returned when a request is denied.
 	DeniedResponseStatusCode v1.StatusCode `protobuf:"varint,9,opt,name=denied_response_status_code,json=deniedResponseStatusCode,proto3,enum=aperture.flowcontrol.check.v1.StatusCode" json:"denied_response_status_code,omitempty"`
 }
@@ -1923,7 +1923,7 @@ type RateLimiter_Parameters struct {
 	// This is an optional parameter and takes highest precedence
 	// when assigning tokens to a request.
 	// The label value must be a valid uint64 number.
-	TokensLabelKey string `protobuf:"bytes,2,opt,name=tokens_label_key,json=tokensLabelKey,proto3" json:"tokens_label_key,omitempty" default:"tokens"` // @gotags: default:"tokens"
+	TokensLabelKey string `protobuf:"bytes,2,opt,name=tokens_label_key,json=tokensLabelKey,proto3" json:"tokens_label_key,omitempty"`
 	// Interval defines the time interval in which the token bucket
 	// will fill tokens specified by `fill_amount` signal.
 	// This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -2583,10 +2583,8 @@
           "x-go-tag-default": "7200s"
         },
         "tokens_label_key": {
-          "default": "tokens",
-          "description": "Flow label key that will be used to override the number of tokens\nfor this request.\nThis is an optional parameter and takes highest precedence\nwhen assigning tokens to a request.\nThe label value must be a valid uint64 number.\n\n",
-          "type": "string",
-          "x-go-tag-default": "tokens"
+          "description": "Flow label key that will be used to override the number of tokens\nfor this request.\nThis is an optional parameter and takes highest precedence\nwhen assigning tokens to a request.\nThe label value must be a valid uint64 number.",
+          "type": "string"
         }
       },
       "required": ["interval"],
@@ -2885,16 +2883,12 @@
           "description": "This field allows you to override the default HTTP status code (`503 Service Unavailable`) that is returned when a request is denied."
         },
         "priorities_label_key": {
-          "default": "priorities",
-          "description": "* Key for a flow label that can be used to override the default priority for this flow.\n* The value associated with this key must be a valid uint64 number. Higher numbers means higher priority.\n* If this parameter is not provided, the priority for the flow will be determined by the matched workload's priority.\n\n",
-          "type": "string",
-          "x-go-tag-default": "priorities"
+          "description": "* Key for a flow label that can be used to override the default priority for this flow.\n* The value associated with this key must be a valid uint64 number. Higher numbers means higher priority.\n* If this parameter is not provided, the priority for the flow will be determined by the matched workload's priority.",
+          "type": "string"
         },
         "tokens_label_key": {
-          "default": "tokens",
-          "description": "* Key for a flow label that can be used to override the default number of tokens for this flow.\n* The value associated with this key must be a valid uint64 number.\n* If this parameter is not provided, the number of tokens for the flow will be determined by the matched workload's token count.\n\n",
-          "type": "string",
-          "x-go-tag-default": "tokens"
+          "description": "* Key for a flow label that can be used to override the default number of tokens for this flow.\n* The value associated with this key must be a valid uint64 number.\n* If this parameter is not provided, the number of tokens for the flow will be determined by the matched workload's token count.",
+          "type": "string"
         },
         "workloads": {
           "description": "List of workloads to be used in scheduler.\n\nCategorizing flows into workloads\nallows for load throttling to be \"intelligent\" instead of queueing flows in an arbitrary order.\nThere are two aspects of this \"intelligence\":\n* Scheduler can more precisely calculate concurrency if it understands\n  that flows belonging to different classes have different weights (for example, insert queries compared to select queries).\n* Setting different priorities to different workloads lets the scheduler\n  avoid dropping important traffic during overload.\n\nEach workload in this list specifies also a matcher that is used to\ndetermine which flow will be categorized into which workload.\nIn case of multiple matching workloads, the first matching one will be used.\nIf none of workloads match, `default_workload` will be used.\n\n:::info\n\nSee also [workload definition in the concepts\nsection](/concepts/scheduler/scheduler.md#workload).\n\n:::\n\n",

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2722,16 +2722,13 @@ definitions:
                 type: string
                 x-go-tag-default: 7200s
             tokens_label_key:
-                default: tokens
-                description: |+
+                description: |-
                     Flow label key that will be used to override the number of tokens
                     for this request.
                     This is an optional parameter and takes highest precedence
                     when assigning tokens to a request.
                     The label value must be a valid uint64 number.
-
                 type: string
-                x-go-tag-default: tokens
         required:
             - interval
         type: object
@@ -3112,23 +3109,17 @@ definitions:
                 $ref: '#/definitions/StatusCode'
                 description: This field allows you to override the default HTTP status code (`503 Service Unavailable`) that is returned when a request is denied.
             priorities_label_key:
-                default: priorities
-                description: |+
+                description: |-
                     * Key for a flow label that can be used to override the default priority for this flow.
                     * The value associated with this key must be a valid uint64 number. Higher numbers means higher priority.
                     * If this parameter is not provided, the priority for the flow will be determined by the matched workload's priority.
-
                 type: string
-                x-go-tag-default: priorities
             tokens_label_key:
-                default: tokens
-                description: |+
+                description: |-
                     * Key for a flow label that can be used to override the default number of tokens for this flow.
                     * The value associated with this key must be a valid uint64 number.
                     * If this parameter is not provided, the number of tokens for the flow will be determined by the matched workload's token count.
-
                 type: string
-                x-go-tag-default: tokens
             workloads:
                 description: |+
                     List of workloads to be used in scheduler.

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -3302,16 +3302,13 @@ definitions:
                 type: string
                 x-go-tag-default: 7200s
             tokens_label_key:
-                default: tokens
-                description: |+
+                description: |-
                     Flow label key that will be used to override the number of tokens
                     for this request.
                     This is an optional parameter and takes highest precedence
                     when assigning tokens to a request.
                     The label value must be a valid uint64 number.
-
                 type: string
-                x-go-tag-default: tokens
         required:
             - interval
         type: object
@@ -3753,23 +3750,17 @@ definitions:
                 $ref: '#/definitions/StatusCode'
                 description: This field allows you to override the default HTTP status code (`503 Service Unavailable`) that is returned when a request is denied.
             priorities_label_key:
-                default: priorities
-                description: |+
+                description: |-
                     * Key for a flow label that can be used to override the default priority for this flow.
                     * The value associated with this key must be a valid uint64 number. Higher numbers means higher priority.
                     * If this parameter is not provided, the priority for the flow will be determined by the matched workload's priority.
-
                 type: string
-                x-go-tag-default: priorities
             tokens_label_key:
-                default: tokens
-                description: |+
+                description: |-
                     * Key for a flow label that can be used to override the default number of tokens for this flow.
                     * The value associated with this key must be a valid uint64 number.
                     * If this parameter is not provided, the number of tokens for the flow will be determined by the matched workload's token count.
-
                 type: string
-                x-go-tag-default: tokens
             workloads:
                 description: |+
                     List of workloads to be used in scheduler.

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -6408,7 +6408,7 @@ a value of "10s" would signify a duration of 10 seconds.
 
 <!-- vale off -->
 
-(string, default: `"tokens"`)
+(string)
 
 <!-- vale on -->
 
@@ -7198,7 +7198,7 @@ This field allows you to override the default HTTP status code
 
 <!-- vale off -->
 
-(string, default: `"priorities"`)
+(string)
 
 <!-- vale on -->
 
@@ -7215,7 +7215,7 @@ This field allows you to override the default HTTP status code
 
 <!-- vale off -->
 
-(string, default: `"tokens"`)
+(string)
 
 <!-- vale on -->
 

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -2649,16 +2649,13 @@ definitions:
                 type: string
                 x-go-tag-default: 7200s
             tokens_label_key:
-                default: tokens
-                description: |+
+                description: |-
                     Flow label key that will be used to override the number of tokens
                     for this request.
                     This is an optional parameter and takes highest precedence
                     when assigning tokens to a request.
                     The label value must be a valid uint64 number.
-
                 type: string
-                x-go-tag-default: tokens
         required:
             - interval
         type: object
@@ -3039,23 +3036,17 @@ definitions:
                 $ref: '#/definitions/StatusCode'
                 description: This field allows you to override the default HTTP status code (`503 Service Unavailable`) that is returned when a request is denied.
             priorities_label_key:
-                default: priorities
-                description: |+
+                description: |-
                     * Key for a flow label that can be used to override the default priority for this flow.
                     * The value associated with this key must be a valid uint64 number. Higher numbers means higher priority.
                     * If this parameter is not provided, the priority for the flow will be determined by the matched workload's priority.
-
                 type: string
-                x-go-tag-default: priorities
             tokens_label_key:
-                default: tokens
-                description: |+
+                description: |-
                     * Key for a flow label that can be used to override the default number of tokens for this flow.
                     * The value associated with this key must be a valid uint64 number.
                     * If this parameter is not provided, the number of tokens for the flow will be determined by the matched workload's token count.
-
                 type: string
-                x-go-tag-default: tokens
             workloads:
                 description: |+
                     List of workloads to be used in scheduler.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Updated `RateLimiter` and `Scheduler` message definitions in `flowcontrol.proto`. Removed default values for `tokens_label_key` and `priorities_label_key`, they will now default to empty strings if not provided.
- Refactor: Changes in configuration fields in `spec.md`. Default values have been removed and the type has been simplified. This allows more flexibility when specifying HTTP status codes and duration values.
---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->