### PR TITLE
Fix data race in Controller shutdown

### DIFF
--- a/pkg/notifiers/watcher.go
+++ b/pkg/notifiers/watcher.go
@@ -55,25 +55,3 @@ func WatcherLifecycle(lc fx.Lifecycle, watcher Watcher, notifiers []PrefixNotifi
 		},
 	})
 }
-
-// NotifierLifecycle adds/removed prefix notifier to etcd watcher.
-func NotifierLifecycle(lc fx.Lifecycle, watcher Watcher, notifier PrefixNotifier) {
-	lc.Append(fx.Hook{
-		OnStart: func(_ context.Context) error {
-			err := watcher.AddPrefixNotifier(notifier)
-			if err != nil {
-				log.Error().Err(err).Msg("Failed to add notifier")
-				return err
-			}
-			return nil
-		},
-		OnStop: func(_ context.Context) error {
-			err := watcher.RemovePrefixNotifier(notifier)
-			if err != nil {
-				log.Error().Err(err).Msg("Failed to remove notifier")
-				return err
-			}
-			return nil
-		},
-	})
-}

--- a/pkg/policies/controlplane/runtime/background-scheduler.go
+++ b/pkg/policies/controlplane/runtime/background-scheduler.go
@@ -17,10 +17,10 @@ import (
 
 var circuitBackgroundJobGroupTag = iface.PoliciesRoot + "circuit_background_jobs"
 
-// BackgroundSchedulerModule returns fx options for PromQL in the main app.
+// BackgroundSchedulerModule returns fx options for Background Jobs in the main app.
 func BackgroundSchedulerModule() fx.Option {
 	return fx.Options(
-		jobs.JobGroupConstructor{Name: circuitBackgroundJobGroupTag, Key: iface.PoliciesRoot + ".promql_jobs_scheduler"}.Annotate(),
+		jobs.JobGroupConstructor{Name: circuitBackgroundJobGroupTag, Key: iface.PoliciesRoot + ".background_jobs_scheduler"}.Annotate(),
 		fx.Provide(fx.Annotate(
 			provideFxOptionsFunc,
 			fx.ParamTags(config.NameTag(circuitBackgroundJobGroupTag)),
@@ -29,9 +29,9 @@ func BackgroundSchedulerModule() fx.Option {
 	)
 }
 
-func provideFxOptionsFunc(promQLJobGroup *jobs.JobGroup) notifiers.FxOptionsFunc {
+func provideFxOptionsFunc(backgroundJobGroup *jobs.JobGroup) notifiers.FxOptionsFunc {
 	return func(key notifiers.Key, _ config.Unmarshaller, _ status.Registry) (fx.Option, error) {
-		return fx.Supply(fx.Annotated{Name: circuitBackgroundJobGroupTag, Target: promQLJobGroup}), nil
+		return fx.Supply(fx.Annotated{Name: circuitBackgroundJobGroupTag, Target: backgroundJobGroup}), nil
 	}
 }
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Simplified the creation of watcher instances in `policy-factory.go` by removing unnecessary variables and consolidating the creation process.
- Refactor: Removed the `NotifierLifecycle` function from `watcher.go`, indicating a refactoring or relocation of the functionality for adding and removing prefix notifiers.
- Style: Updated job group name from "promql_jobs_scheduler" to "background_jobs_scheduler" in `background-scheduler.go` for better clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->