### PR TITLE
Fix promql query in postgres blueprint

### DIFF
--- a/api/buf.lock
+++ b/api/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: 9a74a145c4b14407b84dddb59d394ff1
-    digest: shake256:7b2c74681f94ab5d33d6537bdda3d206e5a990a2d4a6bc0e197d19690475d19e785f3856132dc687ef5edfa40e0c564e01163b6933afeb8abe743ca5b02f3789
+    commit: aa51a8afc66f4d859881920aeb95d3ba
+    digest: shake256:62c3f3650b775dafe48e19af41be7b8332e57e1747c1523be1572a95d42e16149a5ce47444dc6ec6b87f6381b333c61d2cf533d4f45a7a83a211806163c22ba0
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate

--- a/blueprints/load-scheduling/postgresql/policy.libsonnet
+++ b/blueprints/load-scheduling/postgresql/policy.libsonnet
@@ -2,7 +2,7 @@ local promqlPolicyFn = import '../promql/policy.libsonnet';
 
 function(cfg, metadata={}) {
   local policyName = cfg.policy.policy_name,
-  local promqlQuery = '(sum(postgresql_backends{policy_name="%(policy_name)s",infra_meter_name="postgresql"}}) / sum(postgresql_connection_max{policy_name="%(policy_name)s",infra_meter_name="postgresql"})) * 100' % { policy_name: policyName },
+  local promqlQuery = '(sum(postgresql_backends{policy_name="%(policy_name)s",infra_meter_name="postgresql"}) / sum(postgresql_connection_max{policy_name="%(policy_name)s",infra_meter_name="postgresql"})) * 100' % { policy_name: policyName },
 
   local updated_cfg = cfg {
     policy+: {

--- a/playground/scenarios/graceful-js/policies/postgres-connections-cr.yaml
+++ b/playground/scenarios/graceful-js/policies/postgres-connections-cr.yaml
@@ -58,7 +58,7 @@ spec:
           out_ports:
             output:
               signal_name: SIGNAL
-          query_string: (sum(postgresql_backends{policy_name="postgres-connections",infra_meter_name="postgresql"}})
+          query_string: (sum(postgresql_backends{policy_name="postgres-connections",infra_meter_name="postgresql"})
             / sum(postgresql_connection_max{policy_name="postgres-connections",infra_meter_name="postgresql"}))
             * 100
     - variable:


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Corrected a syntax error in the `promqlQuery` variable assignment within the `policy.libsonnet` file under the `load-scheduling/postgresql` blueprint. This fix ensures that the query is properly formed, preventing potential execution errors and enhancing the reliability of load scheduling for PostgreSQL databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->