### PR TITLE
Fixed incorrect message on policy delete

### DIFF
--- a/cmd/aperturectl/cmd/cloud/delete/policy.go
+++ b/cmd/aperturectl/cmd/cloud/delete/policy.go
@@ -41,7 +41,7 @@ func deletePolicyUsingAPI() error {
 	}
 	_, err := client.DeletePolicy(context.Background(), &policyRequest)
 	if err != nil {
-		log.Warn().Err(err).Str("policy", policyName).Msg("failed to delete Policy")
+		return fmt.Errorf("failed to delete policy '%s' using API: %w", policyName, err)
 	}
 
 	return nil

--- a/cmd/aperturectl/cmd/delete/policy.go
+++ b/cmd/aperturectl/cmd/delete/policy.go
@@ -86,7 +86,7 @@ func deletePolicyUsingAPI() error {
 	}
 	_, err := client.DeletePolicy(context.Background(), &policyRequest)
 	if err != nil {
-		log.Warn().Err(err).Str("policy", policyName).Msg("failed to delete Policy")
+		return fmt.Errorf("failed to delete policy '%s' using API: %w", policyName, err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes: #2638
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Bug Fix":
- Enhanced error handling in the `deletePolicyUsingAPI` function across multiple modules. Now, instead of just logging a warning message, the function returns a detailed error using `fmt.Errorf`. This change allows for better error context and enables the caller to handle errors more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->