### PR TITLE
Added workload_index label in request_in_queue_duration metrics

### DIFF
--- a/blueprints/grafana/panels/grouped/quota_scheduler.libsonnet
+++ b/blueprints/grafana/panels/grouped/quota_scheduler.libsonnet
@@ -1,9 +1,9 @@
 local accepted_token_rate = import '../accepted_token_rate.libsonnet';
 local incoming_token_rate = import '../incoming_token_rate.libsonnet';
-local quota_checks = import '../quota_checks.libsonnet';
 local request_in_queue_duration = import '../request_in_queue_duration.libsonnet';
 local wfq_scheduler_flows = import '../wfq_scheduler_flows.libsonnet';
 local wfq_scheduler_heap_requests = import '../wfq_scheduler_heap_requests.libsonnet';
+local workload_decisions = import '../workload_decisions.libsonnet';
 local workload_accepted = import '../workload_decisions_accepted.libsonnet';
 local workload_rejected = import '../workload_decisions_rejected.libsonnet';
 local workload_latency = import '../workload_latency.libsonnet';
@@ -12,7 +12,7 @@ local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v9.4.0/main.libsonn
 
 function(cfg) {
   panels: [
-    quota_checks(cfg).panel
+    workload_decisions(cfg).panel
     + g.panel.timeSeries.gridPos.withY(10),
     workload_accepted(cfg).panel
     + g.panel.timeSeries.gridPos.withY(20),

--- a/blueprints/grafana/panels/request_in_queue_duration.libsonnet
+++ b/blueprints/grafana/panels/request_in_queue_duration.libsonnet
@@ -6,7 +6,7 @@ function(cfg) {
 
   local workloadLatency = timeSeriesPanel('Request in Queue Duration',
                                           cfg.dashboard.datasource.name,
-                                          '(sum by (component_id) (increase(request_in_queue_duration_ms_sum{%(filters)s}[$__rate_interval])))/(sum by (component_id) (increase(request_in_queue_duration_ms_count{%(filters)s}[$__rate_interval])))',
+                                          '(sum by (component_id, workload_index) (increase(request_in_queue_duration_ms_sum{%(filters)s}[$__rate_interval])))/(sum by (component_id, workload_index) (increase(request_in_queue_duration_ms_count{%(filters)s}[$__rate_interval])))',
                                           stringFilters,
                                           'Wait Time',
                                           'ms'),

--- a/blueprints/grafana/panels/workload_decisions.libsonnet
+++ b/blueprints/grafana/panels/workload_decisions.libsonnet
@@ -4,7 +4,7 @@ local timeSeriesPanel = import '../utils/time_series_panel.libsonnet';
 function(cfg) {
   local stringFilters = utils.dictToPrometheusFilter(cfg.dashboard.extra_filters { policy_name: cfg.policy.policy_name }),
 
-  local quotaScheduler = timeSeriesPanel('Quota Checks',
+  local quotaScheduler = timeSeriesPanel('Workload Decisions',
                                          cfg.dashboard.datasource.name,
                                          'sum by(decision_type) (rate(workload_requests_total{%(filters)s}[$__rate_interval]))',
                                          stringFilters,


### PR DESCRIPTION
![image](https://github.com/fluxninja/aperture/assets/34568645/afa93221-a843-4fe1-9c4f-5414865ddd42)

##### Checklist

- [x] Tested in playground or other setup
- [x] Screenshot (Grafana) from playground added to PR for 15+ minute run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Replaced the `quota_checks` module with the `workload_decisions` module in Grafana panels, providing more detailed insights into workload decisions.
- Refactor: Updated the query in the `request_in_queue_duration` panel to include the `workload_index` field, allowing for more granular aggregation of metrics.
- Style: Renamed the time series panel from "Quota Checks" to "Workload Decisions" in Grafana, improving clarity and consistency.
- Refactor: Enhanced Prometheus metrics creation in the workload scheduler by specifying additional label keys, enabling more precise tracking and analysis.
- Test: Updated tests in `wfq_test.go` to reflect changes in metrics and labels, ensuring accurate testing conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->