### PR TITLE
Fixed jq version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -20,4 +20,4 @@ tilt 0.32.3
 go-jsonnet 0.20.0
 circleci 0.1.26343
 java corretto-19.0.2.7.1
-jq 1.16
+jq 1.7


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Downgraded the version of `jq` from 1.16 to 1.7.

Please note that this change might affect the functionality of scripts or tools relying on features specific to `jq` version 1.16. Ensure to test all dependent components thoroughly after this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->