### PR TITLE
rename panel

### DIFF
--- a/blueprints/grafana/panels/request_queue_duration_bar.libsonnet
+++ b/blueprints/grafana/panels/request_queue_duration_bar.libsonnet
@@ -4,7 +4,7 @@ local utils = import '../utils/policy_utils.libsonnet';
 function(cfg) {
   local stringFilters = utils.dictToPrometheusFilter(cfg.dashboard.extra_filters { policy_name: cfg.policy.policy_name }),
 
-  local requestsDuration = barChartPanel('Requests Duration',
+  local requestsDuration = barChartPanel('Requests in Queue Duration',
                                          cfg.dashboard.datasource.name,
                                          'topk(10, (sum by(workload_index) (increase(request_in_queue_duration_ms_sum{%(filters)s}[$__range])) ) / (sum by(workload_index) (increase(request_in_queue_duration_ms_count{%(filters)s}[$__range])) ))',
                                          stringFilters,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the title of a chart panel in Grafana from 'Requests Duration' to 'Requests in Queue Duration'. This change better reflects the data being displayed, providing users with more accurate insights into the duration of requests within a queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->