### PR TITLE
Set workload index as fairness label

### DIFF
--- a/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
+++ b/pkg/policies/flowcontrol/actuators/workload-scheduler/scheduler.go
@@ -403,7 +403,7 @@ func (s *Scheduler) Decide(ctx context.Context, labels labels.Labels) *flowcontr
 		matchedWorkloadIndex = s.defaultWorkload.proto.Name
 	}
 
-	fairnessLabel := "workload:" + matchedWorkloadIndex
+	fairnessLabel := matchedWorkloadIndex
 
 	tokens := float64(1)
 	// Precedence order:

--- a/pkg/scheduler/wfq.go
+++ b/pkg/scheduler/wfq.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -161,7 +160,7 @@ func NewWFQScheduler(clk clockwork.Clock, tokenManger TokenManager, metrics *WFQ
 
 func (sched *WFQScheduler) updateRequestInQueueMetrics(accepted bool, request *Request, startTime time.Time) {
 	metricsLabels := make(prometheus.Labels, len(sched.metricsLabels)+1)
-	metricsLabels[metrics.WorkloadIndexLabel] = strings.TrimPrefix(request.FairnessLabel, "workload:")
+	metricsLabels[metrics.WorkloadIndexLabel] = request.FairnessLabel
 	for k, v := range sched.metricsLabels {
 		metricsLabels[k] = v
 	}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Simplified the assignment of `fairnessLabel` in the `Decide` function of the `Scheduler` struct by removing unnecessary string concatenation.
- Refactor: Streamlined the assignment of `request.FairnessLabel` to `metricsLabels[metrics.WorkloadIndexLabel]` in `wfq.go`, eliminating the need for the `strings` package.

These changes enhance code readability and maintainability without altering the underlying logic or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->