### PR TITLE
aperture-js: use record type for peroperties

### DIFF
--- a/sdks/aperture-js/example/routes/use_aperture.ts
+++ b/sdks/aperture-js/example/routes/use_aperture.ts
@@ -8,7 +8,7 @@ export const apertureClient = new ApertureClient();
 export const apertureRoute = express.Router();
 apertureRoute.get("/", function (_: express.Request, res: express.Response) {
   // do some business logic to collect labels
-  const labels: { [key: string]: string } = {
+  const labels: Record<string, string> = {
     user: "kenobi",
   };
 

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -71,7 +71,7 @@ export class ApertureClient {
   // The default semantics are fail-to-wire. If StartFlow fails, calling Flow.ShouldRun() on returned Flow returns as true.
   async StartFlow(
     controlPointArg: string,
-    labelsArg: { [key: string]: string },
+    labels: Record<string, string> = {},
     failOpen: boolean = true,
   ): Promise<Flow> {
     return new Promise<Flow>((resolve) => {
@@ -93,7 +93,7 @@ export class ApertureClient {
           return;
         }
 
-        let labelsBaggage = {} as { [key: string]: string };
+        let labelsBaggage = {} as Record<string, string>;
         let baggage = otelApi.propagation.getBaggage(otelApi.context.active());
 
         if (baggage !== undefined) {
@@ -102,7 +102,7 @@ export class ApertureClient {
           }
         }
 
-        let mergedLabels = { ...labelsArg, ...labelsBaggage };
+        let mergedLabels = { ...labels, ...labelsBaggage };
 
         let checkParams: grpc.CallOptions = {};
         if (this.timeoutMilliseconds != 0) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Improved type safety in `use_aperture.ts` and `client.ts` by replacing `{ [key: string]: string }` with the built-in `Record<string, string>` type for label declarations.
- Refactor: Simplified the merging of `labelsArg` and `labelsBaggage` into `mergedLabels` using the spread operator in `StartFlow` method of `ApertureClient` class in `client.ts`.
  
These changes enhance code readability and maintainability without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->