### PR TITLE
Add Preemptive Panels to Scheduler Dashboard

### DIFF
--- a/blueprints/grafana/panels/avg_preemption_gauge.libsonnet
+++ b/blueprints/grafana/panels/avg_preemption_gauge.libsonnet
@@ -1,0 +1,16 @@
+local barGaugePanel = import '../utils/bar_gauge_panel.libsonnet';
+local utils = import '../utils/policy_utils.libsonnet';
+
+function(cfg) {
+  local stringFilters = utils.dictToPrometheusFilter(cfg.dashboard.extra_filters { policy_name: cfg.policy.policy_name }),
+
+  local preemptionRequest = barGaugePanel('Average preemption per request by Workload',
+                                          cfg.dashboard.datasource.name,
+                                          '( sum by (workload_index) (rate(workload_preempted_tokens_sum[$__rate_interval])) - sum by (workload_index) (rate(workload_delayed_tokens_sum[$__rate_interval])) ) / ( sum by (workload_index) (rate(workload_preempted_tokens_count[$__rate_interval])) + sum by (workload_index) (rate(workload_delayed_tokens_count[$__rate_interval])) )',
+                                          stringFilters,
+                                          unit='percent',
+                                          instantQuery=true,
+                                          range=false),
+
+  panel: preemptionRequest.panel,
+}

--- a/blueprints/grafana/panels/avg_preemption_gauge.libsonnet
+++ b/blueprints/grafana/panels/avg_preemption_gauge.libsonnet
@@ -8,7 +8,7 @@ function(cfg) {
                                           cfg.dashboard.datasource.name,
                                           '( sum by (workload_index) (rate(workload_preempted_tokens_sum[$__rate_interval])) - sum by (workload_index) (rate(workload_delayed_tokens_sum[$__rate_interval])) ) / ( sum by (workload_index) (rate(workload_preempted_tokens_count[$__rate_interval])) + sum by (workload_index) (rate(workload_delayed_tokens_count[$__rate_interval])) )',
                                           stringFilters,
-                                          unit='percent',
+                                          unit='short',
                                           instantQuery=true,
                                           range=false),
 

--- a/blueprints/grafana/panels/avg_preemption_time_series.libsonnet
+++ b/blueprints/grafana/panels/avg_preemption_time_series.libsonnet
@@ -1,0 +1,14 @@
+local utils = import '../utils/policy_utils.libsonnet';
+local timeSeriesPanel = import '../utils/time_series_panel.libsonnet';
+
+function(cfg) {
+  local stringFilters = utils.dictToPrometheusFilter(cfg.dashboard.extra_filters { policy_name: cfg.policy.policy_name }),
+
+  local avgPreemption = timeSeriesPanel('Average preemption per request by Workload',
+                                        cfg.dashboard.datasource.name,
+                                        '( sum by (workload_index) (rate(workload_preempted_tokens_sum[$__rate_interval])) - sum by (workload_index) (rate(workload_delayed_tokens_sum[$__rate_interval])) ) / ( sum by (workload_index) (rate(workload_preempted_tokens_count[$__rate_interval])) + sum by (workload_index) (rate(workload_delayed_tokens_count[$__rate_interval])) )',
+                                        stringFilters,
+                                        '%'),
+
+  panel: avgPreemption.panel,
+}

--- a/blueprints/grafana/panels/avg_preemption_time_series.libsonnet
+++ b/blueprints/grafana/panels/avg_preemption_time_series.libsonnet
@@ -8,7 +8,7 @@ function(cfg) {
                                         cfg.dashboard.datasource.name,
                                         '( sum by (workload_index) (rate(workload_preempted_tokens_sum[$__rate_interval])) - sum by (workload_index) (rate(workload_delayed_tokens_sum[$__rate_interval])) ) / ( sum by (workload_index) (rate(workload_preempted_tokens_count[$__rate_interval])) + sum by (workload_index) (rate(workload_delayed_tokens_count[$__rate_interval])) )',
                                         stringFilters,
-                                        '%'),
+                                        'Tokens'),
 
   panel: avgPreemption.panel,
 }

--- a/blueprints/grafana/panels/grouped/quota_scheduler.libsonnet
+++ b/blueprints/grafana/panels/grouped/quota_scheduler.libsonnet
@@ -1,4 +1,6 @@
 local accepted_token_rate = import '../accepted_token_rate.libsonnet';
+local avg_preemption_gauge = import '../avg_preemption_gauge.libsonnet';
+local avg_preemption_time_series = import '../avg_preemption_time_series.libsonnet';
 local incoming_token_rate = import '../incoming_token_rate.libsonnet';
 local request_in_queue_duration = import '../request_in_queue_duration.libsonnet';
 local request_queue_duration_bar = import '../request_queue_duration_bar.libsonnet';
@@ -44,28 +46,35 @@ function(cfg) {
     + g.panel.barGauge.gridPos.withX(12)
     + g.panel.barGauge.gridPos.withY(60)
     + g.panel.barGauge.gridPos.withW(12),
+    avg_preemption_time_series(cfg).panel
+    + g.panel.timeSeries.gridPos.withY(70)
+    + g.panel.timeSeries.gridPos.withW(12),
+    avg_preemption_gauge(cfg).panel
+    + g.panel.barGauge.gridPos.withX(12)
+    + g.panel.barGauge.gridPos.withY(70)
+    + g.panel.barGauge.gridPos.withW(12),
     incoming_token_rate(cfg).panel
-    + g.panel.timeSeries.gridPos.withY(70),
+    + g.panel.timeSeries.gridPos.withY(80),
     accepted_token_rate(cfg).panel
     + g.panel.timeSeries.gridPos.withX(12)
-    + g.panel.timeSeries.gridPos.withY(70),
+    + g.panel.timeSeries.gridPos.withY(80),
     total_incoming_tokens(cfg).panel
     + g.panel.stat.gridPos.withX(0)
-    + g.panel.stat.gridPos.withY(80),
+    + g.panel.stat.gridPos.withY(90),
     total_accepted_tokens(cfg).panel
     + g.panel.stat.gridPos.withX(8)
-    + g.panel.stat.gridPos.withY(80),
+    + g.panel.stat.gridPos.withY(90),
     total_rejected_tokens(cfg).panel
     + g.panel.stat.gridPos.withX(16)
-    + g.panel.stat.gridPos.withY(80),
+    + g.panel.stat.gridPos.withY(90),
     wfq_scheduler_flows(cfg).panel
     + g.panel.barGauge.gridPos.withH(6)
     + g.panel.barGauge.gridPos.withW(12)
-    + g.panel.timeSeries.gridPos.withY(90),
+    + g.panel.timeSeries.gridPos.withY(100),
     wfq_scheduler_heap_requests(cfg).panel
     + g.panel.barGauge.gridPos.withH(6)
     + g.panel.barGauge.gridPos.withW(12)
     + g.panel.barGauge.gridPos.withX(12)
-    + g.panel.timeSeries.gridPos.withY(90),
+    + g.panel.timeSeries.gridPos.withY(100),
   ],
 }


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes**

- New Feature: Added a new `avg_preemption_gauge` panel to the Grafana dashboard. This panel displays the average preemption per request, providing users with insights into system performance.
- New Feature: Introduced an `avg_preemption_time_series` panel to the Grafana dashboard. This time series panel shows the average preemption per request over time, allowing users to track and analyze trends in system performance.
- Refactor: Updated the `quota_scheduler` panel layout in the Grafana dashboard. The grid positions of existing panels have been adjusted to accommodate the newly added panels, improving the overall user interface and experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->