### PR TITLE
Hide prometheus datasource dropdown in grafana dashboard

### DIFF
--- a/blueprints/grafana/utils/base_dashboard.libsonnet
+++ b/blueprints/grafana/utils/base_dashboard.libsonnet
@@ -6,7 +6,8 @@ function(cfg) {
     var.datasource.new('datasource', 'prometheus')
     + var.datasource.generalOptions.withLabel('Data Source')
     + var.datasource.selectionOptions.withMulti(false)
-    + var.datasource.selectionOptions.withIncludeAll(false),
+    + var.datasource.selectionOptions.withIncludeAll(false)
+    + var.datasource.generalOptions.showOnDashboard.withNothing(),
 
   local dashboardDef =
     g.dashboard.new(cfg.dashboard.title)


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- New Feature: Enhanced the Grafana dashboard configuration with a new option in the data source settings. Users can now choose to display no data on the dashboard using the `var.datasource.generalOptions.showOnDashboard.withNothing()` method. This feature provides more flexibility in controlling what is displayed on the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->