### PR TITLE
aperture-js: improve failOpen handling

### DIFF
--- a/cmd/sdk-validator/main.go
+++ b/cmd/sdk-validator/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -271,6 +272,7 @@ func runDockerContainer(image string, port string) (string, error) {
 		}
 		if containerJSON.State != nil {
 			if containerJSON.State.Status == "exited" {
+				printContainerLogs(resp.ID)
 				log.Fatal().Msg("Container exited")
 			}
 			if containerJSON.State.Health != nil {
@@ -282,12 +284,28 @@ func runDockerContainer(image string, port string) (string, error) {
 	}
 }
 
+func printContainerLogs(id string) {
+	ctx := context.Background()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return
+	}
+	// print all container logs
+	out, err := cli.ContainerLogs(ctx, id, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
+	if err != nil {
+		return
+	}
+	_, _ = io.Copy(os.Stdout, out)
+}
+
 func stopDockerContainer(id string) error {
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}
+
+	printContainerLogs(id)
 
 	err = cli.ContainerStop(ctx, id, container.StopOptions{})
 	if err != nil {
@@ -320,11 +338,11 @@ func confirmConnectedAndStartTraffic(url string, requests int) int {
 
 func startTraffic(url string, requests int) int {
 	rejected := 0
-	superReq, err := http.NewRequest(http.MethodGet, url+"/super", nil)
-	if err != nil {
-		log.Error().Err(err).Str("url", superReq.URL.String()).Msg("Failed to create http request")
-	}
 	for i := 0; i < requests; i++ {
+		superReq, err := http.NewRequest(http.MethodGet, url+"/super", nil)
+		if err != nil {
+			log.Error().Err(err).Str("url", superReq.URL.String()).Msg("Failed to create http request")
+		}
 		res, err := http.DefaultClient.Do(superReq)
 		if err != nil {
 			log.Error().Err(err).Str("url", superReq.URL.String()).Msg("Failed to make http request")
@@ -332,7 +350,8 @@ func startTraffic(url string, requests int) int {
 		if res.Body != nil {
 			res.Body.Close()
 		}
-		if (res.StatusCode > 400 && res.StatusCode < 500) || (res.StatusCode > 500 && res.StatusCode < 600) {
+		if res.StatusCode >= 400 {
+			log.Trace().Int("status code", res.StatusCode).Msg("Request rejected")
 			rejected += 1
 		}
 	}

--- a/cmd/sdk-validator/main.go
+++ b/cmd/sdk-validator/main.go
@@ -47,7 +47,7 @@ var (
 func init() {
 	logLevel, logLevelSet := os.LookupEnv("LOG_LEVEL")
 	if !logLevelSet {
-		logLevel = log.DebugLevel.String()
+		logLevel = log.TraceLevel.String()
 	}
 	logger = log.NewLogger(log.GetPrettyConsoleWriter(), logLevel)
 	log.SetGlobalLogger(logger)

--- a/cmd/sdk-validator/validator/common.go
+++ b/cmd/sdk-validator/validator/common.go
@@ -45,7 +45,7 @@ func (c *CommonHandler) CheckRequest(ctx context.Context,
 		RejectReason:  flowcontrolv1.CheckResponse_REJECT_REASON_NONE,
 	}
 
-	if c.Rejected != c.Rejects && shouldBeTested(path) {
+	if c.Rejected < c.Rejects && shouldBeTested(path) {
 		log.Trace().Msg("Rejecting call")
 		resp.DecisionType = flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED
 		resp.RejectReason = flowcontrolv1.CheckResponse_REJECT_REASON_RATE_LIMITED

--- a/cmd/sdk-validator/validator/common.go
+++ b/cmd/sdk-validator/validator/common.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"context"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	flowcontrolv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/flowcontrol/check/v1"
 	"github.com/fluxninja/aperture/v2/pkg/log"
@@ -15,6 +15,7 @@ import (
 type CommonHandler struct {
 	check.HandlerWithValues
 
+	mutex    sync.Mutex
 	Rejects  int64
 	Rejected int64
 }
@@ -35,7 +36,7 @@ func (c *CommonHandler) CheckRequest(ctx context.Context,
 		log.Trace().Msg("Missing request path label")
 		path = targetLabelMissing
 	}
-	log.Trace().Msgf("Received FlowControl Check request from path %v", path)
+	log.Trace().Msgf("Received FlowControl Check request from path %v, control point %v, services %v", path, controlPoint, services)
 
 	resp := &flowcontrolv1.CheckResponse{
 		DecisionType:  flowcontrolv1.CheckResponse_DECISION_TYPE_ACCEPTED,
@@ -45,11 +46,13 @@ func (c *CommonHandler) CheckRequest(ctx context.Context,
 		RejectReason:  flowcontrolv1.CheckResponse_REJECT_REASON_NONE,
 	}
 
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	if c.Rejected < c.Rejects && shouldBeTested(path) {
 		log.Trace().Msg("Rejecting call")
 		resp.DecisionType = flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED
 		resp.RejectReason = flowcontrolv1.CheckResponse_REJECT_REASON_RATE_LIMITED
-		atomic.AddInt64(&c.Rejected, 1)
+		c.Rejected++
 	}
 
 	return resp

--- a/cmd/sdk-validator/validator/common.go
+++ b/cmd/sdk-validator/validator/common.go
@@ -49,10 +49,10 @@ func (c *CommonHandler) CheckRequest(ctx context.Context,
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if c.Rejected < c.Rejects && shouldBeTested(path) {
-		log.Trace().Msg("Rejecting call")
 		resp.DecisionType = flowcontrolv1.CheckResponse_DECISION_TYPE_REJECTED
 		resp.RejectReason = flowcontrolv1.CheckResponse_REJECT_REASON_RATE_LIMITED
 		c.Rejected++
+		log.Trace().Msgf("Rejecting request from path %v, control point %v, services %v, rejected %v", path, controlPoint, services, c.Rejected)
 	}
 
 	return resp

--- a/sdks/aperture-js/example/routes/connected.ts
+++ b/sdks/aperture-js/example/routes/connected.ts
@@ -7,7 +7,6 @@ export const connectedRouter = express.Router();
 connectedRouter.get("/", function (_: express.Request, res:express.Response) {
   try {
     let clientState = apertureClient.GetState();
-    console.log(`Client state ${clientState}`);
     if (clientState != grpc.connectivityState.READY) {
       res.status(503).send("Unavailable");
     } else {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -106,7 +106,6 @@ export class ApertureClient {
       ) {
         if (flow.failOpen) {
           // Accept the request if failOpen is true even if we encounter an error
-          console.log(`Aperture server unavailable. Accepting request.`);
           flow.checkResponse = null;
         } else {
           // Reject the request if failOpen is false if we encounter an error
@@ -128,11 +127,6 @@ export class ApertureClient {
           if (err) {
             if (flow.failOpen) {
               // Accept the request if failOpen is true even if we encounter an error
-              console.log(
-                `Aperture server unavailable due to ${JSON.stringify(
-                  err,
-                )}. Accepting request.`,
-              );
               flow.checkResponse = null;
             } else {
               // Reject the request if failOpen is false if we encounter an error

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -1,4 +1,5 @@
 import grpc from "@grpc/grpc-js";
+import { ConnectivityState } from "@grpc/grpc-js/build/src/connectivity-state.js";
 import * as otelApi from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
 import { Resource } from "@opentelemetry/resources";
@@ -6,8 +7,6 @@ import { BatchSpanProcessor, Tracer } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 
-import { Flow } from "./flow.js";
-import { fcs, FlowControlService } from "./utils.js";
 import {
   FLOW_START_TIMESTAMP_LABEL,
   LIBRARY_NAME,
@@ -16,12 +15,13 @@ import {
   URL,
   WORKLOAD_START_TIMESTAMP_LABEL,
 } from "./consts.js";
+import { Flow } from "./flow.js";
+import { fcs, FlowControlService } from "./utils.js";
 
 /**
  * Types to be exported from package
  */
 export type { FlowControlService, Flow };
-
 export { grpc };
 
 type ControlPoint = unknown;
@@ -59,6 +59,16 @@ export class ApertureClient {
     this.tracer = this.tracerProvider.getTracer(LIBRARY_NAME, LIBRARY_VERSION);
 
     this.timeout = timeout;
+
+    const kickChannel = () => {
+      const state = this.fcsClient.getChannel().getConnectivityState(true);
+      if (state != ConnectivityState.SHUTDOWN) {
+        this.fcsClient
+          .getChannel()
+          .watchConnectivityState(state, Infinity, kickChannel);
+      }
+    };
+    kickChannel();
   }
 
   // StartFlow takes a control point and labels that get passed to Aperture Agent via flowcontrolv1.Check call.
@@ -87,9 +97,28 @@ export class ApertureClient {
         checkParams = { deadline: Date.now() + this.timeout };
       }
 
+      // check connection state
+      // if not ready, return flow with fail-to-wire semantics
+      // if ready, call check
+      if (
+        this.fcsClient.getChannel().getConnectivityState(true) !=
+        ConnectivityState.READY
+      ) {
+        if (flow.failOpen) {
+          // Accept the request if failOpen is true even if we encounter an error
+          console.log(`Aperture server unavailable. Accepting request.`);
+          flow.checkResponse = null;
+        } else {
+          // Reject the request if failOpen is false if we encounter an error
+          reject("Aperture server unavailable");
+        }
+        resolve(flow);
+        return;
+      }
+
       this.fcsClient.Check(
         {
-          control_point: controlPointArg,
+          controlPoint: controlPointArg,
           labels: mergedLabels,
         },
         checkParams,
@@ -120,7 +149,7 @@ export class ApertureClient {
   }
 
   Shutdown() {
-    grpc.closeClient(this.fcsClient);
+    this.fcsClient.getChannel().close();
     this.exporter.shutdown();
     this.tracerProvider.shutdown();
     return;

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -1,5 +1,4 @@
-import grpc from "@grpc/grpc-js";
-import { ConnectivityState } from "@grpc/grpc-js/build/src/connectivity-state.js";
+import grpc, { connectivityState } from "@grpc/grpc-js";
 import * as otelApi from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
 import { Resource } from "@opentelemetry/resources";
@@ -62,7 +61,7 @@ export class ApertureClient {
 
     const kickChannel = () => {
       const state = this.fcsClient.getChannel().getConnectivityState(true);
-      if (state != ConnectivityState.SHUTDOWN) {
+      if (state != connectivityState.SHUTDOWN) {
         this.fcsClient
           .getChannel()
           .watchConnectivityState(state, Infinity, kickChannel);
@@ -102,7 +101,7 @@ export class ApertureClient {
       // if ready, call check
       if (
         this.fcsClient.getChannel().getConnectivityState(true) !=
-        ConnectivityState.READY
+        connectivityState.READY
       ) {
         if (flow.failOpen) {
           // Accept the request if failOpen is true even if we encounter an error

--- a/sdks/aperture-js/sdk/utils.ts
+++ b/sdks/aperture-js/sdk/utils.ts
@@ -43,7 +43,7 @@ export abstract class FlowControlService extends Client {
 }
 
 const clientPackage = protoLoader.loadSync(PROTO_PATH, {
-  keepCase: false,
+  keepCase: true,
   longs: String,
   enums: String,
   defaults: true,

--- a/sdks/aperture-js/sdk/utils.ts
+++ b/sdks/aperture-js/sdk/utils.ts
@@ -22,7 +22,7 @@ export type ApertureGrpcObject = {
   };
 };
 
-type CheckOptions1 = { control_point: unknown; labels: unknown };
+type CheckOptions1 = { controlPoint: unknown; labels: unknown };
 
 type CheckOptions2 = {
   deadline: number;
@@ -43,7 +43,7 @@ export abstract class FlowControlService extends Client {
 }
 
 const clientPackage = protoLoader.loadSync(PROTO_PATH, {
-  keepCase: true,
+  keepCase: false, // NOTE: make sure we are using camelCase to access the proto
   longs: String,
   enums: String,
   defaults: true,


### PR DESCRIPTION






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a `kickChannel` function in the Aperture JS SDK to monitor and reestablish the connectivity state of the channel, improving reliability.
- Refactor: Updated the `StartFlow` method in the Aperture JS SDK to check the connectivity state before making the `Check` call, enhancing error handling.
- Refactor: Replaced atomic operations with mutex locks in the SDK Validator for better thread safety.
- Bug Fix: Fixed an issue in the SDK Validator where requests were not correctly rejected based on the condition. Now, it checks if `c.Rejected` is less than `c.Rejects`.
- Chore: Changed the default log level from `DebugLevel` to `TraceLevel` in the SDK Validator for more detailed logging.
- Style: Updated field names in protobuf loading to preserve their original case in the Aperture JS SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->