### PR TITLE
Fixed aperturectl cloud command addition

### DIFF
--- a/cmd/aperturectl/cmd/cloud/root.go
+++ b/cmd/aperturectl/cmd/cloud/root.go
@@ -4,10 +4,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/cloud/apply"
+	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/cloud/delete"
 )
 
 func init() {
-	CloudCmd.AddCommand(apply.ApplyPolicyCmd)
+	CloudCmd.AddCommand(apply.ApplyCmd)
+	CloudCmd.AddCommand(delete.DeleteCmd)
 }
 
 // CloudCmd is the command to apply a policy to the Cloud Controller.

--- a/docs/content/reference/aperturectl/cloud/apply/apply.md
+++ b/docs/content/reference/aperturectl/cloud/apply/apply.md
@@ -1,0 +1,33 @@
+---
+sidebar_label: Apply
+hide_title: true
+keywords:
+  - aperturectl
+  - aperturectl_cloud_apply
+---
+
+<!-- markdownlint-disable -->
+
+## aperturectl cloud apply
+
+Apply Aperture Policies to the Cloud Controller
+
+### Synopsis
+
+Use this command to apply the Aperture Policies to the Cloud Controller.
+
+### Options
+
+```
+      --api-key string      Aperture Cloud API Key to be used when using Cloud Controller
+      --config string       Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
+      --controller string   Address of Aperture Cloud Controller
+  -h, --help                help for apply
+      --insecure            Allow connection to controller running without TLS
+      --skip-verify         Skip TLS certificate verification while connecting to controller
+```
+
+### SEE ALSO
+
+- [aperturectl cloud](/reference/aperturectl/cloud/cloud.md) - Commands to communicate with the Cloud Controller
+- [aperturectl cloud apply policy](/reference/aperturectl/cloud/apply/policy/policy.md) - Apply Aperture Policy to the Aperture Cloud Controller

--- a/docs/content/reference/aperturectl/cloud/apply/policy/policy.md
+++ b/docs/content/reference/aperturectl/cloud/apply/policy/policy.md
@@ -3,12 +3,12 @@ sidebar_label: Policy
 hide_title: true
 keywords:
   - aperturectl
-  - aperturectl_cloud_policy
+  - aperturectl_cloud_apply_policy
 ---
 
 <!-- markdownlint-disable -->
 
-## aperturectl cloud policy
+## aperturectl cloud apply policy
 
 Apply Aperture Policy to the Aperture Cloud Controller
 
@@ -17,7 +17,7 @@ Apply Aperture Policy to the Aperture Cloud Controller
 Use this command to apply the Aperture Policy to the Aperture Cloud Controller.
 
 ```
-aperturectl cloud policy [flags]
+aperturectl cloud apply policy [flags]
 ```
 
 ### Examples
@@ -38,6 +38,16 @@ aperturectl cloud apply policy --dir=policies --controller ORGANIZATION_NAME.app
   -s, --select-all    Apply all policies in the directory
 ```
 
+### Options inherited from parent commands
+
+```
+      --api-key string      Aperture Cloud API Key to be used when using Cloud Controller
+      --config string       Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
+      --controller string   Address of Aperture Cloud Controller
+      --insecure            Allow connection to controller running without TLS
+      --skip-verify         Skip TLS certificate verification while connecting to controller
+```
+
 ### SEE ALSO
 
-- [aperturectl cloud](/reference/aperturectl/cloud/cloud.md) - Commands to communicate with the Cloud Controller
+- [aperturectl cloud apply](/reference/aperturectl/cloud/apply/apply.md) - Apply Aperture Policies to the Cloud Controller

--- a/docs/content/reference/aperturectl/cloud/cloud.md
+++ b/docs/content/reference/aperturectl/cloud/cloud.md
@@ -25,4 +25,5 @@ Use this command to talk to the Cloud Controller.
 ### SEE ALSO
 
 - [aperturectl](/reference/aperturectl/aperturectl.md) - aperturectl - CLI tool to interact with Aperture
-- [aperturectl cloud policy](/reference/aperturectl/cloud/policy/policy.md) - Apply Aperture Policy to the Aperture Cloud Controller
+- [aperturectl cloud apply](/reference/aperturectl/cloud/apply/apply.md) - Apply Aperture Policies to the Cloud Controller
+- [aperturectl cloud delete](/reference/aperturectl/cloud/delete/delete.md) - Delete Aperture Policies from Aperture Cloud

--- a/docs/content/reference/aperturectl/cloud/delete/delete.md
+++ b/docs/content/reference/aperturectl/cloud/delete/delete.md
@@ -1,0 +1,34 @@
+---
+sidebar_label: Delete
+hide_title: true
+keywords:
+  - aperturectl
+  - aperturectl_cloud_delete
+---
+
+<!-- markdownlint-disable -->
+
+## aperturectl cloud delete
+
+Delete Aperture Policies from Aperture Cloud
+
+### Synopsis
+
+Use this command to delete the Aperture Policies from Aperture Cloud.
+
+### Options
+
+```
+      --api-key string      Aperture Cloud API Key to be used when using Cloud Controller
+      --config string       Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
+      --controller string   Address of Aperture Cloud Controller
+  -h, --help                help for delete
+      --insecure            Allow connection to controller running without TLS
+      --policy string       Name of the Policy to delete
+      --skip-verify         Skip TLS certificate verification while connecting to controller
+```
+
+### SEE ALSO
+
+- [aperturectl cloud](/reference/aperturectl/cloud/cloud.md) - Commands to communicate with the Cloud Controller
+- [aperturectl cloud delete policy](/reference/aperturectl/cloud/delete/policy/policy.md) - Delete Aperture Policy from the Aperture Cloud Controller

--- a/docs/content/reference/aperturectl/cloud/delete/policy/policy.md
+++ b/docs/content/reference/aperturectl/cloud/delete/policy/policy.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: Policy
+hide_title: true
+keywords:
+  - aperturectl
+  - aperturectl_cloud_delete_policy
+---
+
+<!-- markdownlint-disable -->
+
+## aperturectl cloud delete policy
+
+Delete Aperture Policy from the Aperture Cloud Controller
+
+### Synopsis
+
+Use this command to delete the Aperture Policy from the Aperture Cloud Controller.
+
+```
+aperturectl cloud delete policy [flags]
+```
+
+### Examples
+
+```
+aperturectl cloud delete policy --policy=rate-limiting --controller ORGANIZATION_NAME.app.fluxninja.com:443 --api-key API_KEY
+```
+
+### Options
+
+```
+  -h, --help   help for policy
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string      Aperture Cloud API Key to be used when using Cloud Controller
+      --config string       Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
+      --controller string   Address of Aperture Cloud Controller
+      --insecure            Allow connection to controller running without TLS
+      --policy string       Name of the Policy to delete
+      --skip-verify         Skip TLS certificate verification while connecting to controller
+```
+
+### SEE ALSO
+
+- [aperturectl cloud delete](/reference/aperturectl/cloud/delete/delete.md) - Delete Aperture Policies from Aperture Cloud


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added two new commands to the `aperturectl` CLI tool, `apply.ApplyCmd` and `delete.DeleteCmd`, enhancing user control over policy application and resource deletion in the Cloud Controller.
- Documentation: Updated and added comprehensive documentation for the new commands, including usage examples and options. Renamed `aperturectl cloud policy` to `aperturectl cloud apply policy` for clarity and consistency.
- User Impact: These changes provide users with more precise command options for managing Aperture policies, improving usability and efficiency of the `aperturectl` tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->