### PR TITLE
docs: update usage of aperturectl blueprints generate

### DIFF
--- a/docs/content/get-started/policies/policies.md
+++ b/docs/content/get-started/policies/policies.md
@@ -103,8 +103,7 @@ Once the `values.yaml` file is ready, you can generate the blueprint using the
 following command:
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=rate-limiting/base
---values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints generate --values-file=values.yaml --output-dir=policy-gen</CodeBlock>
 ```
 
 The following directory structure will be generated:

--- a/docs/content/use-cases/adaptive-service-protection/average-latency-feedback.md
+++ b/docs/content/use-cases/adaptive-service-protection/average-latency-feedback.md
@@ -92,8 +92,7 @@ Adjust the values to match the application requirements. Use the following
 command to generate the policy.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=load-scheduling/average-latency
---values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints generate --values-file=values.yaml --output-dir=policy-gen</CodeBlock>
 ```
 
 Apply the policy using the `aperturectl` CLI or `kubectl`.

--- a/docs/content/use-cases/adaptive-service-protection/workload-prioritization.md
+++ b/docs/content/use-cases/adaptive-service-protection/workload-prioritization.md
@@ -87,8 +87,7 @@ Adjust the values to match the application requirements. Use the following
 command to generate the policy.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=load-scheduling/average-latency
---values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints generate --values-file=values.yaml --output-dir=policy-gen</CodeBlock>
 ```
 
 Apply the policy using the `aperturectl` CLI or `kubectl`.

--- a/docs/content/use-cases/managing-quotas/inter-service-rate-limiting.md
+++ b/docs/content/use-cases/managing-quotas/inter-service-rate-limiting.md
@@ -83,8 +83,7 @@ Adjust the values to match the application requirements. Use the following
 command to generate the policy.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=quota-scheduling/base
---values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints generate --values-file=values.yaml --output-dir=policy-gen</CodeBlock>
 ```
 
 Apply the policy using the `aperturectl` CLI or `kubectl`.

--- a/docs/content/use-cases/percentage-rollouts/average-latency-feedback.md
+++ b/docs/content/use-cases/percentage-rollouts/average-latency-feedback.md
@@ -96,8 +96,7 @@ Adjust the values to match the application requirements. Use the following
 command to generate the policy.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=load-ramping/base
---values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints generate --values-file=values.yaml --output-dir=policy-gen</CodeBlock>
 ```
 
 Apply the policy using the `aperturectl` CLI or `kubectl`.

--- a/docs/content/use-cases/rate-limiting/graphql-rate-limiting.md
+++ b/docs/content/use-cases/rate-limiting/graphql-rate-limiting.md
@@ -118,8 +118,7 @@ Adjust the values to match the application requirements. Use the following
 command to generate the policy.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=rate-limiting/base
---values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints generate --values-file=values.yaml --output-dir=policy-gen</CodeBlock>
 ```
 
 Apply the policy using the `aperturectl` CLI or `kubectl`.

--- a/docs/content/use-cases/rate-limiting/static-rate-limiting.md
+++ b/docs/content/use-cases/rate-limiting/static-rate-limiting.md
@@ -89,8 +89,7 @@ Adjust the values to match the application requirements. Use the following
 command to generate the policy.
 
 ```mdx-code-block
-<CodeBlock language="bash">aperturectl blueprints generate --name=rate-limiting/base
---values-file=values.yaml --output-dir=policy-gen --version={apertureVersion}</CodeBlock>
+<CodeBlock language="bash">aperturectl blueprints generate --values-file=values.yaml --output-dir=policy-gen</CodeBlock>
 ```
 
 Apply the policy using the `aperturectl` CLI or `kubectl`.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Documentation: 

- Simplified the `aperturectl blueprints generate` command across multiple documentation files. Removed the `--name` and `--version` flags as these values can now be adjusted in the `values.yaml` file.
- Updated instructions to apply policies using `aperturectl` or `kubectl`.
- Aligned all commands with the latest application requirements for a more streamlined user experience."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->