### PR TITLE
Put control points in cache even if service doesn't exist

### DIFF
--- a/pkg/otelcollector/metricsprocessor/processor.go
+++ b/pkg/otelcollector/metricsprocessor/processor.go
@@ -348,6 +348,9 @@ func (p *metricsProcessor) updateMetricsForFluxMeters(
 }
 
 func (p *metricsProcessor) populateControlPointCache(checkResponse *flowcontrolv1.CheckResponse, controlPointType string) {
+	if len(checkResponse.GetServices()) == 0 {
+		p.cfg.controlPointCache.Put(selectors.NewTypedControlPointID(checkResponse.GetControlPoint(), controlPointType, ""))
+	}
 	for _, service := range checkResponse.GetServices() {
 		p.cfg.controlPointCache.Put(selectors.NewTypedControlPointID(checkResponse.GetControlPoint(), controlPointType, service))
 	}

--- a/sdks/aperture-go/README.md
+++ b/sdks/aperture-go/README.md
@@ -11,16 +11,16 @@ functionality on fine-grained features inside service code.
 
 ```go
  options := aperture.Options{
-  ClientConn: client,
-  // checkTimeout is the time that the client will wait for a response from Aperture Agent.
-  // if not provided, the default value of 200 milliseconds will be used.
-  CheckTimeout: 200 * time.Millisecond,
+    ClientConn: client,
+    // checkTimeout is the time that the client will wait for a response from Aperture Agent.
+    // if not provided, the default value of 200 milliseconds will be used.
+    CheckTimeout: 200 * time.Millisecond,
  }
 
  // initialize Aperture Client with the provided options.
  apertureClient, err := aperture.NewClient(options)
  if err != nil {
-  log.Fatalf("failed to create client: %v", err)
+    log.Fatalf("failed to create client: %v", err)
  }
 ```
 
@@ -32,16 +32,16 @@ functionality on fine-grained features inside service code.
  // StartFlow performs a flowcontrolv1.Check call to Aperture Agent. It returns a Flow and an error if any.
  flow, err := a.apertureClient.StartFlow(ctx, "awesomeFeature", labels)
  if err != nil {
-  log.Printf("Aperture flow control got error. Returned flow defaults to Allowed. flow.ShouldRun(): %t", flow.ShouldRun())
+    log.Printf("Aperture flow control got error. Returned flow defaults to Allowed. flow.ShouldRun(): %t", flow.ShouldRun())
  }
 
  // See whether flow was accepted by Aperture Agent.
  if flow.ShouldRun() {
-  // Simulate work being done
-  time.Sleep(5 * time.Second)
+    // Simulate work being done
+    time.Sleep(5 * time.Second)
  } else {
-  // Flow has been rejected by Aperture Agent.
-  flow.SetStatus(aperture.Error)
+    // Flow has been rejected by Aperture Agent.
+    flow.SetStatus(aperture.Error)
  }
  // Need to call End() on the Flow in order to provide telemetry to Aperture Agent for completing the control loop. SetStatus() method of Flow object can be used to capture whether the Flow was successful or resulted in an error. If not set, status defaults to OK.
  _ = flow.End()

--- a/sdks/aperture-go/go.mod
+++ b/sdks/aperture-go/go.mod
@@ -13,7 +13,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.15.1
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230726155614-23370e0ffb3e
 	google.golang.org/grpc v1.57.0

--- a/sdks/aperture-go/go.sum
+++ b/sdks/aperture-go/go.sum
@@ -40,8 +40,6 @@ go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLk
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=
 golang.org/x/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated `populateControlPointCache` function in `pkg/otelcollector/metricsprocessor/processor.go` to handle cases where there are no services in the response, improving the processing of control point IDs.
- Documentation: Enhanced readability and error handling instructions in `sdks/aperture-go/README.md`. Also updated sleep duration for better flow control.
- Refactor: Removed deprecated methods `HTTPMiddleware` and `GRPCUnaryInterceptor` from `apertureClient` struct in `sdks/aperture-go/sdk/client.go`, promoting use of updated middleware functions for improved modularity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->