### PR TITLE
Revert "Set log timestamp format to include nanoseconds (#2614)"

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -61,7 +61,7 @@ var global *Logger
 
 // Always create a global logger instance.
 func init() {
-	zerolog.TimeFieldFormat = time.RFC3339Nano
+	zerolog.TimeFieldFormat = time.RFC3339
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 	zerolog.CallerMarshalFunc = func(_ uintptr, file string, line int) string {
 		// short caller format


### PR DESCRIPTION
This reverts commit d6547ee1cd90b4339b95ac5b0e739ce68e7a1bfd.

### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Updated the timestamp format in log messages. The global logger instance now uses `time.RFC3339` instead of `time.RFC3339Nano`. This change affects the presentation of timestamps in log outputs, making them less granular but more readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->