### PR TITLE
Make sure Tree.Node is always defined

### DIFF
--- a/pkg/policies/controlplane/circuitfactory/circuit.go
+++ b/pkg/policies/controlplane/circuitfactory/circuit.go
@@ -14,7 +14,7 @@ import (
 //
 // Circuit can also be converted to its graph view.
 type Circuit struct {
-	Tree           *Tree
+	Tree           Tree
 	LeafComponents []*runtime.ConfiguredComponent
 }
 
@@ -50,7 +50,7 @@ func CompileFromProto(
 	}
 
 	return &Circuit{
-		Tree:           &tree,
+		Tree:           tree,
 		LeafComponents: leafComponents,
 	}, option, nil
 }

--- a/pkg/policies/controlplane/circuitfactory/circuit.go
+++ b/pkg/policies/controlplane/circuitfactory/circuit.go
@@ -14,7 +14,7 @@ import (
 //
 // Circuit can also be converted to its graph view.
 type Circuit struct {
-	Tree           Tree
+	Tree           *Tree
 	LeafComponents []*runtime.ConfiguredComponent
 }
 
@@ -50,7 +50,7 @@ func CompileFromProto(
 	}
 
 	return &Circuit{
-		Tree:           tree,
+		Tree:           &tree,
 		LeafComponents: leafComponents,
 	}, option, nil
 }

--- a/pkg/policies/controlplane/policy.go
+++ b/pkg/policies/controlplane/policy.go
@@ -162,8 +162,13 @@ func compilePolicyWrapper(wrapperMessage *policysyncv1.PolicyWrapper, registry s
 		}
 	}
 
+	rootTree, rootTreeErr := circuitfactory.RootTree(&policylangv1.Circuit{})
+	if rootTreeErr != nil {
+		return nil, nil, nil, rootTreeErr
+	}
 	compiledCircuit := &circuitfactory.Circuit{
 		LeafComponents: make([]*runtime.ConfiguredComponent, 0),
+		Tree:           rootTree,
 	}
 
 	partialCircuitOption := fx.Options()


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `rootTree` variable to hold the result of `circuitfactory.RootTree()` function, enhancing the structure of the compiled circuit.
- Refactor: Removed early return condition based on `policy.evaluationInterval > 0`, simplifying the control flow and making the function more readable.
- Error Handling: Added `rootTreeErr` to capture any errors returned by `circuitfactory.RootTree()`, improving error handling and debugging capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->