### PR TITLE
aperture-js: fix json convertion of all duration fields

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/flow.ts
+++ b/sdks/aperture-js/sdk/flow.ts
@@ -93,15 +93,17 @@ export class Flow {
         CHECK_RESPONSE_LABEL,
         JSON.stringify(localCheckResponse),
       );
-      // walk through individual decisions and convert waitTime fields
-      // and add to localCheckResponse
+      // Walk through individual decisions and convert waitTime fields,
+      // then add to localCheckResponse, preserving immutability.
       if (this.checkResponse.limiterDecisions) {
-        const decisions = this.checkResponse.limiterDecisions as any;
+        const decisions = [...this.checkResponse.limiterDecisions];
+
         for (let i = 0; i < decisions.length; i++) {
-          const decision = decisions[i];
+          const decision = { ...decisions[i] };
           decision.waitTime = this.protoDurationToJSON(decision.waitTime);
+          decisions[i] = decision;
         }
-        localCheckResponse.decisions = decisions;
+        localCheckResponse.limiterDecisions = decisions;
       }
     }
 

--- a/sdks/aperture-js/sdk/flow.ts
+++ b/sdks/aperture-js/sdk/flow.ts
@@ -93,6 +93,16 @@ export class Flow {
         CHECK_RESPONSE_LABEL,
         JSON.stringify(localCheckResponse),
       );
+      // walk through individual decisions and convert waitTime fields
+      // and add to localCheckResponse
+      if (this.checkResponse.limiterDecisions) {
+        const decisions = this.checkResponse.limiterDecisions as any;
+        for (let i = 0; i < decisions.length; i++) {
+          const decision = decisions[i];
+          decision.waitTime = this.protoDurationToJSON(decision.waitTime);
+        }
+        localCheckResponse.decisions = decisions;
+      }
     }
 
     this.span.setAttribute(FLOW_STATUS_LABEL, this.status);

--- a/sdks/aperture-js/sdk/flow.ts
+++ b/sdks/aperture-js/sdk/flow.ts
@@ -89,10 +89,6 @@ export class Flow {
       localCheckResponse.waitTime = this.protoDurationToJSON(
         this.checkResponse.waitTime,
       );
-      this.span.setAttribute(
-        CHECK_RESPONSE_LABEL,
-        JSON.stringify(localCheckResponse),
-      );
       // Walk through individual decisions and convert waitTime fields,
       // then add to localCheckResponse, preserving immutability.
       if (this.checkResponse.limiterDecisions) {
@@ -106,6 +102,10 @@ export class Flow {
         );
         localCheckResponse.limiterDecisions = decisions;
       }
+      this.span.setAttribute(
+        CHECK_RESPONSE_LABEL,
+        JSON.stringify(localCheckResponse),
+      );
     }
 
     this.span.setAttribute(FLOW_STATUS_LABEL, this.status);

--- a/sdks/aperture-js/sdk/flow.ts
+++ b/sdks/aperture-js/sdk/flow.ts
@@ -96,13 +96,14 @@ export class Flow {
       // Walk through individual decisions and convert waitTime fields,
       // then add to localCheckResponse, preserving immutability.
       if (this.checkResponse.limiterDecisions) {
-        const decisions = [...this.checkResponse.limiterDecisions];
-
-        for (let i = 0; i < decisions.length; i++) {
-          const decision = { ...decisions[i] };
-          decision.waitTime = this.protoDurationToJSON(decision.waitTime);
-          decisions[i] = decision;
-        }
+        const decisions = this.checkResponse.limiterDecisions.map(
+          (decision) => {
+            return {
+              ...decision,
+              waitTime: this.protoDurationToJSON(decision.waitTime),
+            };
+          },
+        );
         localCheckResponse.limiterDecisions = decisions;
       }
     }


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the handling of `waitTime` fields in the Aperture JavaScript SDK. The `waitTime` values in the `checkResponse` object and `limiterDecisions` array are now converted to JSON format using the `protoDurationToJSON` function. This change ensures immutability while providing updated `waitTime` values, improving the reliability and consistency of data processing within the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->