### PR TITLE
aperture-js: set longs to strings

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -38,7 +38,7 @@ buf-generate:
 		set -e; \
 		pushd ../sdks/aperture-js; \
 		npm install; \
-		node ./node_modules/@grpc/proto-loader/build/bin/proto-loader-gen-types.js --defaults=true --outDir=sdk/gen --grpcLib=@grpc/grpc-js proto/flowcontrol/check/v1/check.proto; \
+		node ./node_modules/@grpc/proto-loader/build/bin/proto-loader-gen-types.js --defaults=true --longs=String --outDir=sdk/gen --grpcLib=@grpc/grpc-js proto/flowcontrol/check/v1/check.proto; \
 		git add ./sdk/gen; \
 		popd; \
 	}

--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "aperture-js is an SDK to interact with Aperture Agent.",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/gen/aperture/flowcontrol/check/v1/ClassifierInfo.ts
+++ b/sdks/aperture-js/sdk/gen/aperture/flowcontrol/check/v1/ClassifierInfo.ts
@@ -39,6 +39,6 @@ export interface ClassifierInfo {
 export interface ClassifierInfo__Output {
   'policyName': (string);
   'policyHash': (string);
-  'classifierIndex': (Long);
+  'classifierIndex': (string);
   'error': (_aperture_flowcontrol_check_v1_ClassifierInfo_Error__Output);
 }

--- a/sdks/aperture-js/sdk/gen/aperture/flowcontrol/check/v1/LimiterDecision.ts
+++ b/sdks/aperture-js/sdk/gen/aperture/flowcontrol/check/v1/LimiterDecision.ts
@@ -57,7 +57,7 @@ export interface _aperture_flowcontrol_check_v1_LimiterDecision_SchedulerInfo {
 
 export interface _aperture_flowcontrol_check_v1_LimiterDecision_SchedulerInfo__Output {
   'workloadIndex': (string);
-  'tokensConsumed': (Long);
+  'tokensConsumed': (string);
 }
 
 export interface LimiterDecision {

--- a/sdks/aperture-js/sdk/gen/google/protobuf/Duration.ts
+++ b/sdks/aperture-js/sdk/gen/google/protobuf/Duration.ts
@@ -8,6 +8,6 @@ export interface Duration {
 }
 
 export interface Duration__Output {
-  'seconds': (Long);
+  'seconds': (string);
   'nanos': (number);
 }

--- a/sdks/aperture-js/sdk/gen/google/protobuf/Timestamp.ts
+++ b/sdks/aperture-js/sdk/gen/google/protobuf/Timestamp.ts
@@ -8,6 +8,6 @@ export interface Timestamp {
 }
 
 export interface Timestamp__Output {
-  'seconds': (Long);
+  'seconds': (string);
   'nanos': (number);
 }

--- a/sdks/aperture-js/sdk/utils.ts
+++ b/sdks/aperture-js/sdk/utils.ts
@@ -7,6 +7,7 @@ import { ProtoGrpcType } from "./gen/check.js";
 
 const clientPackage = protoLoader.loadSync(PROTO_PATH, {
   defaults: true,
+  longs: String,
 });
 
 export const fcs = (


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- New Feature: Updated the build script and SDK utility to handle long integer fields in protocol buffers. These fields will now be represented as strings in the generated TypeScript types, improving compatibility and precision in JavaScript environments. This change is transparent to end-users but enhances the robustness of our data handling processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->