### PR TITLE
add validation checks for deprecated fields

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -33,7 +33,8 @@ message FlowControl {
     LoadScheduler load_scheduler = 7;
 
     // _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
-    AdaptiveLoadScheduler adaptive_load_scheduler = 8;
+    // Deprecated: v3.0.0. Use _AIMD Load Scheduler_ instead.
+    AdaptiveLoadScheduler adaptive_load_scheduler = 8; // @gotags: validate:"deprecated"
 
     // Sampler is a component that regulates the flow of requests to the service by allowing only the specified percentage of requests or sticky sessions.
     Sampler sampler = 9;

--- a/api/aperture/policy/language/v1/policy.proto
+++ b/api/aperture/policy/language/v1/policy.proto
@@ -202,7 +202,7 @@ message Circuit {
 message Resources {
   // TelemetryCollector configures OpenTelemetry collector integration.
   // Deprecated: v3.0.0. Use `infra_meters` instead.
-  repeated TelemetryCollector telemetry_collectors = 1;
+  repeated TelemetryCollector telemetry_collectors = 1; // @gotags: validate:"deprecated"
 
   // _Infra Meters_ configure custom metrics OpenTelemetry collector pipelines, which will
   // receive and process telemetry at the agents and send metrics to the configured Prometheus.
@@ -309,7 +309,7 @@ message Component {
 
     // Differentiator calculates rate of change per tick.
     // Deprecated: v3.0.0. Use `PIDController` instead.
-    Differentiator differentiator = 17;
+    Differentiator differentiator = 17; // @gotags: validate:"deprecated"
 
     // Logical AND.
     And and = 19;

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -235,7 +235,8 @@ type FlowControl_LoadScheduler struct {
 
 type FlowControl_AdaptiveLoadScheduler struct {
 	// _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
-	AdaptiveLoadScheduler *AdaptiveLoadScheduler `protobuf:"bytes,8,opt,name=adaptive_load_scheduler,json=adaptiveLoadScheduler,proto3,oneof"`
+	// Deprecated: v3.0.0. Use _AIMD Load Scheduler_ instead.
+	AdaptiveLoadScheduler *AdaptiveLoadScheduler `protobuf:"bytes,8,opt,name=adaptive_load_scheduler,json=adaptiveLoadScheduler,proto3,oneof" validate:"deprecated"` // @gotags: validate:"deprecated"
 }
 
 type FlowControl_Sampler struct {

--- a/api/gen/proto/go/aperture/policy/language/v1/policy.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/policy.pb.go
@@ -727,7 +727,7 @@ type Resources struct {
 
 	// TelemetryCollector configures OpenTelemetry collector integration.
 	// Deprecated: v3.0.0. Use `infra_meters` instead.
-	TelemetryCollectors []*TelemetryCollector `protobuf:"bytes,1,rep,name=telemetry_collectors,json=telemetryCollectors,proto3" json:"telemetry_collectors,omitempty"`
+	TelemetryCollectors []*TelemetryCollector `protobuf:"bytes,1,rep,name=telemetry_collectors,json=telemetryCollectors,proto3" json:"telemetry_collectors,omitempty" validate:"deprecated"` // @gotags: validate:"deprecated"
 	// _Infra Meters_ configure custom metrics OpenTelemetry collector pipelines, which will
 	// receive and process telemetry at the agents and send metrics to the configured Prometheus.
 	// Key in this map refers to OTel pipeline name. Prefixing pipeline name with `metrics/`
@@ -1206,7 +1206,7 @@ type Component_Integrator struct {
 type Component_Differentiator struct {
 	// Differentiator calculates rate of change per tick.
 	// Deprecated: v3.0.0. Use `PIDController` instead.
-	Differentiator *Differentiator `protobuf:"bytes,17,opt,name=differentiator,proto3,oneof"`
+	Differentiator *Differentiator `protobuf:"bytes,17,opt,name=differentiator,proto3,oneof" validate:"deprecated"` // @gotags: validate:"deprecated"
 }
 
 type Component_And struct {

--- a/blueprints/CONTRIBUTING.md
+++ b/blueprints/CONTRIBUTING.md
@@ -13,17 +13,17 @@ An example metadata looks like this:
 ```yaml
 blueprint: Latency AIMD Concurrency Limiting Policy
 sources:
-  Dashboard:
-    prefix: dashboard
-    path: policies/service-protection/average-latency/dashboard.libsonnet
-  Policy:
-    prefix: policy
-    path: policies/service-protection/average-latency/policy.libsonnet
+  policy: service-protection/average-latency/policy.libsonnet
+deprecation_message: |
+  This blueprint is deprecated and will be removed in the future.
+  Please use the `load-scheduling/average-latency` blueprint instead.
 ```
 
 - `blueprint` key is currently unused, but it names this specific bundle
 - `sources` provides a list of dashboards and policies that are part of this
   blueprint.
+- `deprecation_message` is an optional message that will be displayed in the
+  generated README.md. It can be used to mark blueprints as deprecated.
 
 ### More on sources
 

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -793,7 +793,8 @@
         },
         "differentiator": {
           "$ref": "#/definitions/Differentiator",
-          "description": "Differentiator calculates rate of change per tick.\nDeprecated: v3.0.0. Use `PIDController` instead."
+          "description": "Differentiator calculates rate of change per tick.\nDeprecated: v3.0.0. Use `PIDController` instead.\n\n",
+          "x-go-tag-validate": "deprecated"
         },
         "ema": {
           "$ref": "#/definitions/EMA",
@@ -1304,7 +1305,8 @@
       "properties": {
         "adaptive_load_scheduler": {
           "$ref": "#/definitions/AdaptiveLoadScheduler",
-          "description": "_Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy."
+          "description": "_Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.\nDeprecated: v3.0.0. Use _AIMD Load Scheduler_ instead.\n\n",
+          "x-go-tag-validate": "deprecated"
         },
         "aiad_load_scheduler": {
           "$ref": "#/definitions/AIADLoadScheduler",
@@ -3146,12 +3148,14 @@
           "type": "object"
         },
         "telemetry_collectors": {
-          "description": "TelemetryCollector configures OpenTelemetry collector integration.\nDeprecated: v3.0.0. Use `infra_meters` instead.",
+          "description": "TelemetryCollector configures OpenTelemetry collector integration.\nDeprecated: v3.0.0. Use `infra_meters` instead.\n\n",
           "items": {
             "$ref": "#/definitions/TelemetryCollector",
             "type": "object"
           },
-          "type": "array"
+          "type": "array",
+          "x-deprecated": true,
+          "x-go-tag-validate": "deprecated"
         }
       },
       "title": "Resources that need to be setup for the policy to function",

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -857,9 +857,11 @@ definitions:
                 description: Decider emits the binary result of comparison operator on two operands.
             differentiator:
                 $ref: '#/definitions/Differentiator'
-                description: |-
+                description: |+
                     Differentiator calculates rate of change per tick.
                     Deprecated: v3.0.0. Use `PIDController` instead.
+
+                x-go-tag-validate: deprecated
             ema:
                 $ref: '#/definitions/EMA'
                 description: Exponential Moving Average filter.
@@ -1340,7 +1342,11 @@ definitions:
         properties:
             adaptive_load_scheduler:
                 $ref: '#/definitions/AdaptiveLoadScheduler'
-                description: _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
+                description: |+
+                    _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
+                    Deprecated: v3.0.0. Use _AIMD Load Scheduler_ instead.
+
+                x-go-tag-validate: deprecated
             aiad_load_scheduler:
                 $ref: '#/definitions/AIADLoadScheduler'
                 description: AIAD Load Scheduler.
@@ -3349,13 +3355,16 @@ definitions:
                     :::
                 type: object
             telemetry_collectors:
-                description: |-
+                description: |+
                     TelemetryCollector configures OpenTelemetry collector integration.
                     Deprecated: v3.0.0. Use `infra_meters` instead.
+
                 items:
                     $ref: '#/definitions/TelemetryCollector'
                     type: object
                 type: array
+                x-deprecated: true
+                x-go-tag-validate: deprecated
         title: Resources that need to be setup for the policy to function
         type: object
     Rule:

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -1079,9 +1079,11 @@ definitions:
                 description: Decider emits the binary result of comparison operator on two operands.
             differentiator:
                 $ref: '#/definitions/Differentiator'
-                description: |-
+                description: |+
                     Differentiator calculates rate of change per tick.
                     Deprecated: v3.0.0. Use `PIDController` instead.
+
+                x-go-tag-validate: deprecated
             ema:
                 $ref: '#/definitions/EMA'
                 description: Exponential Moving Average filter.
@@ -1644,7 +1646,11 @@ definitions:
         properties:
             adaptive_load_scheduler:
                 $ref: '#/definitions/AdaptiveLoadScheduler'
-                description: _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
+                description: |+
+                    _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
+                    Deprecated: v3.0.0. Use _AIMD Load Scheduler_ instead.
+
+                x-go-tag-validate: deprecated
             aiad_load_scheduler:
                 $ref: '#/definitions/AIADLoadScheduler'
                 description: AIAD Load Scheduler.
@@ -4011,13 +4017,16 @@ definitions:
                     :::
                 type: object
             telemetry_collectors:
-                description: |-
+                description: |+
                     TelemetryCollector configures OpenTelemetry collector integration.
                     Deprecated: v3.0.0. Use `infra_meters` instead.
+
                 items:
                     $ref: '#/definitions/TelemetryCollector'
                     type: object
                 type: array
+                x-deprecated: true
+                x-go-tag-validate: deprecated
         title: Resources that need to be setup for the policy to function
         type: object
     Response:

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -3283,7 +3283,8 @@ to features within a service.
 
 _Adaptive Load Scheduler_ component does additive increase of load multiplier
 during non-overload state. During overload, the load multiplier is throttled
-based on the provided strategy.
+based on the provided strategy. Deprecated: v3.0.0. Use _AIMD Load Scheduler_
+instead.
 
 </dd>
 <dt>aiad_load_scheduler</dt>
@@ -7819,7 +7820,7 @@ of the agent(s).
 
 <!-- vale off -->
 
-([[]TelemetryCollector](#telemetry-collector))
+([[]TelemetryCollector](#telemetry-collector), **DEPRECATED**)
 
 <!-- vale on -->
 

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -858,9 +858,11 @@ definitions:
                 description: Decider emits the binary result of comparison operator on two operands.
             differentiator:
                 $ref: '#/definitions/Differentiator'
-                description: |-
+                description: |+
                     Differentiator calculates rate of change per tick.
                     Deprecated: v3.0.0. Use `PIDController` instead.
+
+                x-go-tag-validate: deprecated
             ema:
                 $ref: '#/definitions/EMA'
                 description: Exponential Moving Average filter.
@@ -1341,7 +1343,11 @@ definitions:
         properties:
             adaptive_load_scheduler:
                 $ref: '#/definitions/AdaptiveLoadScheduler'
-                description: _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
+                description: |+
+                    _Adaptive Load Scheduler_ component does additive increase of load multiplier during non-overload state. During overload, the load multiplier is throttled based on the provided strategy.
+                    Deprecated: v3.0.0. Use _AIMD Load Scheduler_ instead.
+
+                x-go-tag-validate: deprecated
             aiad_load_scheduler:
                 $ref: '#/definitions/AIADLoadScheduler'
                 description: AIAD Load Scheduler.
@@ -3269,13 +3275,16 @@ definitions:
                     :::
                 type: object
             telemetry_collectors:
-                description: |-
+                description: |+
                     TelemetryCollector configures OpenTelemetry collector integration.
                     Deprecated: v3.0.0. Use `infra_meters` instead.
+
                 items:
                     $ref: '#/definitions/TelemetryCollector'
                     type: object
                 type: array
+                x-deprecated: true
+                x-go-tag-validate: deprecated
         title: Resources that need to be setup for the policy to function
         type: object
     Rule:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- **Deprecation**: The `AdaptiveLoadScheduler` component in the `FlowControl` message has been deprecated. Users are advised to use the "AIMD Load Scheduler" instead for better performance and efficiency.
- **Deprecation**: The `telemetry_collectors` field in the `Resources` message and the `differentiator` field in the `Component` message have been marked as deprecated. Future updates will remove these fields.
- **Documentation**: Updated the configuration specification document to reflect the deprecation of the "Adaptive Load Scheduler" and "TelemetryCollector".
- **Refactor**: Updated blueprint metadata to include a new `deprecation_message` key, providing users with more information about deprecated components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->