### PR TITLE
Added request in queue duration metrics

### DIFF
--- a/blueprints/grafana/panels/grouped/quota_scheduler.libsonnet
+++ b/blueprints/grafana/panels/grouped/quota_scheduler.libsonnet
@@ -1,6 +1,7 @@
 local accepted_token_rate = import '../accepted_token_rate.libsonnet';
 local incoming_token_rate = import '../incoming_token_rate.libsonnet';
 local quota_checks = import '../quota_checks.libsonnet';
+local request_in_queue_duration = import '../request_in_queue_duration.libsonnet';
 local wfq_scheduler_flows = import '../wfq_scheduler_flows.libsonnet';
 local wfq_scheduler_heap_requests = import '../wfq_scheduler_heap_requests.libsonnet';
 local workload_accepted = import '../workload_decisions_accepted.libsonnet';
@@ -19,19 +20,21 @@ function(cfg) {
     + g.panel.timeSeries.gridPos.withY(30),
     workload_latency(cfg).panel
     + g.panel.timeSeries.gridPos.withY(40),
-    incoming_token_rate(cfg).panel
+    request_in_queue_duration(cfg).panel
     + g.panel.timeSeries.gridPos.withY(50),
+    incoming_token_rate(cfg).panel
+    + g.panel.timeSeries.gridPos.withY(60),
     accepted_token_rate(cfg).panel
     + g.panel.timeSeries.gridPos.withX(12)
-    + g.panel.timeSeries.gridPos.withY(50),
+    + g.panel.timeSeries.gridPos.withY(60),
     wfq_scheduler_flows(cfg).panel
     + g.panel.barGauge.gridPos.withH(6)
     + g.panel.barGauge.gridPos.withW(12)
-    + g.panel.timeSeries.gridPos.withY(60),
+    + g.panel.timeSeries.gridPos.withY(70),
     wfq_scheduler_heap_requests(cfg).panel
     + g.panel.barGauge.gridPos.withH(6)
     + g.panel.barGauge.gridPos.withW(12)
     + g.panel.barGauge.gridPos.withX(12)
-    + g.panel.timeSeries.gridPos.withY(60),
+    + g.panel.timeSeries.gridPos.withY(70),
   ],
 }

--- a/blueprints/grafana/panels/request_in_queue_duration.libsonnet
+++ b/blueprints/grafana/panels/request_in_queue_duration.libsonnet
@@ -1,0 +1,15 @@
+local utils = import '../utils/policy_utils.libsonnet';
+local timeSeriesPanel = import '../utils/time_series_panel.libsonnet';
+
+function(cfg) {
+  local stringFilters = utils.dictToPrometheusFilter(cfg.dashboard.extra_filters { policy_name: cfg.policy.policy_name }),
+
+  local workloadLatency = timeSeriesPanel('Request in Queue Duration',
+                                          cfg.dashboard.datasource.name,
+                                          '(sum by (component_id) (increase(request_in_queue_duration_ms_sum{%(filters)s}[$__rate_interval])))/(sum by (component_id) (increase(request_in_queue_duration_ms_count{%(filters)s}[$__rate_interval])))',
+                                          stringFilters,
+                                          'Latency',
+                                          'ms'),
+
+  panel: workloadLatency.panel,
+}

--- a/blueprints/grafana/panels/request_in_queue_duration.libsonnet
+++ b/blueprints/grafana/panels/request_in_queue_duration.libsonnet
@@ -8,7 +8,7 @@ function(cfg) {
                                           cfg.dashboard.datasource.name,
                                           '(sum by (component_id) (increase(request_in_queue_duration_ms_sum{%(filters)s}[$__rate_interval])))/(sum by (component_id) (increase(request_in_queue_duration_ms_count{%(filters)s}[$__rate_interval])))',
                                           stringFilters,
-                                          'Latency',
+                                          'Wait Time',
                                           'ms'),
 
   panel: workloadLatency.panel,

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -83,6 +83,11 @@ const (
 	// FlowControlRejectReasonsMetricName - metric for reject reason on FCS Check requests.
 	FlowControlRejectReasonsMetricName = "flowcontrol_reject_reasons_total"
 
+	// Check flow metrics.
+
+	// RequestInQueueDurationMetricName - metric used for grouping durations for requests in queue of Scheduler.
+	RequestInQueueDurationMetricName = "request_in_queue_duration_ms"
+
 	// OTel metrics.
 
 	// RollupMetricName - logs rollup histogram.

--- a/pkg/scheduler/wfq.go
+++ b/pkg/scheduler/wfq.go
@@ -151,19 +151,19 @@ func NewWFQScheduler(clk clockwork.Clock, tokenManger TokenManager, metrics *WFQ
 	return sched
 }
 
-func (sched *WFQScheduler) updateMetricsAndReturn(accepted bool, remaining float64, current float64, request *Request, startTime float64) (bool, float64, float64) {
+func (sched *WFQScheduler) updateMetricsAndReturn(accepted bool, remaining float64, current float64, request *Request, startTime time.Time) (bool, float64, float64) {
 	if accepted {
 		sched.metrics.AcceptedTokensCounter.Add(request.Tokens)
 	}
 	sched.metrics.IncomingTokensCounter.Add(request.Tokens)
-	sched.metrics.RequestInQueueDurationSummary.Observe((float64(sched.clk.Now().UnixNano()) - startTime) / 1e6)
+	sched.metrics.RequestInQueueDurationSummary.Observe(float64(time.Since(startTime).Nanoseconds() / 1e6))
 	return accepted, remaining, current
 }
 
 // Schedule blocks until the request is scheduled or until timeout.
 // Return value - true: Accept, false: Reject.
 func (sched *WFQScheduler) Schedule(ctx context.Context, request *Request) (bool, float64, float64) {
-	startTime := float64(sched.clk.Now().UnixNano())
+	startTime := time.Now()
 	if request.Tokens == 0 {
 		return sched.updateMetricsAndReturn(true, 0, 0, request, startTime)
 	}

--- a/pkg/scheduler/wfq.go
+++ b/pkg/scheduler/wfq.go
@@ -151,19 +151,21 @@ func NewWFQScheduler(clk clockwork.Clock, tokenManger TokenManager, metrics *WFQ
 	return sched
 }
 
-func (sched *WFQScheduler) updateMetricsAndReturn(accepted bool, remaining float64, current float64, request *Request) (bool, float64, float64) {
+func (sched *WFQScheduler) updateMetricsAndReturn(accepted bool, remaining float64, current float64, request *Request, startTime float64) (bool, float64, float64) {
 	if accepted {
 		sched.metrics.AcceptedTokensCounter.Add(request.Tokens)
 	}
 	sched.metrics.IncomingTokensCounter.Add(request.Tokens)
+	sched.metrics.RequestInQueueDurationSummary.Observe((float64(sched.clk.Now().UnixNano()) - startTime) / 1e6)
 	return accepted, remaining, current
 }
 
 // Schedule blocks until the request is scheduled or until timeout.
 // Return value - true: Accept, false: Reject.
 func (sched *WFQScheduler) Schedule(ctx context.Context, request *Request) (bool, float64, float64) {
+	startTime := float64(sched.clk.Now().UnixNano())
 	if request.Tokens == 0 {
-		return sched.updateMetricsAndReturn(true, 0, 0, request)
+		return sched.updateMetricsAndReturn(true, 0, 0, request, startTime)
 	}
 
 	sched.lock.Lock()
@@ -172,7 +174,7 @@ func (sched *WFQScheduler) Schedule(ctx context.Context, request *Request) (bool
 	sched.lock.Unlock()
 
 	if sched.manager.PreprocessRequest(ctx, request) {
-		return sched.updateMetricsAndReturn(true, 0, 0, request)
+		return sched.updateMetricsAndReturn(true, 0, 0, request, startTime)
 	}
 
 	// try to schedule right now
@@ -180,7 +182,7 @@ func (sched *WFQScheduler) Schedule(ctx context.Context, request *Request) (bool
 		accepted, _, remaining, current := sched.manager.TakeIfAvailable(ctx, request.Tokens)
 		if accepted {
 			// we got the tokens, no need to queue
-			return sched.updateMetricsAndReturn(true, remaining, current, request)
+			return sched.updateMetricsAndReturn(true, remaining, current, request, startTime)
 		}
 	}
 
@@ -191,10 +193,10 @@ func (sched *WFQScheduler) Schedule(ctx context.Context, request *Request) (bool
 	select {
 	case <-qRequest.ready:
 		accepted, remaining, current := sched.scheduleRequest(ctx, request, qRequest)
-		return sched.updateMetricsAndReturn(accepted, remaining, current, request)
+		return sched.updateMetricsAndReturn(accepted, remaining, current, request, startTime)
 	case <-ctx.Done():
 		sched.cancelRequest(qRequest)
-		return sched.updateMetricsAndReturn(false, 0, 0, request)
+		return sched.updateMetricsAndReturn(false, 0, 0, request, startTime)
 	}
 }
 
@@ -462,8 +464,9 @@ func (sched *WFQScheduler) GetPendingRequests() int {
 
 // WFQMetrics holds metrics related to internal workings of WFQScheduler.
 type WFQMetrics struct {
-	FlowsGauge            prometheus.Gauge
-	HeapRequestsGauge     prometheus.Gauge
-	IncomingTokensCounter prometheus.Counter
-	AcceptedTokensCounter prometheus.Counter
+	FlowsGauge                    prometheus.Gauge
+	HeapRequestsGauge             prometheus.Gauge
+	IncomingTokensCounter         prometheus.Counter
+	AcceptedTokensCounter         prometheus.Counter
+	RequestInQueueDurationSummary prometheus.Observer
 }

--- a/pkg/scheduler/wfq_test.go
+++ b/pkg/scheduler/wfq_test.go
@@ -30,7 +30,7 @@ var (
 	wfqHeapRequestsGauge            prometheus.Gauge
 	wfqAcceptedTokensCounter        prometheus.Counter
 	wfqIncomingTokensCounter        prometheus.Counter
-	requestInQueueDurationSummmary  prometheus.Summary
+	requestInQueueDurationSummary  prometheus.Summary
 	tokenBucketLMGauge              prometheus.Gauge
 	tokenBucketFillRateGauge        prometheus.Gauge
 	tokenBucketBucketCapacityGauge  prometheus.Gauge
@@ -66,11 +66,11 @@ func getMetrics() (prometheus.Gauge, *TokenBucketMetrics) {
 		ConstLabels: constLabels,
 	})
 	_ = prometheusRegistry.Register(wfqAcceptedTokensCounter)
-	requestInQueueDurationSummmary = prometheus.NewSummary(prometheus.SummaryOpts{
+	requestInQueueDurationSummary = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name: metrics.RequestInQueueDurationMetricName,
 		Help: "A summary that tracks the duration of requests in queue",
 	})
-	_ = prometheusRegistry.Register(requestInQueueDurationSummmary)
+	_ = prometheusRegistry.Register(requestInQueueDurationSummary)
 	tokenBucketLMGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: metrics.TokenBucketLMMetricName,
 		Help: "A gauge that tracks the load multiplier",
@@ -250,7 +250,7 @@ func BenchmarkBasicTokenBucket(b *testing.B) {
 		HeapRequestsGauge:             wfqHeapRequestsGauge,
 		IncomingTokensCounter:         wfqIncomingTokensCounter,
 		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
-		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
+		RequestInQueueDurationSummary: requestInQueueDurationSummary,
 	}
 	sched := NewWFQScheduler(c, manager, schedMetrics)
 
@@ -290,7 +290,7 @@ func BenchmarkTokenBucketLoadMultiplier(b *testing.B) {
 		HeapRequestsGauge:             wfqHeapRequestsGauge,
 		IncomingTokensCounter:         wfqIncomingTokensCounter,
 		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
-		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
+		RequestInQueueDurationSummary: requestInQueueDurationSummary,
 	}
 	sched := NewWFQScheduler(c, manager, schedMetrics)
 
@@ -353,7 +353,7 @@ func baseOfBasicBucketTest(t *testing.T, flows flowTrackers, fillRate float64, n
 		HeapRequestsGauge:             wfqHeapRequestsGauge,
 		IncomingTokensCounter:         wfqIncomingTokensCounter,
 		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
-		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
+		RequestInQueueDurationSummary: requestInQueueDurationSummary,
 	}
 	sched := NewWFQScheduler(c, basicBucket, metrics)
 	var wg sync.WaitGroup
@@ -596,7 +596,7 @@ func TestLoadMultiplierBucket(t *testing.T) {
 		HeapRequestsGauge:             wfqHeapRequestsGauge,
 		IncomingTokensCounter:         wfqIncomingTokensCounter,
 		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
-		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
+		RequestInQueueDurationSummary: requestInQueueDurationSummary,
 	}
 
 	c := clockwork.NewFakeClock()

--- a/pkg/scheduler/wfq_test.go
+++ b/pkg/scheduler/wfq_test.go
@@ -30,6 +30,7 @@ var (
 	wfqHeapRequestsGauge            prometheus.Gauge
 	wfqAcceptedTokensCounter        prometheus.Counter
 	wfqIncomingTokensCounter        prometheus.Counter
+	requestInQueueDurationSummmary  prometheus.Summary
 	tokenBucketLMGauge              prometheus.Gauge
 	tokenBucketFillRateGauge        prometheus.Gauge
 	tokenBucketBucketCapacityGauge  prometheus.Gauge
@@ -65,6 +66,11 @@ func getMetrics() (prometheus.Gauge, *TokenBucketMetrics) {
 		ConstLabels: constLabels,
 	})
 	_ = prometheusRegistry.Register(wfqAcceptedTokensCounter)
+	requestInQueueDurationSummmary = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: metrics.RequestInQueueDurationMetricName,
+		Help: "A summary that tracks the duration of requests in queue",
+	})
+	_ = prometheusRegistry.Register(requestInQueueDurationSummmary)
 	tokenBucketLMGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: metrics.TokenBucketLMMetricName,
 		Help: "A gauge that tracks the load multiplier",
@@ -240,10 +246,11 @@ func BenchmarkBasicTokenBucket(b *testing.B) {
 	manager := NewBasicTokenBucket(c, 0, metrics)
 
 	schedMetrics := &WFQMetrics{
-		FlowsGauge:            wfqFlowsGauge,
-		HeapRequestsGauge:     wfqHeapRequestsGauge,
-		IncomingTokensCounter: wfqIncomingTokensCounter,
-		AcceptedTokensCounter: wfqAcceptedTokensCounter,
+		FlowsGauge:                    wfqFlowsGauge,
+		HeapRequestsGauge:             wfqHeapRequestsGauge,
+		IncomingTokensCounter:         wfqIncomingTokensCounter,
+		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
+		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
 	}
 	sched := NewWFQScheduler(c, manager, schedMetrics)
 
@@ -279,10 +286,11 @@ func BenchmarkTokenBucketLoadMultiplier(b *testing.B) {
 	})
 
 	schedMetrics := &WFQMetrics{
-		FlowsGauge:            wfqFlowsGauge,
-		HeapRequestsGauge:     wfqHeapRequestsGauge,
-		IncomingTokensCounter: wfqIncomingTokensCounter,
-		AcceptedTokensCounter: wfqAcceptedTokensCounter,
+		FlowsGauge:                    wfqFlowsGauge,
+		HeapRequestsGauge:             wfqHeapRequestsGauge,
+		IncomingTokensCounter:         wfqIncomingTokensCounter,
+		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
+		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
 	}
 	sched := NewWFQScheduler(c, manager, schedMetrics)
 
@@ -341,10 +349,11 @@ func baseOfBasicBucketTest(t *testing.T, flows flowTrackers, fillRate float64, n
 	_, tbMetrics := getMetrics()
 	basicBucket := NewBasicTokenBucket(c, fillRate, tbMetrics)
 	metrics := &WFQMetrics{
-		FlowsGauge:            wfqFlowsGauge,
-		HeapRequestsGauge:     wfqHeapRequestsGauge,
-		IncomingTokensCounter: wfqIncomingTokensCounter,
-		AcceptedTokensCounter: wfqAcceptedTokensCounter,
+		FlowsGauge:                    wfqFlowsGauge,
+		HeapRequestsGauge:             wfqHeapRequestsGauge,
+		IncomingTokensCounter:         wfqIncomingTokensCounter,
+		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
+		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
 	}
 	sched := NewWFQScheduler(c, basicBucket, metrics)
 	var wg sync.WaitGroup
@@ -583,10 +592,11 @@ func TestLoadMultiplierBucket(t *testing.T) {
 		},
 	}
 	schedMetrics := &WFQMetrics{
-		FlowsGauge:            wfqFlowsGauge,
-		HeapRequestsGauge:     wfqHeapRequestsGauge,
-		IncomingTokensCounter: wfqIncomingTokensCounter,
-		AcceptedTokensCounter: wfqAcceptedTokensCounter,
+		FlowsGauge:                    wfqFlowsGauge,
+		HeapRequestsGauge:             wfqHeapRequestsGauge,
+		IncomingTokensCounter:         wfqIncomingTokensCounter,
+		AcceptedTokensCounter:         wfqAcceptedTokensCounter,
+		RequestInQueueDurationSummary: requestInQueueDurationSummmary,
 	}
 
 	c := clockwork.NewFakeClock()


### PR DESCRIPTION
![image](https://github.com/fluxninja/aperture/assets/34568645/9981cb1a-8d5e-455a-ae67-2a54de17d62a)

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new Prometheus summary metric `RequestInQueueDurationMetricName` to track the duration of requests in the queue, enhancing monitoring capabilities.
- New Feature: Introduced a new Grafana panel for workload latency using the newly added Prometheus metric, providing better visibility into system performance.
- Refactor: Updated the `Factory` struct and its associated methods in `scheduler.go` to initialize, retrieve, and delete the new metric.
- Test: Modified tests in `wfq_test.go` to include the new metric in the `WFQMetrics` struct, ensuring accurate testing of the new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->