### PR TITLE
aperture-js: set additional grpc options

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.19",
+      "version": "2.0.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -30,7 +30,12 @@ export class ApertureClient {
   private readonly tracer: Tracer;
 
   constructor({ channelCredentials = grpc.credentials.createInsecure() } = {}) {
-    this.fcsClient = new fcs.FlowControlService(URL, channelCredentials);
+    this.fcsClient = new fcs.FlowControlService(URL, channelCredentials, {
+      "grpc.keepalive_time_ms": 10000,
+      "grpc.keepalive_timeout_ms": 5000,
+      "grpc.keepalive_permit_without_calls": 1,
+      "grpc.client_idle_timeout_ms": 0,
+    });
 
     this.exporter = new OTLPTraceExporter({
       url: URL,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `ApertureClient` class in the Aperture JS SDK with advanced configuration options for the `FlowControlService`. This includes settings related to keepalive time, timeout, and idle timeout. These improvements aim to optimize gRPC communication performance and behavior, providing a more robust and efficient user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->