### PR TITLE
aperture-js: add tryConnect flag

### DIFF
--- a/playground/scenarios/rate-limiting/load-generator/test.js
+++ b/playground/scenarios/rate-limiting/load-generator/test.js
@@ -29,6 +29,7 @@ export default function () {
       "session=eyJ1c2VyIjoia2Vub2JpIn0.YbsY4Q.kTaKRTyOIfVlIbNB48d9YH6Q0wo",
     "User-Type": userType,
     "User-Id": userId,
+    Tokens: "2",
   };
   const body = {
     request: [

--- a/playground/scenarios/rate-limiting/policies/rate-limiting-cr.yaml
+++ b/playground/scenarios/rate-limiting/policies/rate-limiting-cr.yaml
@@ -19,7 +19,8 @@ spec:
           parameters:
             interval: 1s
             label_key: http.request.header.user_id
-          request_parameters: {}
+          request_parameters:
+            tokens_label_key: http.request.header.tokens
           selectors:
           - agent_group: default
             control_point: ingress
@@ -28,9 +29,3 @@ spec:
   resources:
     flow_control:
       classifiers: []
-    infra_meters:
-      aerospike:
-        agent_group: default
-        per_agent_group: true
-        receivers:
-          aerospike: {}

--- a/playground/scenarios/rate-limiting/policies/rate-limiting.yaml
+++ b/playground/scenarios/rate-limiting/policies/rate-limiting.yaml
@@ -4,13 +4,6 @@
 # https://docs.fluxninja.com/reference/blueprints/rate-limiting
 policy:
   policy_name: rate-limiting
-  resources:
-    infra_meters:
-      aerospike:
-        agent_group: default
-        per_agent_group: true
-        receivers:
-          aerospike: {}
   rate_limiter:
     bucket_capacity: 40
     fill_amount: 2
@@ -21,3 +14,5 @@ policy:
     parameters:
       label_key: http.request.header.user_id
       interval: 1s
+    request_parameters:
+      tokens_label_key: http.request.header.tokens

--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.17",
+      "version": "2.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -17,6 +17,7 @@ export interface FlowParams {
   labels?: Record<string, string>;
   timeoutMilliseconds?: number;
   failOpen?: boolean;
+  tryConnect?: boolean;
 }
 
 export class ApertureClient {
@@ -78,8 +79,9 @@ export class ApertureClient {
         // if not ready, return flow with fail-to-wire semantics
         // if ready, call check
         if (
+          (params.tryConnect === undefined || params.tryConnect == false) &&
           this.fcsClient.getChannel().getConnectivityState(true) !=
-          connectivityState.READY
+            connectivityState.READY
         ) {
           resolveFlow(null, new Error("connection not ready"));
           return;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a "Tokens" header field in the `load-generator/test.js` file, which allows for better control over rate-limiting scenarios during testing.
- Enhancement: Updated the `ApertureClient` class in `client.ts` to include an optional `tryConnect` parameter. This provides more flexibility by allowing users to decide whether to attempt a connection or not. If `tryConnect` is false or not provided, and the connection is not ready, the flow will resolve with an error, improving error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->