### PR TITLE
Fixed job name conflict in background scheduler when multiple policies are deployed

### DIFF
--- a/pkg/policies/controlplane/runtime/background-scheduler.go
+++ b/pkg/policies/controlplane/runtime/background-scheduler.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	statusv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/status/v1"
@@ -51,7 +52,8 @@ func BackgroundSchedulerModuleForPolicyApp(circuitAPI CircuitSuperAPI) fx.Option
 		jws = append(jws, scheduler)
 
 		// Create backgroundMultiJob for running background jobs in this circuit
-		backgroundMultiJob := jobs.NewMultiJob(jobGroup.GetStatusRegistry().Child("policy", circuitAPI.GetPolicyName()), jws, nil)
+		jobName := fmt.Sprintf("policy-%s", circuitAPI.GetPolicyHash())
+		backgroundMultiJob := jobs.NewMultiJob(jobGroup.GetStatusRegistry().Child(jobName, circuitAPI.GetPolicyName()), jws, nil)
 		scheduler.multiJob = backgroundMultiJob
 
 		executionPeriod := config.MakeDuration(-1)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Updated the `background-scheduler.go` in the control plane runtime to enhance job tracking. Now, each job is assigned a unique name derived from the policy hash, improving the visibility and traceability of individual jobs within the system. This change will not affect the end-user experience but will significantly aid in system maintenance and debugging processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->