### PR TITLE
Set default tokens in the workload to 1 and switch off auto tokens by default

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -162,7 +162,7 @@ message LoadScheduler {
     // The value of tokens estimated takes a lower precedence
     // than the value of `tokens` specified in the workload definition
     // and `tokens` explicitly specified in the flow labels.
-    bool workload_latency_based_tokens = 1; // @gotags: default:"true"
+    bool workload_latency_based_tokens = 1; // @gotags: default:"false"
 
     // Configuration of Weighted Fair Queuing-based workload scheduler.
     //
@@ -236,7 +236,7 @@ message Scheduler {
       // number of flows (3rd party rate limiters).
       // This override is applicable only if tokens for the flow aren't specified
       // in the flow labels.
-      uint32 tokens = 2; // @gotags: validate:"gte=0"
+      uint32 tokens = 2; // @gotags: validate:"gte=0" default:"1"
 
       // Timeout for the flow in the workload.
       // If timeout is provided on the Check call as well, the minimum of the two is picked.

--- a/api/buf.lock
+++ b/api/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: 5aeb6044ee474cc6a2bc2281ebe40134
-    digest: shake256:b20786801a82a2f292100395dacff6eda733d431716a189279c0256e4902bedd60db0a76f678e188d11bc9690edbc1185707498d5f1973bc2819388edb4ca086
+    commit: 3e797ed6699f49f48f4be7cfcfe78822
+    digest: shake256:5ba58a25a7d0d685fd9a9d556cc80585479082465bf842d286a310e6e31cb6fefdd6940121b2d56a70aa09c93357153d603419fab2d6647773fbe02e07902ec1
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -2160,7 +2160,7 @@ type LoadScheduler_Parameters struct {
 	// The value of tokens estimated takes a lower precedence
 	// than the value of `tokens` specified in the workload definition
 	// and `tokens` explicitly specified in the flow labels.
-	WorkloadLatencyBasedTokens bool `protobuf:"varint,1,opt,name=workload_latency_based_tokens,json=workloadLatencyBasedTokens,proto3" json:"workload_latency_based_tokens,omitempty" default:"true"` // @gotags: default:"true"
+	WorkloadLatencyBasedTokens bool `protobuf:"varint,1,opt,name=workload_latency_based_tokens,json=workloadLatencyBasedTokens,proto3" json:"workload_latency_based_tokens,omitempty" default:"false"` // @gotags: default:"false"
 	// Configuration of Weighted Fair Queuing-based workload scheduler.
 	//
 	// Contains configuration of per-agent scheduler
@@ -2414,7 +2414,7 @@ type Scheduler_Workload_Parameters struct {
 	// number of flows (3rd party rate limiters).
 	// This override is applicable only if tokens for the flow aren't specified
 	// in the flow labels.
-	Tokens uint32 `protobuf:"varint,2,opt,name=tokens,proto3" json:"tokens,omitempty" validate:"gte=0"` // @gotags: validate:"gte=0"
+	Tokens uint32 `protobuf:"varint,2,opt,name=tokens,proto3" json:"tokens,omitempty" validate:"gte=0" default:"1"` // @gotags: validate:"gte=0" default:"1"
 	// Timeout for the flow in the workload.
 	// If timeout is provided on the Check call as well, the minimum of the two is picked.
 	// If this override is not provided, the timeout provided in the check call is used.

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -1903,10 +1903,10 @@
           "x-go-tag-validate": "required,gt=0,dive"
         },
         "workload_latency_based_tokens": {
-          "default": true,
+          "default": false,
           "description": "Automatically estimate the size of flows within each workload, based on\nhistorical latency. Each workload's `tokens` will be set to average\nlatency of flows in that workload during the last few seconds (exact duration\nof this average can change).\nThis setting is useful in concurrency limiting use-case, where the\nconcurrency is calculated as `(avg. latency \\* in-flight flows)` (Little's Law).\n\nThe value of tokens estimated takes a lower precedence\nthan the value of `tokens` specified in the workload definition\nand `tokens` explicitly specified in the flow labels.\n\n",
           "type": "boolean",
-          "x-go-tag-default": "true"
+          "x-go-tag-default": "false"
         }
       },
       "required": ["selectors"],
@@ -2946,10 +2946,12 @@
           "type": "string"
         },
         "tokens": {
+          "default": 1,
           "description": "Tokens determines the cost of admitting a single flow in the workload,\nwhich is typically defined as milliseconds of flow latency (time to response or duration of a feature) or\nsimply equal to 1 if the resource being accessed is constrained by the\nnumber of flows (3rd party rate limiters).\nThis override is applicable only if tokens for the flow aren't specified\nin the flow labels.\n\n",
           "format": "int64",
           "minimum": 0,
           "type": "integer",
+          "x-go-tag-default": "1",
           "x-go-tag-validate": "gte=0"
         }
       },

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2051,7 +2051,7 @@ definitions:
                 type: array
                 x-go-tag-validate: required,gt=0,dive
             workload_latency_based_tokens:
-                default: true
+                default: false
                 description: |+
                     Automatically estimate the size of flows within each workload, based on
                     historical latency. Each workload's `tokens` will be set to average
@@ -2065,7 +2065,7 @@ definitions:
                     and `tokens` explicitly specified in the flow labels.
 
                 type: boolean
-                x-go-tag-default: "true"
+                x-go-tag-default: "false"
         required:
             - selectors
         title: Parameters for _Load Scheduler_ component
@@ -3207,6 +3207,7 @@ definitions:
                     This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
                 type: string
             tokens:
+                default: 1
                 description: |+
                     Tokens determines the cost of admitting a single flow in the workload,
                     which is typically defined as milliseconds of flow latency (time to response or duration of a feature) or
@@ -3218,6 +3219,7 @@ definitions:
                 format: int64
                 minimum: 0
                 type: integer
+                x-go-tag-default: "1"
                 x-go-tag-validate: gte=0
         type: object
     Selector:

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -2523,7 +2523,7 @@ definitions:
                 type: array
                 x-go-tag-validate: required,gt=0,dive
             workload_latency_based_tokens:
-                default: true
+                default: false
                 description: |+
                     Automatically estimate the size of flows within each workload, based on
                     historical latency. Each workload's `tokens` will be set to average
@@ -2537,7 +2537,7 @@ definitions:
                     and `tokens` explicitly specified in the flow labels.
 
                 type: boolean
-                x-go-tag-default: "true"
+                x-go-tag-default: "false"
         required:
             - selectors
         title: Parameters for _Load Scheduler_ component
@@ -3848,6 +3848,7 @@ definitions:
                     This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
                 type: string
             tokens:
+                default: 1
                 description: |+
                     Tokens determines the cost of admitting a single flow in the workload,
                     which is typically defined as milliseconds of flow latency (time to response or duration of a feature) or
@@ -3859,6 +3860,7 @@ definitions:
                 format: int64
                 minimum: 0
                 type: integer
+                x-go-tag-default: "1"
                 x-go-tag-validate: gte=0
         type: object
     Selector:

--- a/docs/content/concepts/scheduler/scheduler.md
+++ b/docs/content/concepts/scheduler/scheduler.md
@@ -96,10 +96,10 @@ time window.
 Tokens are determined in the following order of precedence:
 
 - Specified in the flow labels.
-- Specified in the `Workload.tokens` setting.
 - Estimated tokens (see
   [`workload_latency_based_tokens`](/reference/configuration/spec.md#load-scheduler)
   setting).
+- Specified in the `Workload.tokens` setting.
 
 ### Queue Timeout {#queue-timeout}
 

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -4804,7 +4804,7 @@ Selectors for the component.
 
 <!-- vale off -->
 
-(bool, default: `true`)
+(bool, default: `false`)
 
 <!-- vale on -->
 
@@ -7393,7 +7393,7 @@ a value of "10s" would signify a duration of 10 seconds.
 
 <!-- vale off -->
 
-(int64, minimum: `0`)
+(int64, minimum: `0`, default: `1`)
 
 <!-- vale on -->
 

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -1998,7 +1998,7 @@ definitions:
                 type: array
                 x-go-tag-validate: required,gt=0,dive
             workload_latency_based_tokens:
-                default: true
+                default: false
                 description: |+
                     Automatically estimate the size of flows within each workload, based on
                     historical latency. Each workload's `tokens` will be set to average
@@ -2012,7 +2012,7 @@ definitions:
                     and `tokens` explicitly specified in the flow labels.
 
                 type: boolean
-                x-go-tag-default: "true"
+                x-go-tag-default: "false"
         required:
             - selectors
         title: Parameters for _Load Scheduler_ component
@@ -3134,6 +3134,7 @@ definitions:
                     This field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an "s" to indicate 'seconds.' For example, a value of "10s" would signify a duration of 10 seconds.
                 type: string
             tokens:
+                default: 1
                 description: |+
                     Tokens determines the cost of admitting a single flow in the workload,
                     which is typically defined as milliseconds of flow latency (time to response or duration of a feature) or
@@ -3145,6 +3146,7 @@ definitions:
                 format: int64
                 minimum: 0
                 type: integer
+                x-go-tag-default: "1"
                 x-go-tag-validate: gte=0
         type: object
     Selector:

--- a/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
+++ b/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
@@ -378,16 +378,16 @@ func (s *Scheduler) Decide(ctx context.Context, labels labels.Labels) iface.Limi
 	fairnessLabel := "workload:" + matchedWorkloadIndex
 
 	tokens := uint64(1)
-	// Precedence order (lowest to highest):
-	// 1. Estimated Tokens
-	// 2. Workload tokens
-	// 3. Label tokens
-	if tokensEstimated, ok := s.GetEstimatedTokens(matchedWorkloadIndex); ok {
-		tokens = tokensEstimated
-	}
-
+	// Precedence order:
+	// 1. Label tokens
+	// 2. Estimated Tokens
+	// 3. Workload tokens
 	if matchedWorkloadParametersProto.GetTokens() != 0 {
 		tokens = uint64(matchedWorkloadParametersProto.GetTokens())
+	}
+
+	if estimatedTokens, ok := s.GetEstimatedTokens(matchedWorkloadIndex); ok {
+		tokens = estimatedTokens
 	}
 
 	var matchedWorkloadTimeout time.Duration

--- a/playground/scenarios/basic-service-protection/policies/basic-service-protection-cr.yaml
+++ b/playground/scenarios/basic-service-protection/policies/basic-service-protection-cr.yaml
@@ -37,6 +37,7 @@ spec:
               - agent_group: default
                 control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - query:
         promql:

--- a/playground/scenarios/basic-service-protection/policies/basic-service-protection.yaml
+++ b/playground/scenarios/basic-service-protection/policies/basic-service-protection.yaml
@@ -10,6 +10,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection-cr.yaml
@@ -68,6 +68,7 @@ spec:
               - agent_group: default
                 control_point: egress
                 service: service2-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - query:
         promql:

--- a/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
+++ b/playground/scenarios/demo-app-fan-in/policies/weighted-service-protection.yaml
@@ -8,6 +8,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/elasticsearch-overload/policies/elasticsearch-overload.yaml
+++ b/playground/scenarios/elasticsearch-overload/policies/elasticsearch-overload.yaml
@@ -5,6 +5,7 @@ policy:
     dry_run: false
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/elasticsearch-overload/policies/service1-demoapp-elasticsearch-overload-cr.yaml
+++ b/playground/scenarios/elasticsearch-overload/policies/service1-demoapp-elasticsearch-overload-cr.yaml
@@ -37,6 +37,7 @@ spec:
               - agent_group: default
                 control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - query:
         promql:

--- a/playground/scenarios/graceful-js/policies/postgres-connections-cr.yaml
+++ b/playground/scenarios/graceful-js/policies/postgres-connections-cr.yaml
@@ -51,6 +51,7 @@ spec:
               - agent_group: default
                 control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - query:
         promql:

--- a/playground/scenarios/graceful-js/policies/postgres-connections.yaml
+++ b/playground/scenarios/graceful-js/policies/postgres-connections.yaml
@@ -28,6 +28,7 @@ policy:
     dry_run: false
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         selectors:
           - agent_group: default
             control_point: ingress

--- a/playground/scenarios/graceful-js/policies/workload-prioritization.yaml
+++ b/playground/scenarios/graceful-js/policies/workload-prioritization.yaml
@@ -23,6 +23,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection-cr.yaml
@@ -49,6 +49,7 @@ spec:
               - agent_group: default
                 control_point: awesomeFeature
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - decider:
         in_ports:

--- a/playground/scenarios/java-service-protection/policies/service-protection.yaml
+++ b/playground/scenarios/java-service-protection/policies/service-protection.yaml
@@ -69,6 +69,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/jmx-service-protection/policies/jmx-service-protection-cr.yaml
+++ b/playground/scenarios/jmx-service-protection/policies/jmx-service-protection-cr.yaml
@@ -49,6 +49,7 @@ spec:
               - agent_group: default
                 control_point: awesomeFeature
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - decider:
         in_ports:

--- a/playground/scenarios/jmx-service-protection/policies/jmx-service-protection.yaml
+++ b/playground/scenarios/jmx-service-protection/policies/jmx-service-protection.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../../../blueprints/load-scheduling/average-latency/gen/definitions.json
+# yaml-language-server: $schema=../../../../blueprints/load-scheduling/jmx/gen/definitions.json
 # Generated values file for load-scheduling/average-latency blueprint
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-scheduling/average-latency
@@ -69,6 +69,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True
@@ -95,4 +96,4 @@ policy:
       load_multiplier_linear_increment: 0.025
 
   jmx:
-    app_namespace: 'demoapp'
+    app_namespace: "demoapp"

--- a/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization-cr.yaml
+++ b/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization-cr.yaml
@@ -53,6 +53,7 @@ spec:
                     http.path: /api/v1/write
                     is_demo_app: "true"
                 service: controller-prometheus-server.aperture-controller.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - query:
         promql:

--- a/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization.yaml
+++ b/playground/scenarios/prometheus-workload-prioritization/policies/prometheus-workload-prioritization.yaml
@@ -49,6 +49,7 @@ policy:
       # Type: []aperture.spec.v1.Selector
       # Required: True
       load_scheduler:
+        workload_latency_based_tokens: true
         selectors:
           - agent_group: default
             control_point: ingress

--- a/playground/scenarios/rabbitmq-queue-buildup/policies/rabbitmq-queue-buildup.yaml
+++ b/playground/scenarios/rabbitmq-queue-buildup/policies/rabbitmq-queue-buildup.yaml
@@ -5,6 +5,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/rabbitmq-queue-buildup/policies/service1-demoapp-rabbitmq-queue-buildup-cr.yaml
+++ b/playground/scenarios/rabbitmq-queue-buildup/policies/service1-demoapp-rabbitmq-queue-buildup-cr.yaml
@@ -37,6 +37,7 @@ spec:
               - agent_group: default
                 control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - query:
         promql:

--- a/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale-cr.yaml
+++ b/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale-cr.yaml
@@ -36,6 +36,7 @@ spec:
               selectors:
               - control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - auto_scale:
         auto_scaler:

--- a/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale.yaml
+++ b/playground/scenarios/service-protection-auto-scale-escalation/policies/load-based-auto-scale.yaml
@@ -11,6 +11,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app-cr.yaml
@@ -55,6 +55,7 @@ spec:
                   match_labels:
                     http.target: /service1/request
                 service: kong-server.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - decider:
         in_ports:

--- a/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-kong/policies/service1-demo-app.yaml
@@ -72,6 +72,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app-cr.yaml
@@ -54,6 +54,7 @@ spec:
                   match_labels:
                     http.target: /service1
                 service: nginx-server.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - decider:
         in_ports:

--- a/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app.yaml
+++ b/playground/scenarios/service-protection-rl-escalation-nginx/policies/service1-demo-app.yaml
@@ -71,6 +71,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app-cr.yaml
+++ b/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app-cr.yaml
@@ -54,6 +54,7 @@ spec:
               - agent_group: default
                 control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - decider:
         in_ports:

--- a/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app.yaml
+++ b/playground/scenarios/service-protection-rl-escalation/policies/service1-demo-app.yaml
@@ -73,6 +73,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/playground/scenarios/workload-prioritization/policies/workload-prioritization-cr.yaml
+++ b/playground/scenarios/workload-prioritization/policies/workload-prioritization-cr.yaml
@@ -51,6 +51,7 @@ spec:
               - agent_group: default
                 control_point: ingress
                 service: service1-demo-app.demoapp.svc.cluster.local
+              workload_latency_based_tokens: true
             max_load_multiplier: 2
     - query:
         promql:

--- a/playground/scenarios/workload-prioritization/policies/workload-prioritization.yaml
+++ b/playground/scenarios/workload-prioritization/policies/workload-prioritization.yaml
@@ -23,6 +23,7 @@ policy:
   service_protection_core:
     adaptive_load_scheduler:
       load_scheduler:
+        workload_latency_based_tokens: true
         # The selectors determine the flows that are protected by this policy.
         # Type: []aperture.spec.v1.Selector
         # Required: True

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/generated/aperture/flowcontrol/check/v1/FlowControlServiceGrpc.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/generated/aperture/flowcontrol/check/v1/FlowControlServiceGrpc.java
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.57.2)",
+    value = "by gRPC proto compiler (version 1.58.0)",
     comments = "Source: aperture/flowcontrol/check/v1/check.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class FlowControlServiceGrpc {

--- a/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/generated/aperture/flowcontrol/checkhttp/v1/FlowControlServiceHTTPGrpc.java
+++ b/sdks/aperture-java/lib/core/src/main/java/com/fluxninja/generated/aperture/flowcontrol/checkhttp/v1/FlowControlServiceHTTPGrpc.java
@@ -5,7 +5,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.57.2)",
+    value = "by gRPC proto compiler (version 1.58.0)",
     comments = "Source: aperture/flowcontrol/checkhttp/v1/checkhttp.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class FlowControlServiceHTTPGrpc {


### PR DESCRIPTION
### Description of change

![screencapture-localhost-3000-d-1cafa24eadc87e0eeb9217b9179e31473bcfa21d-aperture-service-protection-2023-09-08-10_46_30](https://github.com/fluxninja/aperture/assets/1553055/514806eb-ceea-47f8-9f24-cee9c1d40c83)

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Changed the default value of `workload_latency_based_tokens` from `true` to `false` in `LoadScheduler` message to prevent unexpected behavior.
- Refactor: Set a default value of `1` and a minimum limit of `0` for `tokens` field in `Scheduler` message to ensure valid token allocation.
- Documentation: Updated the configuration specification and scheduler concept documents to reflect the changes in default and minimum values.
- New Feature: Modified the token allocation precedence in the `Decide` function of `Scheduler`. Label tokens now have the highest precedence, providing users with more control over token allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->