### PR TITLE
Backward compatible policy read

### DIFF
--- a/pkg/policies/controlplane/policy-service.go
+++ b/pkg/policies/controlplane/policy-service.go
@@ -18,6 +18,7 @@ import (
 
 	policylangv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
 	policysyncv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/sync/v1"
+	"github.com/fluxninja/aperture/v2/pkg/config"
 	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 	"github.com/fluxninja/aperture/v2/pkg/policies/paths"
@@ -194,7 +195,12 @@ func (s *PolicyService) UpsertPolicy(ctx context.Context, req *policylangv1.Upse
 	if len(etcdPolicy.Kvs) > 0 {
 		err = proto.Unmarshal(etcdPolicy.Kvs[0].Value, oldPolicy)
 		if err != nil {
-			return nil, status.Error(codes.FailedPrecondition, "cannot patch, existing policy is invalid")
+			// Deprecated: v3.0.0. Older way of string policy on etcd.
+			// Remove this code in v3.0.0.
+			err = config.UnmarshalJSON(etcdPolicy.Kvs[0].Value, oldPolicy)
+			if err != nil {
+				return nil, status.Error(codes.FailedPrecondition, "cannot patch, existing policy is invalid")
+			}
 		}
 	}
 

--- a/pkg/policies/controlplane/provider.go
+++ b/pkg/policies/controlplane/provider.go
@@ -130,8 +130,13 @@ func setupPoliciesNotifier(
 			policyMessage := &languagev1.Policy{}
 			unmarshalErr := proto.Unmarshal(bytes, policyMessage)
 			if unmarshalErr != nil {
-				log.Warn().Err(unmarshalErr).Msg("Failed to unmarshal policy")
-				return key, nil, unmarshalErr
+				// Deprecated: v3.0.0. Older way of string policy on etcd.
+				// Remove this code in v3.0.0.
+				unmarshalErr = config.UnmarshalJSON(bytes, policyMessage)
+				if unmarshalErr != nil {
+					log.Warn().Err(unmarshalErr).Msg("Failed to unmarshal policy")
+					return key, nil, unmarshalErr
+				}
 			}
 
 			wrapper, wrapErr := hashAndPolicyWrap(policyMessage, string(key))


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added backward compatibility to the `PolicyService` and `setupPoliciesNotifier` functions. These changes ensure that older versions of string policies stored in etcd can still be processed correctly, even as we transition to a new format. This feature enhances the robustness of our system during updates, ensuring seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->