### PR TITLE
Fixed issue in aperturectl when both uri and version is provided with blueprints generate

### DIFF
--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -92,10 +92,10 @@ aperturectl blueprints generate --values-file=rate-limiting.yaml --apply`,
 			}
 		}
 
-		if blueprintsURI == "" {
+		if blueprintsVersion == "" && blueprintsURI == "" {
 			blueprintsURI, ok = values["uri"].(string)
 			if !ok {
-				return fmt.Errorf("values file does not contain uri field")
+				return fmt.Errorf("neither --version flag is set nor values file contains uri field")
 			}
 		}
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Bug Fix: Enhanced error handling in blueprint generation command

- The update introduces a more robust check for the presence of `blueprintsVersion` and `blueprintsURI`. 
- If both are missing, the system now attempts to retrieve these values from the `values` map. 
- In case the required information is still not found, an explicit error message is returned, improving user feedback and troubleshooting.
- This fix enhances the reliability of the blueprint generation process and provides clearer guidance when input parameters are missing."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->