### PR TITLE
Set log timestamp format to include nanoseconds

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -61,7 +61,7 @@ var global *Logger
 
 // Always create a global logger instance.
 func init() {
-	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.TimeFieldFormat = time.RFC3339Nano
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 	zerolog.CallerMarshalFunc = func(_ uintptr, file string, line int) string {
 		// short caller format


### PR DESCRIPTION
### Description of change
Ref #2585
##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Updated the global logger instance to use `time.RFC3339Nano` for more precise timestamp logging.
- Refactor: Enhanced the `zerolog.ErrorStackMarshaler` and `zerolog.CallerMarshalFunc` functions for improved error tracking and caller information.

These changes will provide more detailed logs, aiding in debugging and system monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->