### PR TITLE
global token bucket: delay filling when bucket has tokens

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -111,7 +111,7 @@ message RateLimiter {
 
   // Inputs for the RateLimiter component
   message Ins {
-    // Capacity of the bucket.
+    // Capacity of the bucket to allow for bursty traffic. The bucket is given a chance to empty out before the filling starts.
     InPort bucket_capacity = 1; // @gotags: validate:"required"
     // Number of tokens to fill within an `interval`.
     InPort fill_amount = 2; // @gotags: validate:"required"

--- a/api/buf.lock
+++ b/api/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: 972458cb2988476bb126cae881cc3469
-    digest: shake256:4861668a1f688af8f0312feb923d2c6fb8106a360b4d5a7885afa56b0da017e69108316c9618881f0121b1c0176ec973122ae61fc4273941ec41c0e7a7e38b0c
+    commit: fca14c4204644e47b3c6667f09c9a627
+    digest: shake256:dcee0b6a7de626bb5e33ae754a96cd4b7ee5bdb8383ca9dc22778ea3dbe45517bc52809961336e7ca76248cd5df4f1571c07a075bc25d7348e17bd1be271821c
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
@@ -34,8 +34,8 @@ deps:
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry
-    commit: 2ad07e196ee74068901737616c3f9e6c
-    digest: shake256:b3ac419a36c0ab35b3d05ac4425cb6d824f8d8dbdebf12dd71f6f7ef6e728a527251080d22dddcfeae104840457153bf4f70e890562d120e76c609958c386fdc
+    commit: c5370fbbc76844b595972771b6888e08
+    digest: shake256:1cd6aa4b458ae4874f645bc35cb667c19e1edcced751a0f409c96b85110c7cbb52aab415898a9034c591fa0f3d92086824bba3b6f923cd72c26a24a44c5fa3f8
   - remote: buf.build
     owner: prometheus
     repository: client-model

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -2026,7 +2026,7 @@ type RateLimiter_Ins struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Capacity of the bucket.
+	// Capacity of the bucket to allow for bursty traffic. The bucket is given a chance to empty out before the filling starts.
 	BucketCapacity *InPort `protobuf:"bytes,1,opt,name=bucket_capacity,json=bucketCapacity,proto3" json:"bucket_capacity,omitempty" validate:"required"` // @gotags: validate:"required"
 	// Number of tokens to fill within an `interval`.
 	FillAmount *InPort `protobuf:"bytes,2,opt,name=fill_amount,json=fillAmount,proto3" json:"fill_amount,omitempty" validate:"required"` // @gotags: validate:"required"

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -2542,7 +2542,7 @@
       "properties": {
         "bucket_capacity": {
           "$ref": "#/definitions/InPort",
-          "description": "Capacity of the bucket.\n\n",
+          "description": "Capacity of the bucket to allow for bursty traffic. The bucket is given a chance to empty out before the filling starts.\n\n",
           "x-go-tag-validate": "required"
         },
         "fill_amount": {

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2675,7 +2675,7 @@ definitions:
             bucket_capacity:
                 $ref: '#/definitions/InPort'
                 description: |+
-                    Capacity of the bucket.
+                    Capacity of the bucket to allow for bursty traffic. The bucket is given a chance to empty out before the filling starts.
 
                 x-go-tag-validate: required
             fill_amount:

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -3268,7 +3268,7 @@ definitions:
             bucket_capacity:
                 $ref: '#/definitions/InPort'
                 description: |+
-                    Capacity of the bucket.
+                    Capacity of the bucket to allow for bursty traffic. The bucket is given a chance to empty out before the filling starts.
 
                 x-go-tag-validate: required
             fill_amount:

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -6307,7 +6307,8 @@ Inputs for the RateLimiter component
 
 <!-- vale on -->
 
-Capacity of the bucket.
+Capacity of the bucket to allow for bursty traffic. The bucket is given a chance
+to empty out before the filling starts.
 
 </dd>
 <dt>fill_amount</dt>

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -2602,7 +2602,7 @@ definitions:
             bucket_capacity:
                 $ref: '#/definitions/InPort'
                 description: |+
-                    Capacity of the bucket.
+                    Capacity of the bucket to allow for bursty traffic. The bucket is given a chance to empty out before the filling starts.
 
                 x-go-tag-validate: required
             fill_amount:


### PR DESCRIPTION

<img width="1399" alt="Screenshot 2023-09-14 at 5 02 48 PM" src="https://github.com/fluxninja/aperture/assets/18579817/f10009bd-e226-4119-b568-b20f379382f1">
<img width="1400" alt="Screenshot 2023-09-14 at 5 02 34 PM" src="https://github.com/fluxninja/aperture/assets/18579817/cb46078d-5f83-4725-90dc-9843f55f1cf3">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Improved the functionality of the `GlobalTokenBucket` in the rate-limiter package. The update introduces a mechanism to control token generation based on the start fill time, preventing more tokens than the fill rate in a given time window while using burst capacity.
- Documentation: Updated comments for the `bucket_capacity` field in the `RateLimiter` component and the "Capacity of the bucket" parameter in the configuration specification. The new descriptions provide better clarity on how the capacity allows for bursty traffic and gives the bucket a chance to empty out before filling starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->