### PR TITLE
use policy name in background circuit job name

### DIFF
--- a/pkg/policies/controlplane/runtime/background-scheduler.go
+++ b/pkg/policies/controlplane/runtime/background-scheduler.go
@@ -52,7 +52,7 @@ func BackgroundSchedulerModuleForPolicyApp(circuitAPI CircuitSuperAPI) fx.Option
 		jws = append(jws, scheduler)
 
 		// Create backgroundMultiJob for running background jobs in this circuit
-		jobName := fmt.Sprintf("policy-%s", circuitAPI.GetPolicyHash())
+		jobName := fmt.Sprintf("policy-%s-%s", circuitAPI.GetPolicyName(), circuitAPI.GetPolicyHash())
 		backgroundMultiJob := jobs.NewMultiJob(jobGroup.GetStatusRegistry().Child(jobName, circuitAPI.GetPolicyName()), jws, nil)
 		scheduler.multiJob = backgroundMultiJob
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Enhanced the naming convention for background jobs in the control plane runtime. The job names now include the policy name along with the policy hash, making them more descriptive and unique. This change improves traceability and debugging by providing clearer identification of each job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->