### PR TITLE
Update production instead of staging post-release

### DIFF
--- a/.circleci/post-release.yaml
+++ b/.circleci/post-release.yaml
@@ -165,6 +165,9 @@ jobs:
 
   update-environment:
     parameters:
+      tag:
+        type: string
+        description: The release tag
       job-root:
         type: string
         default: "/home/circleci"
@@ -224,6 +227,7 @@ jobs:
             ENVIRONMENT_PATH: << parameters.environment-path >>
             SKIP_COMPONENT: << parameters.skip-component >>
             RELEASE_TRAIN: << parameters.release-train >>
+            RELEASE_TAG: << parameters.tag >>
           command: .circleci/scripts/update_environment.sh
       - asdf_save_cache:
           cache_name: update-environment
@@ -352,11 +356,12 @@ workflows:
               ignore: /.+/
             tags:
               only: /^v.*/
-          name: aperture-update-environment-everything
-          environment-path: environments/demo/
+          name: aperture-update-environment-everything-customer-demo
+          environment-path: environments/customer-demo/
           skip-component: demo-app
           update: everything
           release-train: pre-release
+          tag: << pipeline.git.tag >>
 
       - update-environment:
           filters:
@@ -364,17 +369,31 @@ workflows:
               ignore: /.+/
             tags:
               only: /^v.*/
-          name: aperture-update-environment-demoapp
-          environment-path: environments/demo/
+          name: aperture-update-environment-everything-production
+          environment-path: environments/production-fn-cloud/
+          skip-component: demo-app
+          update: everything
+          release-train: final-release
+          tag: << pipeline.git.tag >>
+
+      - update-environment:
+          filters:
+            branches:
+              ignore: /.+/
+            tags:
+              only: /^v.*/
+          name: aperture-update-environment-demoapp-customer-demo
+          environment-path: environments/customer-demo/
           component: demo-app
           update: images,deployment-code
+          tag: << pipeline.git.tag >>
 
       - update-brews:
           filters:
-            <<: *release-filters
+            branches:
+              ignore: /.+/
             tags:
               only: /^v.*/
-              ignore: /^.*-rc.*/
           tag: << pipeline.git.tag >>
           deployment-key: "a4:df:98:54:5d:18:ba:a1:01:66:88:e2:26:e3:f2:eb"
 

--- a/.circleci/scripts/update_environment.sh
+++ b/.circleci/scripts/update_environment.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 export LOGURU_LEVEL=TRACE
 export GIT_SSH_COMMAND="fn circleci ssh -o IdentitiesOnly=yes -o IdentityAgent=none"
 
+# Skip execution if release train is final-release and tag contains -rc-
+if [[ "${RELEASE_TRAIN:-}" == "final-release" ]] && [[ "${RELEASE_TAG:-}" == *"-rc."* ]]; then
+    echo "Skipping update_environment.sh for final-release with -rc- tag"
+    exit 0
+fi
+
 commit_author=$(git show --format="%aN <%aE>" --quiet)
 
 args=(


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new parameter "tag" to the "update-environment" job in the CI/CD pipeline, allowing for specific release tagging.
- Refactor: Modified environment paths and skip components for certain jobs to improve pipeline efficiency.
- Chore: Updated the script to skip execution if the `RELEASE_TRAIN` is set to "final-release" and `RELEASE_TAG` contains "-rc-", enhancing the release process.
- New Feature: Introduced three new jobs in the `test-update-environment` workflow for updating different environments with specific configurations and tags.
- Refactor: Enhanced the `update-environment` job by adding new parameters like `tag`, `skip-component`, and `release-train`, and changing the default `manifests-branch` to use the `tests` branch.
- Chore: Improved the CI/CD pipeline by including steps to install Python using `asdf` and save the cache in the `update-environment` job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->