### PR TITLE
aperture-js: rename some variables

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "aperture-js is an SDK to interact with Aperture Agent.",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Renamed `timeout` parameter to `timeoutMilliseconds` in `ApertureClient` class for better clarity, and set its default value to 200 milliseconds.
- Refactor: Improved gRPC call handling by calculating the `deadline` based on the `timeoutMilliseconds` value.
- Refactor: Enhanced encapsulation by changing `fcsClient`, `exporter`, `tracerProvider`, and `tracer` properties from public to private in `ApertureClient` class. This change is not expected to impact end-users as these are internal implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->