### PR TITLE
change default for delayedInitialFill

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -121,7 +121,7 @@ message RateLimiter {
     // When set to true, the token bucket will be given a chance to
     // empty out before the filling starts. The delay is equal to the
     // time it takes to fill the bucket.
-    bool delay_initial_fill = 7; // @gotags: default:"true"
+    bool delay_initial_fill = 7; // @gotags: default:"false"
   }
 
   message RequestParameters {

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -2267,7 +2267,7 @@ type RateLimiter_Parameters struct {
 	// When set to true, the token bucket will be given a chance to
 	// empty out before the filling starts. The delay is equal to the
 	// time it takes to fill the bucket.
-	DelayInitialFill bool `protobuf:"varint,7,opt,name=delay_initial_fill,json=delayInitialFill,proto3" json:"delay_initial_fill,omitempty" default:"true"` // @gotags: default:"true"
+	DelayInitialFill bool `protobuf:"varint,7,opt,name=delay_initial_fill,json=delayInitialFill,proto3" json:"delay_initial_fill,omitempty" default:"false"` // @gotags: default:"false"
 }
 
 func (x *RateLimiter_Parameters) Reset() {

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -3032,10 +3032,10 @@
           "x-go-tag-default": "true"
         },
         "delay_initial_fill": {
-          "default": true,
+          "default": false,
           "description": "Delays the initial filling of the token bucket.\nIf set to false, the token bucket will start filling immediately\nafter the first request is received. This can potentially lead to\nmore requests being accepted than the specified rate limit during\nthe first interval.\nWhen set to true, the token bucket will be given a chance to\nempty out before the filling starts. The delay is equal to the\ntime it takes to fill the bucket.\n\n",
           "type": "boolean",
-          "x-go-tag-default": "true"
+          "x-go-tag-default": "false"
         },
         "interval": {
           "description": "Interval defines the time interval in which the token bucket\nwill fill tokens specified by `fill_amount` signal.\nThis field employs the [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json) JSON representation from Protocol Buffers. The format accommodates fractional seconds up to nine digits after the decimal point, offering nanosecond precision. Every duration value must be suffixed with an \"s\" to indicate 'seconds.' For example, a value of \"10s\" would signify a duration of 10 seconds.\n\n",

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -3136,7 +3136,7 @@ definitions:
                 type: boolean
                 x-go-tag-default: "true"
             delay_initial_fill:
-                default: true
+                default: false
                 description: |+
                     Delays the initial filling of the token bucket.
                     If set to false, the token bucket will start filling immediately
@@ -3148,7 +3148,7 @@ definitions:
                     time it takes to fill the bucket.
 
                 type: boolean
-                x-go-tag-default: "true"
+                x-go-tag-default: "false"
             interval:
                 description: |+
                     Interval defines the time interval in which the token bucket

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -3749,7 +3749,7 @@ definitions:
                 type: boolean
                 x-go-tag-default: "true"
             delay_initial_fill:
-                default: true
+                default: false
                 description: |+
                     Delays the initial filling of the token bucket.
                     If set to false, the token bucket will start filling immediately
@@ -3761,7 +3761,7 @@ definitions:
                     time it takes to fill the bucket.
 
                 type: boolean
-                x-go-tag-default: "true"
+                x-go-tag-default: "false"
             interval:
                 description: |+
                     Interval defines the time interval in which the token bucket

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -7474,7 +7474,7 @@ continuously or only on discrete intervals.
 
 <!-- vale off -->
 
-(bool, default: `true`)
+(bool, default: `false`)
 
 <!-- vale on -->
 

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -3056,7 +3056,7 @@ definitions:
                 type: boolean
                 x-go-tag-default: "true"
             delay_initial_fill:
-                default: true
+                default: false
                 description: |+
                     Delays the initial filling of the token bucket.
                     If set to false, the token bucket will start filling immediately
@@ -3068,7 +3068,7 @@ definitions:
                     time it takes to fill the bucket.
 
                 type: boolean
-                x-go-tag-default: "true"
+                x-go-tag-default: "false"
             interval:
                 description: |+
                     Interval defines the time interval in which the token bucket


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the `GlobalTokenBucket` struct in `global-token-bucket.go` to improve code modularity and reduce duplication. The `TakeIfAvailable` and `Take` methods now utilize a new private method, `executeTakeRequest`, for common logic.
- Change: Modified the default value of the `delay_initial_fill` field in `flowcontrol.proto` from `true` to `false`. This change affects the initial behavior of the token bucket fill rate.
- Documentation: Updated the default boolean variable value in `spec.md` to align with recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->