### PR TITLE
aperture-js: allow setting timeout per check call

### DIFF
--- a/sdks/aperture-js/example/routes/use_aperture.ts
+++ b/sdks/aperture-js/example/routes/use_aperture.ts
@@ -3,9 +3,7 @@ import express from "express";
 import { ApertureClient, FlowStatusEnum } from "@fluxninja/aperture-js";
 
 // Create aperture client
-export const apertureClient = new ApertureClient({
-  timeoutMilliseconds: 300000,
-});
+export const apertureClient = new ApertureClient();
 
 export const apertureRoute = express.Router();
 apertureRoute.get("/", function (_: express.Request, res: express.Response) {
@@ -16,7 +14,10 @@ apertureRoute.get("/", function (_: express.Request, res: express.Response) {
 
   // StartFlow performs a flowcontrolv1.Check call to Aperture Agent. It returns a Flow and an error if any.
   apertureClient
-    .StartFlow("awesome-feature", labels)
+    .StartFlow("awesome-feature", {
+      labels: labels,
+      timeoutMilliseconds: 300000,
+    })
     .then((flow) => {
       // See whether flow was accepted by Aperture Agent.
       if (flow.ShouldRun()) {

--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -13,6 +13,12 @@ import { LIBRARY_NAME, LIBRARY_VERSION, URL } from "./consts.js";
 import { Flow } from "./flow.js";
 import { fcs } from "./utils.js";
 
+export interface FlowParams {
+  labels?: Record<string, string>;
+  timeoutMilliseconds?: number;
+  failOpen?: boolean;
+}
+
 export class ApertureClient {
   private readonly fcsClient: FlowControlServiceClient;
 
@@ -22,13 +28,7 @@ export class ApertureClient {
 
   private readonly tracer: Tracer;
 
-  // Timeout is duration in milliseconds.
-  private readonly timeoutMilliseconds: number;
-
-  constructor({
-    timeoutMilliseconds = 0,
-    channelCredentials = grpc.credentials.createInsecure(),
-  } = {}) {
+  constructor({ channelCredentials = grpc.credentials.createInsecure() } = {}) {
     this.fcsClient = new fcs.FlowControlService(URL, channelCredentials);
 
     this.exporter = new OTLPTraceExporter({
@@ -45,8 +45,6 @@ export class ApertureClient {
     this.tracerProvider.register();
     this.tracer = this.tracerProvider.getTracer(LIBRARY_NAME, LIBRARY_VERSION);
 
-    this.timeoutMilliseconds = timeoutMilliseconds;
-
     const kickChannel = () => {
       const state = this.fcsClient.getChannel().getConnectivityState(true);
       if (state != connectivityState.SHUTDOWN) {
@@ -62,17 +60,17 @@ export class ApertureClient {
   // Return value is a Flow.
   // The call returns immediately in case connection with Aperture Agent is not established.
   // The default semantics are fail-to-wire. If StartFlow fails, calling Flow.ShouldRun() on returned Flow returns as true.
+  // For FlowParams set defaults - labels = {}, timeoutMilliseconds = 0, failOpen = true using Pick.
   async StartFlow(
-    controlPointArg: string,
-    labels: Record<string, string> = {},
-    failOpen: boolean = true,
+    controlPoint: string,
+    params: FlowParams = {},
   ): Promise<Flow> {
     return new Promise<Flow>((resolve) => {
       let span = this.tracer.startSpan("Aperture Check");
       let startDate = Date.now();
 
       const resolveFlow = (response: any, err: any) => {
-        resolve(new Flow(span, startDate, failOpen, response, err));
+        resolve(new Flow(span, startDate, params.failOpen, response, err));
       };
 
       try {
@@ -96,17 +94,18 @@ export class ApertureClient {
           }
         }
 
-        let mergedLabels = { ...labels, ...labelsBaggage };
+        let mergedLabels = { ...params.labels, ...labelsBaggage };
 
         const request: CheckRequest = {
-          controlPoint: controlPointArg,
+          controlPoint: controlPoint,
           labels: mergedLabels,
         };
 
         const grpcParams: grpc.CallOptions = {
           deadline:
-            this.timeoutMilliseconds != 0
-              ? new Date(Date.now() + this.timeoutMilliseconds)
+            params.timeoutMilliseconds != undefined &&
+            params.timeoutMilliseconds > 0
+              ? new Date(Date.now() + params.timeoutMilliseconds)
               : undefined,
         };
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the `ApertureClient` configuration in `sdks/aperture-js/example/routes/use_aperture.ts` and `sdks/aperture-js/sdk/client.ts`. The timeout option is now more flexible, allowing individual setting for each flow.
- New Feature: Introduced a new interface `FlowParams` in `sdks/aperture-js/sdk/client.ts` to encapsulate parameters related to flow control. This change enhances code readability and maintainability.
- Refactor: Modified the `StartFlow` method in `sdks/aperture-js/sdk/client.ts` to accept a `params` object of type `FlowParams`, improving parameter management and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->