### PR TITLE
reject when req tokens are more than bucketCapacity

### DIFF
--- a/cmd/aperturectl/cmd/installation/utils.go
+++ b/cmd/aperturectl/cmd/installation/utils.go
@@ -63,8 +63,8 @@ const (
 	aperturectl            = "aperturectl"
 )
 
-// getTemplets loads CRDs, hooks and manifests from the Helm chart.
-func getTemplets(chartName, releaseName string, order releaseutil.KindSortOrder) ([]chart.CRD, []*release.Hook, []releaseutil.Manifest, error) {
+// getTemplates loads CRDs, hooks and manifests from the Helm chart.
+func getTemplates(chartName, releaseName string, order releaseutil.KindSortOrder) ([]chart.CRD, []*release.Hook, []releaseutil.Manifest, error) {
 	chartURL := fmt.Sprintf("https://fluxninja.github.io/aperture/%s-%s.tgz", chartName, version)
 
 	resp, err := http.Get(chartURL) //nolint
@@ -293,7 +293,7 @@ func prepareUnstructuredObject(manifest string) (*unstructured.Unstructured, err
 
 // handleInstall handles installation for given chart using given release name.
 func handleInstall(chartName, releaseName string) error {
-	crds, _, manifests, err := getTemplets(chartName, releaseName, releaseutil.InstallOrder)
+	crds, _, manifests, err := getTemplates(chartName, releaseName, releaseutil.InstallOrder)
 	if err != nil {
 		return err
 	}
@@ -338,7 +338,7 @@ func handleInstall(chartName, releaseName string) error {
 
 // handleUnInstall handles uninstallation for given chart using given release name.
 func handleUnInstall(chartName, releaseName string) error {
-	crds, hooks, manifests, err := getTemplets(chartName, releaseName, releaseutil.UninstallOrder)
+	crds, hooks, manifests, err := getTemplates(chartName, releaseName, releaseutil.UninstallOrder)
 	if err != nil {
 		return err
 	}

--- a/pkg/rate-limiter/global-token-bucket/global-token-bucket.go
+++ b/pkg/rate-limiter/global-token-bucket/global-token-bucket.go
@@ -182,6 +182,11 @@ func (gtb *GlobalTokenBucket) Take(ctx context.Context, label string, n float64)
 		return false, 0, 0, 0
 	}
 
+	// if we are asking for more tokens than the bucket capacity, return false
+	if n > gtb.bucketCapacity {
+		return false, 0, 0, 0
+	}
+
 	req := takeNRequest{
 		Want:     n,
 		CanWait:  true,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Renamed function `getTemplets` to `getTemplates` in `cmd/aperturectl/cmd/installation/utils.go` for improved readability and consistency.
- Bug Fix: Updated the `Take` method in `pkg/rate-limiter/global-token-bucket/global-token-bucket.go` to prevent taking more tokens than the bucket's capacity, enhancing system stability and preventing potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->