### PR TITLE
aperturectl: Fail early on unsupported commands with Cloud Controller

### DIFF
--- a/cmd/aperturectl/cmd/agents.go
+++ b/cmd/aperturectl/cmd/agents.go
@@ -20,7 +20,7 @@ var agentsCmd = &cobra.Command{
 	PersistentPreRunE: controller.PreRunE,
 	PersistentPostRun: controller.PostRun,
 	RunE: func(*cobra.Command, []string) error {
-		client, err := controller.Client()
+		client, err := controller.IntrospectionClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/apply/root.go
+++ b/cmd/aperturectl/cmd/apply/root.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
 )
 
@@ -13,7 +12,7 @@ var (
 	// Controller is the controller connection object.
 	Controller utils.ControllerConn
 
-	client       cmdv1.ControllerClient
+	client       utils.PolicyClient
 	controllerNs string
 )
 
@@ -40,7 +39,7 @@ Use this command to apply the Aperture Policies.`,
 
 		controllerNs = utils.GetControllerNs()
 
-		client, err = Controller.Client()
+		client, err = Controller.PolicyClient()
 		if err != nil {
 			return fmt.Errorf("failed to get controller client: %w", err)
 		}

--- a/cmd/aperturectl/cmd/autoscale/control-points.go
+++ b/cmd/aperturectl/cmd/autoscale/control-points.go
@@ -20,7 +20,7 @@ var ControlPointsCmd = &cobra.Command{
 	SilenceErrors: true,
 	Example:       `aperturectl auto-scale control-points`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		client, err := controller.Client()
+		client, err := controller.IntrospectionClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/decisions/root.go
+++ b/cmd/aperturectl/cmd/decisions/root.go
@@ -69,7 +69,7 @@ var DecisionsCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := controller.Client()
+		client, err := controller.PolicyClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/delete/root.go
+++ b/cmd/aperturectl/cmd/delete/root.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
 )
 
 var (
 	controller   utils.ControllerConn
-	client       cmdv1.ControllerClient
+	client       utils.PolicyClient
 	controllerNs string
 	policyName   string
 )
@@ -44,7 +43,7 @@ Use this command to delete the Aperture Policies.`,
 
 		controllerNs = utils.GetControllerNs()
 
-		client, err = controller.Client()
+		client, err = controller.PolicyClient()
 		if err != nil {
 			return fmt.Errorf("failed to get controller client: %w", err)
 		}

--- a/cmd/aperturectl/cmd/discovery/entities.go
+++ b/cmd/aperturectl/cmd/discovery/entities.go
@@ -30,7 +30,7 @@ aperturectl discovery entities --find-by="name=service1-demo-app-7dfdf9c698-4wml
 
 aperturectl discovery entities --find-by=“ip=10.244.1.24”`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		client, err := controller.Client()
+		client, err := controller.IntrospectionClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/flowcontrol/control-points.go
+++ b/cmd/aperturectl/cmd/flowcontrol/control-points.go
@@ -20,7 +20,7 @@ var ControlPointsCmd = &cobra.Command{
 	SilenceErrors: true,
 	Example:       `aperturectl flow-control control-points`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		client, err := controller.Client()
+		client, err := controller.IntrospectionClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/flowcontrol/preview.go
+++ b/cmd/aperturectl/cmd/flowcontrol/preview.go
@@ -36,7 +36,7 @@ var PreviewCmd = &cobra.Command{
 	SilenceErrors: true,
 	Args:          cobra.ExactArgs(2),
 	RunE: func(_ *cobra.Command, args []string) error {
-		client, err := controller.Client()
+		client, err := controller.IntrospectionClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/policies.go
+++ b/cmd/aperturectl/cmd/policies.go
@@ -22,7 +22,7 @@ var policiesCmd = &cobra.Command{
 	PersistentPreRunE: controller.PreRunE,
 	PersistentPostRun: controller.PostRun,
 	RunE: func(*cobra.Command, []string) error {
-		client, err := controller.Client()
+		client, err := controller.PolicyClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/status/root.go
+++ b/cmd/aperturectl/cmd/status/root.go
@@ -34,7 +34,7 @@ var StatusCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, err := controller.Client()
+		client, err := controller.StatusClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/aperturectl/cmd/utils/controller-client.go
+++ b/cmd/aperturectl/cmd/utils/controller-client.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"context"
+
+	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
+	v1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
+	v11 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/status/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// IntrospectionClient is a subset of cmdv1.ControllerClient that covers APIs
+// that need controller to grab information from agents via reverse rpc.
+//
+// These are currently not supported for the cloud controller.
+//
+// FIXME: Perhaps it'd be better to split the service on proto level (keep backcompat in mind).
+type IntrospectionClient interface {
+	ListAgents(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*cmdv1.ListAgentsResponse, error)
+	// Seems to be unimplemented on the controller at all?!
+	ListServices(ctx context.Context, in *cmdv1.ListServicesRequest, opts ...grpc.CallOption) (*cmdv1.ListServicesControllerResponse, error)
+	ListFlowControlPoints(ctx context.Context, in *cmdv1.ListFlowControlPointsRequest, opts ...grpc.CallOption) (*cmdv1.ListFlowControlPointsControllerResponse, error)
+	ListAutoScaleControlPoints(ctx context.Context, in *cmdv1.ListAutoScaleControlPointsRequest, opts ...grpc.CallOption) (*cmdv1.ListAutoScaleControlPointsControllerResponse, error)
+	ListDiscoveryEntities(ctx context.Context, in *cmdv1.ListDiscoveryEntitiesRequest, opts ...grpc.CallOption) (*cmdv1.ListDiscoveryEntitiesControllerResponse, error)
+	ListDiscoveryEntity(ctx context.Context, in *cmdv1.ListDiscoveryEntityRequest, opts ...grpc.CallOption) (*cmdv1.ListDiscoveryEntityAgentResponse, error)
+	PreviewFlowLabels(ctx context.Context, in *cmdv1.PreviewFlowLabelsRequest, opts ...grpc.CallOption) (*cmdv1.PreviewFlowLabelsControllerResponse, error)
+	PreviewHTTPRequests(ctx context.Context, in *cmdv1.PreviewHTTPRequestsRequest, opts ...grpc.CallOption) (*cmdv1.PreviewHTTPRequestsControllerResponse, error)
+}
+
+// IntrospectionClient is a subset of cmdv1.ControllerClient that covers APIs related to policies.
+//
+// FIXME: Perhaps it'd be better to split the service on proto level (keep backcompat in mind).
+type PolicyClient interface {
+	ListPolicies(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*v1.GetPoliciesResponse, error)
+	UpsertPolicy(ctx context.Context, in *v1.UpsertPolicyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	PostDynamicConfig(ctx context.Context, in *v1.PostDynamicConfigRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DeletePolicy(ctx context.Context, in *v1.DeletePolicyRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	GetDecisions(ctx context.Context, in *v1.GetDecisionsRequest, opts ...grpc.CallOption) (*v1.GetDecisionsResponse, error)
+}
+
+// IntrospectionClient is a subset of cmdv1.ControllerClient that covers APIs related to status.
+//
+// FIXME: Perhaps it'd be better to split the service on proto level (keep backcompat in mind).
+type StatusClient interface {
+	GetStatus(ctx context.Context, in *v11.GroupStatusRequest, opts ...grpc.CallOption) (*v11.GroupStatus, error)
+}

--- a/cmd/aperturectl/cmd/utils/controller-client.go
+++ b/cmd/aperturectl/cmd/utils/controller-client.go
@@ -28,7 +28,7 @@ type IntrospectionClient interface {
 	PreviewHTTPRequests(ctx context.Context, in *cmdv1.PreviewHTTPRequestsRequest, opts ...grpc.CallOption) (*cmdv1.PreviewHTTPRequestsControllerResponse, error)
 }
 
-// IntrospectionClient is a subset of cmdv1.ControllerClient that covers APIs related to policies.
+// PolicyClient is a subset of cmdv1.ControllerClient that covers APIs related to policies.
 //
 // FIXME: Perhaps it'd be better to split the service on proto level (keep backcompat in mind).
 type PolicyClient interface {
@@ -39,7 +39,7 @@ type PolicyClient interface {
 	GetDecisions(ctx context.Context, in *v1.GetDecisionsRequest, opts ...grpc.CallOption) (*v1.GetDecisionsResponse, error)
 }
 
-// IntrospectionClient is a subset of cmdv1.ControllerClient that covers APIs related to status.
+// StatusClient is a subset of cmdv1.ControllerClient that covers APIs related to status.
 //
 // FIXME: Perhaps it'd be better to split the service on proto level (keep backcompat in mind).
 type StatusClient interface {

--- a/cmd/aperturectl/cmd/utils/controller.go
+++ b/cmd/aperturectl/cmd/utils/controller.go
@@ -192,8 +192,30 @@ func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-// Client returns Controller Client, connecting to controller if not yet connected.
-func (c *ControllerConn) Client() (cmdv1.ControllerClient, error) {
+// client returns Controller IntrospectionClient, connecting to controller if not yet connected.
+func (c *ControllerConn) IntrospectionClient() (IntrospectionClient, error) {
+	if !c.kube && c.apiKey != "" {
+		return nil, errors.New("this subcommand cannot be used with the Cloud Controller")
+	}
+	return c.client()
+}
+
+// client returns Controller PolicyClient, connecting to controller if not yet connected.
+func (c *ControllerConn) PolicyClient() (PolicyClient, error) {
+	// PolicyClient has no restrictions.
+	return c.client()
+}
+
+// client returns Controller StatusClient, connecting to controller if not yet connected.
+func (c *ControllerConn) StatusClient() (StatusClient, error) {
+	// StatusClient has no restrictions.
+	return c.client()
+}
+
+// client returns Controller Client, connecting to controller if not yet connected.
+//
+// This functions is not exposed to force callers to go through the check above.
+func (c *ControllerConn) client() (cmdv1.ControllerClient, error) {
 	if c.conn != nil {
 		return cmdv1.NewControllerClient(c.conn), nil
 	}


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Introduced new client interfaces `IntrospectionClient`, `PolicyClient`, and `StatusClient` for more specific API interactions.
- New Feature: Updated various commands in the CLI application to use the new client interfaces, enhancing modularity and specificity of operations.
- Refactor: Renamed `Controller.Client()` method to `Controller.IntrospectionClient()`, and added `Controller.PolicyClient()` and `Controller.StatusClient()` methods for improved functionality segregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->