### PR TITLE
rename FN_AGENT_* to APERTURE_AGENT_*

### DIFF
--- a/docs/content/integrations/sdk/javascript/manual.md
+++ b/docs/content/integrations/sdk/javascript/manual.md
@@ -17,8 +17,8 @@ JavaScript SDK</a> can be used to manually set feature control points within a
 JavaScript service.
 
 To do so, first create an instance of ApertureClient. Agent host and port will
-be read from environment variables `FN_AGENT_HOST` and `FN_AGENT_PORT`,
-defaulting to localhost:8089.
+be read from environment variables `APERTURE_AGENT_HOST` and
+`APERTURE_AGENT_PORT`, defaulting to localhost:8089.
 
 ```javascript
 export const apertureClient = new ApertureClient();

--- a/playground/resources/java-demo-app/src/main/java/com/javademoapp/javademoapp/RequestController.java
+++ b/playground/resources/java-demo-app/src/main/java/com/javademoapp/javademoapp/RequestController.java
@@ -142,9 +142,9 @@ public class RequestController {
 
         registrationBean.setFilter(apertureFilter);
         registrationBean.addUrlPatterns("/request");
-        registrationBean.addInitParameter("agent_host", System.getenv().getOrDefault("FN_AGENT_HOST", DEFAULT_HOST));
+        registrationBean.addInitParameter("agent_host", System.getenv().getOrDefault("APERTURE_AGENT_HOST", DEFAULT_HOST));
         registrationBean.addInitParameter("agent_port",
-                System.getenv().getOrDefault("FN_AGENT_PORT", DEFAULT_AGENT_PORT));
+                System.getenv().getOrDefault("APERTURE_AGENT_PORT", DEFAULT_AGENT_PORT));
         registrationBean.addInitParameter("control_point_name", "awesomeFeature");
         registrationBean.addInitParameter("enable_fail_open", "true");
         registrationBean.addInitParameter("insecure_grpc", "true");

--- a/playground/tanka/charts/java-demo-app/templates/deployment.yaml
+++ b/playground/tanka/charts/java-demo-app/templates/deployment.yaml
@@ -52,9 +52,9 @@ spec:
           env:
             - name: SIMPLE_SERVICE_PORT
               value: "8099"
-            - name: FN_AGENT_HOST
+            - name: APERTURE_AGENT_HOST
               value: "{{ .Values.agent.host }}"
-            - name: FN_AGENT_PORT
+            - name: APERTURE_AGENT_PORT
               value: "{{ .Values.agent.port }}"
             - name: REJECT_RATIO
               value: "{{ .Values.simplesrv.rejectRatio }}"

--- a/playground/tanka/lib/apps/aperture-sdk-example/aperture-sdk-example.libsonnet
+++ b/playground/tanka/lib/apps/aperture-sdk-example/aperture-sdk-example.libsonnet
@@ -45,8 +45,8 @@ function(values={}, environment={}) {
       ])
       + container.withEnvMap({
         FN_APP_PORT: std.toString(_values.app_port),
-        FN_AGENT_HOST: _values.agent.host,
-        FN_AGENT_PORT: std.toString(_values.agent.port),
+        APERTURE_AGENT_HOST: _values.agent.host,
+        APERTURE_AGENT_PORT: std.toString(_values.agent.port),
       }),
     ])
     + deployment.metadata.withNamespace(_environment.namespace)

--- a/sdks/aperture-go/example/main.go
+++ b/sdks/aperture-go/example/main.go
@@ -49,8 +49,8 @@ func grpcClient(ctx context.Context, address string) (*grpc.ClientConn, error) {
 }
 
 func main() {
-	agentHost := getEnvOrDefault("FN_AGENT_HOST", defaultAgentHost)
-	agentPort := getEnvOrDefault("FN_AGENT_PORT", defaultAgentPort)
+	agentHost := getEnvOrDefault("APERTURE_AGENT_HOST", defaultAgentHost)
+	agentPort := getEnvOrDefault("APERTURE_AGENT_PORT", defaultAgentPort)
 
 	ctx := context.Background()
 

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaClient.java
@@ -19,11 +19,11 @@ public class ArmeriaClient {
     public static final String DEFAULT_ROOT_CERT = "";
 
     public static void main(String[] args) {
-        String agentHost = System.getenv("FN_AGENT_HOST");
+        String agentHost = System.getenv("APERTURE_AGENT_HOST");
         if (agentHost == null) {
             agentHost = DEFAULT_AGENT_HOST;
         }
-        String agentPort = System.getenv("FN_AGENT_PORT");
+        String agentPort = System.getenv("APERTURE_AGENT_PORT");
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }

--- a/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
+++ b/sdks/aperture-java/examples/armeria-example/src/main/java/com/fluxninja/example/ArmeriaServer.java
@@ -47,11 +47,11 @@ public class ArmeriaServer {
     }
 
     public static void main(String[] args) {
-        String agentHost = System.getenv("FN_AGENT_HOST");
+        String agentHost = System.getenv("APERTURE_AGENT_HOST");
         if (agentHost == null) {
             agentHost = DEFAULT_AGENT_HOST;
         }
-        String agentPort = System.getenv("FN_AGENT_PORT");
+        String agentPort = System.getenv("APERTURE_AGENT_PORT");
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }

--- a/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
+++ b/sdks/aperture-java/examples/netty-example/src/main/java/com/fluxninja/example/NettyServer.java
@@ -18,11 +18,11 @@ public class NettyServer {
     public static final String DEFAULT_ROOT_CERT = "";
 
     public static void main(String[] args) throws Exception {
-        String agentHost = System.getenv("FN_AGENT_HOST");
+        String agentHost = System.getenv("APERTURE_AGENT_HOST");
         if (agentHost == null) {
             agentHost = DEFAULT_AGENT_HOST;
         }
-        String agentPort = System.getenv("FN_AGENT_PORT");
+        String agentPort = System.getenv("APERTURE_AGENT_PORT");
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/SpringBootApp.java
@@ -17,16 +17,16 @@ public class SpringBootApp {
     public static final String DEFAULT_ROOT_CERT = "";
 
     public static void main(String[] args) {
-        String agentHost = System.getenv("FN_AGENT_HOST");
+        String agentHost = System.getenv("APERTURE_AGENT_HOST");
         if (agentHost == null) {
             agentHost = DEFAULT_AGENT_HOST;
         }
-        System.setProperty("FN_AGENT_HOST", agentHost);
-        String agentPort = System.getenv("FN_AGENT_PORT");
+        System.setProperty("APERTURE_AGENT_HOST", agentHost);
+        String agentPort = System.getenv("APERTURE_AGENT_PORT");
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }
-        System.setProperty("FN_AGENT_PORT", agentPort);
+        System.setProperty("APERTURE_AGENT_PORT", agentPort);
         String appPort = System.getenv("FN_APP_PORT");
         if (appPort == null) {
             appPort = DEFAULT_APP_PORT;

--- a/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
+++ b/sdks/aperture-java/examples/spring-example/src/main/java/com/fluxninja/example/controller/AppController.java
@@ -41,9 +41,9 @@ public class AppController {
         registrationBean.setFilter(new ApertureFilter());
         registrationBean.addUrlPatterns("/super");
 
-        String agentHost = env.getProperty("FN_AGENT_HOST");
+        String agentHost = env.getProperty("APERTURE_AGENT_HOST");
         registrationBean.addInitParameter("agent_host", agentHost);
-        String agentPort = env.getProperty("FN_AGENT_PORT");
+        String agentPort = env.getProperty("APERTURE_AGENT_PORT");
         registrationBean.addInitParameter("agent_port", agentPort);
         String failOpen = env.getProperty("FN_ENABLE_FAIL_OPEN");
         registrationBean.addInitParameter("enable_fail_open", failOpen);
@@ -68,9 +68,9 @@ public class AppController {
         registrationBean.setFilter(new ApertureFeatureFilter());
         registrationBean.addUrlPatterns("/super2");
 
-        String agentHost = env.getProperty("FN_AGENT_HOST");
+        String agentHost = env.getProperty("APERTURE_AGENT_HOST");
         registrationBean.addInitParameter("agent_host", agentHost);
-        String agentPort = env.getProperty("FN_AGENT_PORT");
+        String agentPort = env.getProperty("APERTURE_AGENT_PORT");
         registrationBean.addInitParameter("agent_port", agentPort);
         String failOpen = env.getProperty("FN_ENABLE_FAIL_OPEN");
         registrationBean.addInitParameter("enable_fail_open", failOpen);

--- a/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-example/src/main/java/com/fluxninja/example/App.java
@@ -33,11 +33,11 @@ public class App {
     }
 
     public static void main(String[] args) {
-        String agentHost = System.getenv("FN_AGENT_HOST");
+        String agentHost = System.getenv("APERTURE_AGENT_HOST");
         if (agentHost == null) {
             agentHost = DEFAULT_AGENT_HOST;
         }
-        String agentPort = System.getenv("FN_AGENT_PORT");
+        String agentPort = System.getenv("APERTURE_AGENT_PORT");
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }

--- a/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
+++ b/sdks/aperture-java/examples/standalone-traffic-flow-example/src/main/java/com/fluxninja/example/App.java
@@ -33,11 +33,11 @@ public class App {
     }
 
     public static void main(String[] args) {
-        String agentHost = System.getenv("FN_AGENT_HOST");
+        String agentHost = System.getenv("APERTURE_AGENT_HOST");
         if (agentHost == null) {
             agentHost = DEFAULT_AGENT_HOST;
         }
-        String agentPort = System.getenv("FN_AGENT_PORT");
+        String agentPort = System.getenv("APERTURE_AGENT_PORT");
         if (agentPort == null) {
             agentPort = DEFAULT_AGENT_PORT;
         }

--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.14",
-  "description": "aperture-js is an SDK to interact with Aperture Agent.",
+  "version": "2.0.15",
+  "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {
     "prebuild": "rm -rf ./lib",

--- a/sdks/aperture-js/sdk/consts.ts
+++ b/sdks/aperture-js/sdk/consts.ts
@@ -8,10 +8,10 @@ export const PROTO_PATH = path.resolve(
   "../proto/flowcontrol/check/v1/check.proto",
 );
 
-const fn_host = process.env.FN_AGENT_HOST
-  ? process.env.FN_AGENT_HOST
+const fn_host = process.env.APERTURE_AGENT_HOST
+  ? process.env.APERTURE_AGENT_HOST
   : "localhost";
-const fn_port = process.env.FN_AGENT_PORT ? process.env.FN_AGENT_PORT : "8089";
+const fn_port = process.env.APERTURE_AGENT_PORT ? process.env.APERTURE_AGENT_PORT : "8089";
 export const URL = fn_host + ":" + fn_port;
 
 export const LIBRARY_NAME = "aperture-js";

--- a/sdks/aperture-py/example/main.py
+++ b/sdks/aperture-py/example/main.py
@@ -11,8 +11,8 @@ from quart import Quart
 defaultAgentHost = "localhost"
 defaultAgentPort = "8089"
 
-agentHost = os.getenv("FN_AGENT_HOST", defaultAgentHost)
-agentPort = os.getenv("FN_AGENT_PORT", defaultAgentPort)
+agentHost = os.getenv("APERTURE_AGENT_HOST", defaultAgentHost)
+agentPort = os.getenv("APERTURE_AGENT_PORT", defaultAgentPort)
 
 app = Quart(__name__)
 aperture_client = ApertureClient.new_client(


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated environment variable names across multiple SDKs and examples. The variables `FN_AGENT_HOST` and `FN_AGENT_PORT` have been renamed to `APERTURE_AGENT_HOST` and `APERTURE_AGENT_PORT`, respectively, for consistency and clarity.
- Chore: Aligned the naming convention across JavaScript, Java, Go, and Python SDKs, improving maintainability and reducing potential confusion.
- Documentation: Updated the manual for the JavaScript SDK to reflect the changes in environment variable names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->