### PR TITLE
token bucket: allow 0 capacity buckets

### DIFF
--- a/cmd/sdk-validator/validator/flowcontrol.go
+++ b/cmd/sdk-validator/validator/flowcontrol.go
@@ -31,6 +31,11 @@ func (f *FlowControlHandler) Check(ctx context.Context, req *flowcontrolv1.Check
 		services = append(services, rpcPeer.Addr.String())
 	}
 
+	// log the deadline of the request
+	if deadline, ok := ctx.Deadline(); ok {
+		log.Trace().Msgf("Deadline: %s, timeout: %s", deadline, time.Until(deadline))
+	}
+
 	start := time.Now()
 	resp := f.CommonHandler.CheckRequest(ctx, iface.RequestContext{
 		FlowLabels:   labels.PlainMap(req.Labels),

--- a/pkg/rate-limiter/global-token-bucket/global-token-bucket.go
+++ b/pkg/rate-limiter/global-token-bucket/global-token-bucket.go
@@ -120,10 +120,6 @@ func (gtb *GlobalTokenBucket) TakeIfAvailable(ctx context.Context, label string,
 		return true, 0, 0, 0
 	}
 
-	if gtb.GetBucketCapacity() == 0 {
-		return false, 0, 0, 0
-	}
-
 	if isMarginExceeded(ctx) {
 		return false, 0, 0, 0
 	}
@@ -169,10 +165,6 @@ func (gtb *GlobalTokenBucket) TakeIfAvailable(ctx context.Context, label string,
 func (gtb *GlobalTokenBucket) Take(ctx context.Context, label string, n float64) (bool, time.Duration, float64, float64) {
 	if gtb.GetPassThrough() {
 		return true, 0, 0, 0
-	}
-
-	if gtb.GetBucketCapacity() == 0 {
-		return false, 0, 0, 0
 	}
 
 	deadline := time.Time{}

--- a/sdks/aperture-js/example/routes/use_aperture.ts
+++ b/sdks/aperture-js/example/routes/use_aperture.ts
@@ -3,7 +3,9 @@ import express from "express";
 import { ApertureClient, FlowStatusEnum } from "@fluxninja/aperture-js";
 
 // Create aperture client
-export const apertureClient = new ApertureClient();
+export const apertureClient = new ApertureClient({
+  timeoutMilliseconds: 300000,
+});
 
 export const apertureRoute = express.Router();
 apertureRoute.get("/", function (_: express.Request, res: express.Response) {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -1,17 +1,17 @@
-import grpc, {connectivityState} from "@grpc/grpc-js";
+import grpc, { connectivityState } from "@grpc/grpc-js";
 import * as otelApi from "@opentelemetry/api";
-import {OTLPTraceExporter} from "@opentelemetry/exporter-trace-otlp-grpc";
-import {Resource} from "@opentelemetry/resources";
-import {BatchSpanProcessor, Tracer} from "@opentelemetry/sdk-trace-base";
-import {NodeTracerProvider} from "@opentelemetry/sdk-trace-node";
-import {SemanticResourceAttributes} from "@opentelemetry/semantic-conventions";
-import {CheckRequest} from "./gen/aperture/flowcontrol/check/v1/CheckRequest.js";
-import {CheckResponse__Output} from "./gen/aperture/flowcontrol/check/v1/CheckResponse.js";
-import {FlowControlServiceClient} from "./gen/aperture/flowcontrol/check/v1/FlowControlService.js";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
+import { Resource } from "@opentelemetry/resources";
+import { BatchSpanProcessor, Tracer } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { CheckRequest } from "./gen/aperture/flowcontrol/check/v1/CheckRequest.js";
+import { CheckResponse__Output } from "./gen/aperture/flowcontrol/check/v1/CheckResponse.js";
+import { FlowControlServiceClient } from "./gen/aperture/flowcontrol/check/v1/FlowControlService.js";
 
-import {LIBRARY_NAME, LIBRARY_VERSION, URL} from "./consts.js";
-import {Flow} from "./flow.js";
-import {fcs} from "./utils.js";
+import { LIBRARY_NAME, LIBRARY_VERSION, URL } from "./consts.js";
+import { Flow } from "./flow.js";
+import { fcs } from "./utils.js";
 
 export class ApertureClient {
   private readonly fcsClient: FlowControlServiceClient;


### PR DESCRIPTION
0 capacity buckets should be allowed, and there is no reason in the code that this leads to any issues.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added logging for request deadline and timeout in `cmd/sdk-validator/validator/flowcontrol.go` to improve debugging capabilities.
- Refactor: Simplified the logic in `pkg/rate-limiter/global-token-bucket/global-token-bucket.go` by removing unnecessary check for bucket capacity, enhancing code readability and maintainability.
- New Feature: Increased the timeout for requests made by the `ApertureClient` in `sdks/aperture-js/example/routes/use_aperture.ts`, improving user experience during network latency.
- Style: Improved code readability in `sdks/aperture-js/sdk/client.ts` by reformatting import statements and overall code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->