### PR TITLE
aperture-js: improve error

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.3",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -32,8 +32,8 @@ export class ApertureClient {
 
   constructor({ channelCredentials = grpc.credentials.createInsecure() } = {}) {
     this.fcsClient = new fcs.FlowControlService(URL, channelCredentials, {
-      "grpc.keepalive_time_ms": 3000,
-      "grpc.keepalive_timeout_ms": 1000,
+      "grpc.keepalive_time_ms": 10000,
+      "grpc.keepalive_timeout_ms": 5000,
       "grpc.keepalive_permit_without_calls": 1,
     });
 

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -86,13 +86,19 @@ export class ApertureClient {
         // check connection state
         // if not ready, return flow with fail-to-wire semantics
         // if ready, call check
-        if (
-          (params.tryConnect === undefined || params.tryConnect == false) &&
-          this.fcsClient.getChannel().getConnectivityState(true) !=
-            connectivityState.READY
-        ) {
-          resolveFlow(null, serializeError(new Error("connection not ready")));
-          return;
+        if (params.tryConnect === undefined || params.tryConnect == false) {
+          const state = this.fcsClient.getChannel().getConnectivityState(true);
+          if (state != connectivityState.READY) {
+            resolveFlow(
+              null,
+              serializeError(
+                new Error(
+                  `connection with Aperture Agent is not established, state: ${state}`,
+                ),
+              ),
+            );
+            return;
+          }
         }
 
         let labelsBaggage = {} as Record<string, string>;

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -88,7 +88,10 @@ export class ApertureClient {
         // if ready, call check
         if (params.tryConnect === undefined || params.tryConnect == false) {
           const state = this.fcsClient.getChannel().getConnectivityState(true);
-          if (state != connectivityState.READY) {
+          if (
+            state != connectivityState.READY &&
+            state != connectivityState.IDLE
+          ) {
             resolveFlow(
               null,
               serializeError(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the connection state handling in `ApertureClient` to include an additional check for the `tryConnect` parameter. This will prevent unexpected failures when the connection state is not ready.
- Refactor: Adjusted the values of `grpc.keepalive_time_ms` and `grpc.keepalive_timeout_ms` options in the `ApertureClient` constructor to improve the stability and reliability of the client-server communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->