### PR TITLE
Use cloud-controller component when updating controller

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -1081,7 +1081,8 @@ jobs:
         description: Name of the playground scenario to apply
       controller-endpoint:
         type: string
-        description: The endpoint of the controller to which the policy should be applied
+        description:
+          The endpoint of the controller to which the policy should be applied
     executor: go-cimg-executor
     steps:
       - checkout
@@ -1230,7 +1231,7 @@ workflows:
           requires:
             - image-build-aperture-controller
           environment-path: environments/latest/
-          component: aperture-controller
+          component: cloud-controller
           update: images
 
       - go-test-coverage:

--- a/.opsninja.yaml
+++ b/.opsninja.yaml
@@ -40,6 +40,16 @@ applications:
       dockerfile: cmd/aperture-controller/Dockerfile
     deployment:
       manifests/charts/aperture-controller/.+: charts/aperture/aperture-controller/
+  cloud-controller:
+    image:
+      name: aperture-controller
+      docker_context: cmd/aperture-controller
+      dockerfile: cmd/aperture-controller/Dockerfile
+    argo_manifests:
+      - app_path: apps/app-of-apps/cloud/organization-operator.yaml
+        image_prefix: NINJA_AGENT_CONTROLLER_
+      - app_path: apps/app-of-apps/cloud/temporal-worker.yaml
+        image_prefix: NINJA_AGENT_CONTROLLER_
   demo-app:
     image:
       name: demo-app


### PR DESCRIPTION
We've switched from aperture-controller to cloud-controller,
and made it into a separate deployment unit. This brings us
in line with the deployment setup.

### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the description of the `controller-endpoint` property in the `.circleci/continue-workflows.yml` configuration file for better clarity and understanding.
- New Feature: Enhanced the `cloud-controller` application configuration in `.opsninja.yaml`. This includes specifying image details and Docker context for the `aperture-controller` image, and adding two Argo manifests with their respective image prefixes. These changes improve the cloud controller functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->