### PR TITLE
Use aperturectl cloud subcommand in playground

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -1093,7 +1093,7 @@ jobs:
           name: Apply Policy
           working_directory: .
           command: |
-            go run ./cmd/aperturectl/main.go apply policy --file ./playground/scenarios/<< parameters.scenario-name >>/policies/<< parameters.policy-name >>-cr.yaml \
+            go run ./cmd/aperturectl/main.go cloud apply policy --file ./playground/scenarios/<< parameters.scenario-name >>/policies/<< parameters.policy-name >>-cr.yaml \
             --controller << parameters.controller-endpoint >> --api-key ${CONTROLLER_API_KEY} -f -s
       - save_cache:
           name: Save go cache

--- a/playground/scripts/render-policy.sh
+++ b/playground/scripts/render-policy.sh
@@ -39,9 +39,9 @@ if [[ "${api_key}" != '' && "${endpoint}" != '' ]]; then
 
 	rendered_policy="${_GEN_DIR}/policies/${new_policy_name}-cr.yaml"
 	if [[ "${action}" == "apply" ]]; then
-		"${aperturectl}" apply policy --file "${rendered_policy}" --controller "${endpoint}" --api-key "${api_key}" "${skipverify}" -f -s >&2
+		"${aperturectl}" cloud apply policy --file "${rendered_policy}" --controller "${endpoint}" --api-key "${api_key}" "${skipverify}" -f -s >&2
 	else
-		"${aperturectl}" delete policy --policy "${new_policy_name}" --controller "${endpoint}" --api-key "${api_key}" "${skipverify}" >&2
+		"${aperturectl}" cloud delete policy --policy "${new_policy_name}" --controller "${endpoint}" --api-key "${api_key}" "${skipverify}" >&2
 	fi
 else
 	"${aperturectl}" blueprints generate --name "${blueprint_name}" --uri "${blueprints_uri}" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Extended `aperturectl` tool to support cloud-related operations. Users can now apply and delete policies in a cloud environment using the "cloud apply policy" and "cloud delete policy" subcommands respectively.
- Refactor: Updated CI/CD pipeline to include the new `cloud` argument for the `go run` command, ensuring continuous integration and deployment processes are aligned with the latest features of the `aperturectl` tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->