### PR TITLE
Added milli second support for time based attributes in SDK

### DIFF
--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -126,12 +126,18 @@ const (
 
 	/* SDK specific labels. */
 
-	// ApertureFlowStartTimestampLabel is the start timestamp of the flow.
+	// ApertureFlowStartTimestampLabel is the start timestamp of the flow in nano seconds.
 	ApertureFlowStartTimestampLabel = "aperture.flow_start_timestamp"
-	// ApertureFlowEndTimestampLabel is the end timestamp of the flow.
+	// ApertureFlowStartTimestampLabelMs is the start timestamp of the flow in milli seconds.
+	ApertureFlowStartTimestampLabelMs = "aperture.flow_start_timestamp_ms"
+	// ApertureFlowEndTimestampLabel is the end timestamp of the flow in nano seconds.
 	ApertureFlowEndTimestampLabel = "aperture.flow_end_timestamp"
-	// ApertureWorkloadStartTimestampLabel is the start timestamp of the workload.
+	// ApertureFlowEndTimestampLabelMs is the end timestamp of the flow in milli seconds.
+	ApertureFlowEndTimestampLabelMs = "aperture.flow_end_timestamp_ms"
+	// ApertureWorkloadStartTimestampLabel is the start timestamp of the workload in nano seconds.
 	ApertureWorkloadStartTimestampLabel = "aperture.workload_start_timestamp"
+	// ApertureWorkloadStartTimestampLabelMs is the start timestamp of the workload in milli seconds.
+	ApertureWorkloadStartTimestampLabelMs = "aperture.workload_start_timestamp_ms"
 
 	/* Aperture specific enrichment labels. */
 

--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -127,14 +127,17 @@ const (
 	/* SDK specific labels. */
 
 	// ApertureFlowStartTimestampLabel is the start timestamp of the flow in nano seconds.
+	// Deprecated: v3.0.0. Use `aperture.flow_start_timestamp_ms` instead.
 	ApertureFlowStartTimestampLabel = "aperture.flow_start_timestamp"
 	// ApertureFlowStartTimestampLabelMs is the start timestamp of the flow in milli seconds.
 	ApertureFlowStartTimestampLabelMs = "aperture.flow_start_timestamp_ms"
 	// ApertureFlowEndTimestampLabel is the end timestamp of the flow in nano seconds.
+	// Deprecated: v3.0.0. Use `aperture.flow_end_timestamp_ms` instead.
 	ApertureFlowEndTimestampLabel = "aperture.flow_end_timestamp"
 	// ApertureFlowEndTimestampLabelMs is the end timestamp of the flow in milli seconds.
 	ApertureFlowEndTimestampLabelMs = "aperture.flow_end_timestamp_ms"
 	// ApertureWorkloadStartTimestampLabel is the start timestamp of the workload in nano seconds.
+	// Deprecated: v3.0.0. Use `aperture.workload_start_timestamp_ms` instead.
 	ApertureWorkloadStartTimestampLabel = "aperture.workload_start_timestamp"
 	// ApertureWorkloadStartTimestampLabelMs is the start timestamp of the workload in milli seconds.
 	ApertureWorkloadStartTimestampLabelMs = "aperture.workload_start_timestamp_ms"

--- a/pkg/otelcollector/metricsprocessor/internal/sdk_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/sdk_labels.go
@@ -13,19 +13,19 @@ import (
 // AddSDKSpecificLabels adds labels specific to SDK data source.
 func AddSDKSpecificLabels(attributes pcommon.Map) {
 	// Compute durations
-	flowStart, flowStartExists := getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowStartTimestampLabel)
+	flowStart, flowStartExists := getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowStartTimestampLabelMs)
 	if !flowStartExists {
-		flowStart, flowStartExists = getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowStartTimestampLabelMs)
+		flowStart, flowStartExists = getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowStartTimestampLabel)
 	}
 
-	workloadStart, workloadStartExists := getSDKLabelTimestampValue(attributes, otelconsts.ApertureWorkloadStartTimestampLabel)
+	workloadStart, workloadStartExists := getSDKLabelTimestampValue(attributes, otelconsts.ApertureWorkloadStartTimestampLabelMs)
 	if !workloadStartExists {
-		workloadStart, workloadStartExists = getSDKLabelTimestampValue(attributes, otelconsts.ApertureWorkloadStartTimestampLabelMs)
+		workloadStart, workloadStartExists = getSDKLabelTimestampValue(attributes, otelconsts.ApertureWorkloadStartTimestampLabel)
 	}
 
-	flowEnd, flowEndExists := getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowEndTimestampLabel)
+	flowEnd, flowEndExists := getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowEndTimestampLabelMs)
 	if !flowEndExists {
-		flowEnd, flowEndExists = getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowEndTimestampLabelMs)
+		flowEnd, flowEndExists = getSDKLabelTimestampValue(attributes, otelconsts.ApertureFlowEndTimestampLabel)
 	}
 
 	// Add ResponseReceivedLabel based on whether flowEnd is present

--- a/pkg/otelcollector/metricsprocessor/internal/sdk_labels_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/sdk_labels_test.go
@@ -1,6 +1,8 @@
 package internal_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -23,15 +25,29 @@ var _ = DescribeTable("SDK labels", func(before map[string]int64, after map[stri
 },
 	Entry("Sets flow duration",
 		map[string]int64{
-			otelconsts.ApertureFlowStartTimestampLabel: 123e6,
-			otelconsts.ApertureFlowEndTimestampLabel:   246e6,
+			otelconsts.ApertureFlowStartTimestampLabel: (time.Millisecond * 123).Nanoseconds(),
+			otelconsts.ApertureFlowEndTimestampLabel:   (time.Millisecond * 246).Nanoseconds(),
 		},
 		map[string]float64{otelconsts.FlowDurationLabel: 123},
 	),
 	Entry("Sets workload duration",
 		map[string]int64{
-			otelconsts.ApertureWorkloadStartTimestampLabel: 123e6,
-			otelconsts.ApertureFlowEndTimestampLabel:       246e6,
+			otelconsts.ApertureWorkloadStartTimestampLabel: (time.Millisecond * 123).Nanoseconds(),
+			otelconsts.ApertureFlowEndTimestampLabel:       (time.Millisecond * 246).Nanoseconds(),
+		},
+		map[string]float64{otelconsts.WorkloadDurationLabel: 123},
+	),
+	Entry("Sets flow ms duration",
+		map[string]int64{
+			otelconsts.ApertureFlowStartTimestampLabelMs: (time.Millisecond * 123).Milliseconds(),
+			otelconsts.ApertureFlowEndTimestampLabelMs:   (time.Millisecond * 246).Milliseconds(),
+		},
+		map[string]float64{otelconsts.FlowDurationLabel: 123},
+	),
+	Entry("Sets workload ms duration",
+		map[string]int64{
+			otelconsts.ApertureWorkloadStartTimestampLabelMs: (time.Millisecond * 123).Milliseconds(),
+			otelconsts.ApertureFlowEndTimestampLabelMs:       (time.Millisecond * 246).Milliseconds(),
 		},
 		map[string]float64{otelconsts.WorkloadDurationLabel: 123},
 	),

--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "aperture-js is an SDK to interact with Aperture Agent.",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/consts.ts
+++ b/sdks/aperture-js/sdk/consts.ts
@@ -24,9 +24,9 @@ export const FLOW_STATUS_LABEL = "aperture.flow.status";
 // Label to hold JSON encoded check response struct.
 export const CHECK_RESPONSE_LABEL = "aperture.check_response";
 // Label to hold flow's start timestamp in Unix nanoseconds since Epoch.
-export const FLOW_START_TIMESTAMP_LABEL = "aperture.flow_start_timestamp";
+export const FLOW_START_TIMESTAMP_LABEL = "aperture.flow_start_timestamp_ms";
 // Label to hold flow's stop timestamp in Unix nanoseconds since Epoch.
-export const FLOW_END_TIMESTAMP_LABEL = "aperture.flow_end_timestamp";
+export const FLOW_END_TIMESTAMP_LABEL = "aperture.flow_end_timestamp_ms";
 // Label to hold workload start timestamp in Unix nanoseconds since Epoch.
 export const WORKLOAD_START_TIMESTAMP_LABEL =
-  "aperture.workload_start_timestamp";
+  "aperture.workload_start_timestamp_ms";

--- a/sdks/aperture-js/sdk/flow.ts
+++ b/sdks/aperture-js/sdk/flow.ts
@@ -32,8 +32,8 @@ export class Flow {
     private error: Error | null = null,
   ) {
     span.setAttribute(SOURCE_LABEL, "sdk");
-    span.setAttribute(FLOW_START_TIMESTAMP_LABEL, startDate * 1000);
-    span.setAttribute(WORKLOAD_START_TIMESTAMP_LABEL, Date.now() * 1000);
+    span.setAttribute(FLOW_START_TIMESTAMP_LABEL, startDate);
+    span.setAttribute(WORKLOAD_START_TIMESTAMP_LABEL, Date.now());
   }
 
   ShouldRun() {
@@ -103,7 +103,7 @@ export class Flow {
 
     this.span.setAttribute(FLOW_STATUS_LABEL, this.status);
 
-    this.span.setAttribute(FLOW_END_TIMESTAMP_LABEL, Date.now() * 1000);
+    this.span.setAttribute(FLOW_END_TIMESTAMP_LABEL, Date.now());
 
     this.span.end();
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced millisecond timestamp labels for flow start, flow end, and workload start timestamps. This change provides more precise time tracking in the SDK.
- Refactor: Updated `AddSDKSpecificLabels` and `_getLabelTimestampValue` functions to handle both nanosecond and millisecond timestamp labels. This ensures backward compatibility with older versions of the SDK that use nanosecond timestamps.
- Test: Modified test cases to accommodate changes in timestamp label handling, ensuring the new functionality is thoroughly tested.
- Chore: Deprecated certain labels in favor of new ones with millisecond timestamps, aligning with version 3.0.0 of the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->