### PR TITLE
Fix dead link in docs

### DIFF
--- a/docs/content/concepts/flow-label.md
+++ b/docs/content/concepts/flow-label.md
@@ -228,7 +228,7 @@ For _Classifier_ created labels, you can disable this behavior by setting
   https://opentelemetry.io/docs/concepts/observability-primer/#distributed-traces
 [control-point]: ./control-point.md
 [otel-conventions]:
-  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
+  https://github.com/open-telemetry/opentelemetry-specification/blob/v1.25.0/specification/trace/semantic_conventions/http.md
 [aperture-sdks]: /integrations/sdk/sdk.md
 [gateways]: /integrations/gateway/gateway.md
 [istio]: /integrations/istio/istio.md


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Documentation: Updated the URL for the `otel-conventions` link in `flow-label.md`. The new link points to a specific version (v1.25.0) of the OpenTelemetry specification, ensuring users are directed to a stable and consistent reference."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->