### PR TITLE
Remove policy marshalling from aperturectl

### DIFF
--- a/cmd/aperturectl/cmd/cloud/apply/policy.go
+++ b/cmd/aperturectl/cmd/cloud/apply/policy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	languagev1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/language/v1"
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 )
@@ -70,16 +69,16 @@ aperturectl cloud apply policy --dir=policies --controller ORGANIZATION_NAME.app
 
 // applyPolicy applies a policy to the cluster.
 func applyPolicy(policyFile string) error {
-	policy, policyName, err := utils.GetPolicy(policyFile)
+	policyBytes, policyName, err := utils.GetPolicy(policyFile)
 	if err != nil {
 		return err
 	}
 
-	return createAndApplyPolicy(policyName, policy)
+	return createAndApplyPolicy(policyName, policyBytes)
 }
 
-func createAndApplyPolicy(name string, policy *languagev1.Policy) error {
-	isUpdated, updatePolicyUsingAPIErr := utils.UpdatePolicyUsingAPI(client, name, policy, force)
+func createAndApplyPolicy(name string, policyBytes []byte) error {
+	isUpdated, updatePolicyUsingAPIErr := utils.UpdatePolicyUsingAPI(client, name, policyBytes, force)
 	if !isUpdated {
 		return updatePolicyUsingAPIErr
 	}

--- a/pkg/policies/controlplane/policy-service.go
+++ b/pkg/policies/controlplane/policy-service.go
@@ -206,7 +206,7 @@ func (s *PolicyService) UpsertPolicy(ctx context.Context, req *policylangv1.Upse
 
 	newPolicy := &policylangv1.Policy{}
 	if req.PolicyString != "" {
-		err = newPolicy.UnmarshalJSON([]byte(req.PolicyString))
+		err = config.UnmarshalYAML([]byte(req.PolicyString), newPolicy)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to unmarshal policy: %s", err)
 		}


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated `applyPolicy` and `createAndApplyPolicy` functions in `cmd/aperturectl/cmd/apply/policy.go` and `cmd/aperturectl/cmd/cloud/apply/policy.go` to use policy bytes instead of policy objects, improving flexibility and consistency.
- Refactor: Modified `GetPolicy` and `UpdatePolicyUsingAPI` functions in `cmd/aperturectl/cmd/utils/policies.go` to handle policy bytes, enhancing code maintainability.
- New Feature: Changed `UpsertPolicy` function in `pkg/policies/controlplane/policy-service.go` to support YAML formatted policies, expanding the range of acceptable input formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->