### PR TITLE
aperture-js: set additional grpc options

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.0.20",
+      "version": "2.0.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.2",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -34,7 +34,6 @@ export class ApertureClient {
       "grpc.keepalive_time_ms": 10000,
       "grpc.keepalive_timeout_ms": 5000,
       "grpc.keepalive_permit_without_calls": 1,
-      "grpc.client_idle_timeout_ms": 0,
     });
 
     this.exporter = new OTLPTraceExporter({


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Removed the `grpc.client_idle_timeout_ms` configuration option from the `ApertureClient` class in `sdks/aperture-js/sdk/client.ts`. This change simplifies the client configuration and improves maintainability. Please note that this may affect how your application handles idle gRPC clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->