### PR TITLE
etcd based rpc

### DIFF
--- a/cmd/aperture-agent/agent.go
+++ b/cmd/aperture-agent/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fluxninja/aperture/v2/pkg/discovery"
 	distcache "github.com/fluxninja/aperture/v2/pkg/dist-cache"
 	agentelection "github.com/fluxninja/aperture/v2/pkg/etcd/election/agent"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/k8s"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 	"github.com/fluxninja/aperture/v2/pkg/otelcollector"
@@ -52,6 +53,7 @@ func main() {
 		discovery.Module(),
 		agentelection.Module(),
 		rpc.ClientModule,
+		transport.TransportClientModule,
 		agentfunctions.Module,
 		Module(),
 		// Start collector after all extensions started, so it won't

--- a/cmd/aperture-controller/controller.go
+++ b/cmd/aperture-controller/controller.go
@@ -14,11 +14,15 @@ import (
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/fx"
 
+	"github.com/fluxninja/aperture/v2/cmd/aperture-agent/agent"
 	"github.com/fluxninja/aperture/v2/cmd/aperture-controller/controller"
 	"github.com/fluxninja/aperture/v2/pkg/agent-functions/agents"
+	agentinfo "github.com/fluxninja/aperture/v2/pkg/agent-info"
 	"github.com/fluxninja/aperture/v2/pkg/cmd"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 	"github.com/fluxninja/aperture/v2/pkg/otelcollector"
+	"github.com/fluxninja/aperture/v2/pkg/peers"
 	"github.com/fluxninja/aperture/v2/pkg/platform"
 	"github.com/fluxninja/aperture/v2/pkg/policies/controlplane"
 	"github.com/fluxninja/aperture/v2/pkg/rpc"
@@ -38,10 +42,16 @@ func main() {
 		controlplane.Module(),
 		webhooks.Module(),
 		policyvalidator.Module(),
+		transport.TransportModule,
+		peers.Constructor{}.Module(),
+		fx.Provide(
+			agentinfo.ProvideAgentInfo,
+			agent.ProvidePeersPrefix,
+		),
 		rpc.ServerModule,
-		agents.Module,
 		cmd.Module,
 		Module(),
+		agents.Module,
 	)
 
 	defer log.WaitFlush()

--- a/cmd/aperture-controller/controller.go
+++ b/cmd/aperture-controller/controller.go
@@ -42,7 +42,7 @@ func main() {
 		controlplane.Module(),
 		webhooks.Module(),
 		policyvalidator.Module(),
-		transport.TransportModule,
+		transport.TransportServerModule,
 		peers.Constructor{}.Module(),
 		fx.Provide(
 			agentinfo.ProvideAgentInfo,

--- a/cmd/aperture-controller/controller.go
+++ b/cmd/aperture-controller/controller.go
@@ -14,15 +14,12 @@ import (
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/fx"
 
-	"github.com/fluxninja/aperture/v2/cmd/aperture-agent/agent"
 	"github.com/fluxninja/aperture/v2/cmd/aperture-controller/controller"
 	"github.com/fluxninja/aperture/v2/pkg/agent-functions/agents"
-	agentinfo "github.com/fluxninja/aperture/v2/pkg/agent-info"
 	"github.com/fluxninja/aperture/v2/pkg/cmd"
 	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 	"github.com/fluxninja/aperture/v2/pkg/otelcollector"
-	"github.com/fluxninja/aperture/v2/pkg/peers"
 	"github.com/fluxninja/aperture/v2/pkg/platform"
 	"github.com/fluxninja/aperture/v2/pkg/policies/controlplane"
 	"github.com/fluxninja/aperture/v2/pkg/rpc"
@@ -43,11 +40,6 @@ func main() {
 		webhooks.Module(),
 		policyvalidator.Module(),
 		transport.TransportServerModule,
-		peers.Constructor{}.Module(),
-		fx.Provide(
-			agentinfo.ProvideAgentInfo,
-			agent.ProvidePeersPrefix,
-		),
 		rpc.ServerModule,
 		cmd.Module,
 		Module(),

--- a/pkg/agent-functions/agents/agents.go
+++ b/pkg/agent-functions/agents/agents.go
@@ -12,7 +12,6 @@ import (
 	previewv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/flowcontrol/preview/v1"
 	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
 	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
-	"github.com/fluxninja/aperture/v2/pkg/peers"
 	"github.com/fluxninja/aperture/v2/pkg/rpc"
 )
 
@@ -24,19 +23,15 @@ var Module = fx.Provide(NewAgents)
 // Agents wraps functions registered in agentfunctions, types should match.
 type Agents struct {
 	*rpc.Clients
-	peers         *peers.PeerDiscovery
 	etcdTransport *transport.EtcdTransportServer
 	etcdClient    *etcdclient.Client
-	// serviceDiscovery *distcache.ServiceDiscovery
 }
 
 // NewAgents wraps Clients with Agent-specific function wrappers.
-func NewAgents(transport *transport.EtcdTransportServer, peersDiscovery *peers.PeerDiscovery, client *etcdclient.Client) Agents {
+func NewAgents(transport *transport.EtcdTransportServer, client *etcdclient.Client) Agents {
 	return Agents{
 		etcdTransport: transport,
-		peers:         peersDiscovery,
 		etcdClient:    client,
-		// serviceDiscovery: serviceDiscovery,
 	}
 }
 
@@ -102,9 +97,8 @@ func (a Agents) PreviewHTTPRequests(
 	return transport.SendRequest[previewv1.PreviewHTTPRequestsResponse](a.etcdTransport, agent, &cmdv1.PreviewHTTPRequestsRequest{Request: req})
 }
 
-// GetAgents lists the agents registered on etcd under /peers/aperture-agent
+// GetAgents lists the agents registered on etcd under /peers/aperture-agent.
 func (a Agents) GetAgents() ([]string, error) {
-
 	re := regexp.MustCompile(`/peers/aperture-agent/[^/]+/`)
 
 	resp, err := a.etcdClient.Client.KV.Get(context.Background(), "/peers/aperture-agent/", clientv3.WithPrefix())

--- a/pkg/agent-functions/agents/agents.go
+++ b/pkg/agent-functions/agents/agents.go
@@ -3,6 +3,7 @@ package agents
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -100,6 +101,9 @@ func (a Agents) PreviewHTTPRequests(
 // GetAgents lists the agents registered on etcd under /peers/aperture-agent.
 func (a Agents) GetAgents() ([]string, error) {
 	re := regexp.MustCompile(`/peers/aperture-agent/[^/]+/`)
+	if re == nil {
+		return nil, fmt.Errorf("failed to compile regular expression")
+	}
 
 	resp, err := a.etcdClient.Client.KV.Get(context.Background(), "/peers/aperture-agent/", clientv3.WithPrefix())
 	if err != nil {

--- a/pkg/agent-functions/agents/agents.go
+++ b/pkg/agent-functions/agents/agents.go
@@ -102,6 +102,7 @@ func (a Agents) PreviewHTTPRequests(
 	return transport.SendRequest[previewv1.PreviewHTTPRequestsResponse](a.etcdTransport, agent, &cmdv1.PreviewHTTPRequestsRequest{Request: req})
 }
 
+// GetAgents lists the agents registered on etcd under /peers/aperture-agent
 func (a Agents) GetAgents() ([]string, error) {
 
 	re := regexp.MustCompile(`/peers/aperture-agent/[^/]+/`)

--- a/pkg/agent-functions/agents/agents.go
+++ b/pkg/agent-functions/agents/agents.go
@@ -2,10 +2,17 @@
 package agents
 
 import (
+	"context"
+	"regexp"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/fx"
 
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	previewv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/flowcontrol/preview/v1"
+	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
+	"github.com/fluxninja/aperture/v2/pkg/peers"
 	"github.com/fluxninja/aperture/v2/pkg/rpc"
 )
 
@@ -15,34 +22,64 @@ var Module = fx.Provide(NewAgents)
 // Agents wraps rpc.Clients where clients are agents and provides wrapper
 //
 // Agents wraps functions registered in agentfunctions, types should match.
-type Agents struct{ *rpc.Clients }
+type Agents struct {
+	*rpc.Clients
+	peers         *peers.PeerDiscovery
+	etcdTransport *transport.EtcdTransportServer
+	etcdClient    *etcdclient.Client
+	// serviceDiscovery *distcache.ServiceDiscovery
+}
 
 // NewAgents wraps Clients with Agent-specific function wrappers.
-func NewAgents(clients *rpc.Clients) Agents { return Agents{Clients: clients} }
+func NewAgents(transport *transport.EtcdTransportServer, peersDiscovery *peers.PeerDiscovery, client *etcdclient.Client) Agents {
+	return Agents{
+		etcdTransport: transport,
+		peers:         peersDiscovery,
+		etcdClient:    client,
+		// serviceDiscovery: serviceDiscovery,
+	}
+}
 
 // ListFlowControlPoints lists control points of all agents.
 //
 // Handled by agentfunctions.ControlPointsHandler.
-func (a Agents) ListFlowControlPoints() ([]rpc.Result[*cmdv1.ListFlowControlPointsAgentResponse], error) {
+func (a Agents) ListFlowControlPoints() ([]transport.Result[*cmdv1.ListFlowControlPointsAgentResponse], error) {
 	var req cmdv1.ListFlowControlPointsRequest
-	return rpc.CallAll[cmdv1.ListFlowControlPointsAgentResponse](a.Clients, &req)
+	agents, err := a.GetAgents()
+	if err != nil {
+		return nil, err
+	}
+	return transport.SendRequests[cmdv1.ListFlowControlPointsAgentResponse](a.etcdTransport, agents, &req)
 }
 
 // ListAutoScaleControlPoints lists auto-scale control points of all agents.
-func (a Agents) ListAutoScaleControlPoints() ([]rpc.Result[*cmdv1.ListAutoScaleControlPointsAgentResponse], error) {
+func (a Agents) ListAutoScaleControlPoints() ([]transport.Result[*cmdv1.ListAutoScaleControlPointsAgentResponse], error) {
 	var req cmdv1.ListAutoScaleControlPointsRequest
-	return rpc.CallAll[cmdv1.ListAutoScaleControlPointsAgentResponse](a.Clients, &req)
+	agents, err := a.GetAgents()
+	if err != nil {
+		return nil, err
+	}
+	return transport.SendRequests[cmdv1.ListAutoScaleControlPointsAgentResponse](a.etcdTransport, agents, &req)
 }
 
 // ListDiscoveryEntities lists discovery entities.
-func (a Agents) ListDiscoveryEntities() ([]rpc.Result[*cmdv1.ListDiscoveryEntitiesAgentResponse], error) {
+func (a Agents) ListDiscoveryEntities() ([]transport.Result[*cmdv1.ListDiscoveryEntitiesAgentResponse], error) {
 	var req cmdv1.ListDiscoveryEntitiesRequest
-	return rpc.CallAll[cmdv1.ListDiscoveryEntitiesAgentResponse](a.Clients, &req)
+	agents, err := a.GetAgents()
+	if err != nil {
+		return nil, err
+	}
+	return transport.SendRequests[cmdv1.ListDiscoveryEntitiesAgentResponse](a.etcdTransport, agents, &req)
 }
 
 // ListDiscoveryEntity lists discovery entity by ip address or name.
 func (a Agents) ListDiscoveryEntity(req *cmdv1.ListDiscoveryEntityRequest) (*cmdv1.ListDiscoveryEntityAgentResponse, error) {
-	return rpc.Call[cmdv1.ListDiscoveryEntityAgentResponse](a.Clients, a.List()[0], req)
+	agents, err := a.GetAgents()
+	if err != nil {
+		return nil, err
+	}
+
+	return transport.SendRequest[cmdv1.ListDiscoveryEntityAgentResponse](a.etcdTransport, agents[0], req)
 }
 
 // PreviewFlowLabels previews flow labels on a given agent.
@@ -52,11 +89,7 @@ func (a Agents) PreviewFlowLabels(
 	agent string,
 	req *previewv1.PreviewRequest,
 ) (*previewv1.PreviewFlowLabelsResponse, error) {
-	return rpc.Call[previewv1.PreviewFlowLabelsResponse](
-		a.Clients,
-		agent,
-		&cmdv1.PreviewFlowLabelsRequest{Request: req},
-	)
+	return transport.SendRequest[previewv1.PreviewFlowLabelsResponse](a.etcdTransport, agent, &cmdv1.PreviewFlowLabelsRequest{Request: req})
 }
 
 // PreviewHTTPRequests previews flow labels on a given agent.
@@ -66,9 +99,21 @@ func (a Agents) PreviewHTTPRequests(
 	agent string,
 	req *previewv1.PreviewRequest,
 ) (*previewv1.PreviewHTTPRequestsResponse, error) {
-	return rpc.Call[previewv1.PreviewHTTPRequestsResponse](
-		a.Clients,
-		agent,
-		&cmdv1.PreviewHTTPRequestsRequest{Request: req},
-	)
+	return transport.SendRequest[previewv1.PreviewHTTPRequestsResponse](a.etcdTransport, agent, &cmdv1.PreviewHTTPRequestsRequest{Request: req})
+}
+
+func (a Agents) GetAgents() ([]string, error) {
+
+	re := regexp.MustCompile(`/peers/aperture-agent/[^/]+/`)
+
+	resp, err := a.etcdClient.Client.KV.Get(context.Background(), "/peers/aperture-agent/", clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	agents := []string{}
+	for _, kv := range resp.Kvs {
+		agents = append(agents, re.ReplaceAllString(string(kv.Key), ""))
+	}
+	return agents, nil
 }

--- a/pkg/agent-functions/flowcontrol-controlpoints.go
+++ b/pkg/agent-functions/flowcontrol-controlpoints.go
@@ -6,9 +6,9 @@ import (
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	agentinfo "github.com/fluxninja/aperture/v2/pkg/agent-info"
 	"github.com/fluxninja/aperture/v2/pkg/cache"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/policies/flowcontrol/selectors"
 	flowcontrolControlPoints "github.com/fluxninja/aperture/v2/pkg/policies/flowcontrol/service/controlpoints"
-	"github.com/fluxninja/aperture/v2/pkg/rpc"
 )
 
 // FlowControlControlPointsHandler is a handler for ListFlowControlPoints function
@@ -43,6 +43,6 @@ func (h *FlowControlControlPointsHandler) ListFlowControlPoints(
 }
 
 // RegisterControlPointsHandler registers ControlPointsHandler in handler registry.
-func RegisterControlPointsHandler(handler FlowControlControlPointsHandler, registry *rpc.HandlerRegistry) error {
-	return rpc.RegisterFunction(registry, handler.ListFlowControlPoints)
+func RegisterControlPointsHandler(handler FlowControlControlPointsHandler, t *transport.EtcTransportClient) error {
+	return transport.RegisterFunction(t, handler.ListFlowControlPoints)
 }

--- a/pkg/agent-functions/flowcontrol-controlpoints.go
+++ b/pkg/agent-functions/flowcontrol-controlpoints.go
@@ -43,6 +43,6 @@ func (h *FlowControlControlPointsHandler) ListFlowControlPoints(
 }
 
 // RegisterControlPointsHandler registers ControlPointsHandler in handler registry.
-func RegisterControlPointsHandler(handler FlowControlControlPointsHandler, t *transport.EtcTransportClient) error {
+func RegisterControlPointsHandler(handler FlowControlControlPointsHandler, t *transport.EtcdTransportClient) error {
 	return transport.RegisterFunction(t, handler.ListFlowControlPoints)
 }

--- a/pkg/agent-functions/preview.go
+++ b/pkg/agent-functions/preview.go
@@ -69,7 +69,7 @@ func (h *PreviewHandler) PreviewHTTPRequests(
 }
 
 // RegisterPreviewHandler registers PreviewHandler in handler registry.
-func RegisterPreviewHandler(handler *PreviewHandler, t *transport.EtcTransportClient) error {
+func RegisterPreviewHandler(handler *PreviewHandler, t *transport.EtcdTransportClient) error {
 	// Note: Registering also when handler is disabled, so that we can send
 	// more specific error code than Unimplemented.
 	if err := transport.RegisterFunction(t, handler.PreviewFlowLabels); err != nil {

--- a/pkg/agent-functions/preview.go
+++ b/pkg/agent-functions/preview.go
@@ -3,14 +3,15 @@ package agentfunctions
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	previewv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/flowcontrol/preview/v1"
 	"github.com/fluxninja/aperture/v2/pkg/config"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/policies/flowcontrol/service/preview"
 	previewconfig "github.com/fluxninja/aperture/v2/pkg/policies/flowcontrol/service/preview/config"
-	"github.com/fluxninja/aperture/v2/pkg/rpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // PreviewHandler is a handler for preview-family of functions.
@@ -68,13 +69,13 @@ func (h *PreviewHandler) PreviewHTTPRequests(
 }
 
 // RegisterPreviewHandler registers PreviewHandler in handler registry.
-func RegisterPreviewHandler(handler *PreviewHandler, registry *rpc.HandlerRegistry) error {
+func RegisterPreviewHandler(handler *PreviewHandler, t *transport.EtcTransportClient) error {
 	// Note: Registering also when handler is disabled, so that we can send
 	// more specific error code than Unimplemented.
-	if err := rpc.RegisterFunction(registry, handler.PreviewFlowLabels); err != nil {
+	if err := transport.RegisterFunction(t, handler.PreviewFlowLabels); err != nil {
 		return err
 	}
-	if err := rpc.RegisterFunction(registry, handler.PreviewHTTPRequests); err != nil {
+	if err := transport.RegisterFunction(t, handler.PreviewHTTPRequests); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/agent-functions/provide.go
+++ b/pkg/agent-functions/provide.go
@@ -58,7 +58,7 @@ func RegisterClient(in RegisterClientIn) error {
 	return nil
 }
 
-// RegisterEtcdTransport registers a server on the etcd transport
+// RegisterEtcdTransport registers a server on the etcd transport.
 func RegisterEtcdTransport(in RegisterClientIn) {
 	transport.RegisterWatcher(in.Lc, in.EtcdTransportClient, info.Hostname)
 }

--- a/pkg/agent-functions/provide.go
+++ b/pkg/agent-functions/provide.go
@@ -39,7 +39,7 @@ type RegisterClientIn struct {
 	Unmarshaller        config.Unmarshaller
 	Handlers            *rpc.HandlerRegistry
 	ConnBuilder         grpcclient.ClientConnectionBuilder `name:"agent-functions"`
-	EtcdTransportClient *transport.EtcTransportClient
+	EtcdTransportClient *transport.EtcdTransportClient
 	EtcdClient          *etcdclient.Client
 }
 
@@ -58,6 +58,7 @@ func RegisterClient(in RegisterClientIn) error {
 	return nil
 }
 
+// RegisterEtcdTransport registers a server on the etcd transport
 func RegisterEtcdTransport(in RegisterClientIn) {
 	transport.RegisterWatcher(in.Lc, in.EtcdTransportClient, info.Hostname)
 }

--- a/pkg/agent-functions/provide.go
+++ b/pkg/agent-functions/provide.go
@@ -5,6 +5,8 @@ import (
 
 	afconfig "github.com/fluxninja/aperture/v2/pkg/agent-functions/config"
 	"github.com/fluxninja/aperture/v2/pkg/config"
+	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/info"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 	grpcclient "github.com/fluxninja/aperture/v2/pkg/net/grpc"
@@ -24,6 +26,7 @@ var Module = fx.Options(
 	),
 	fx.Invoke(
 		RegisterClient,
+		RegisterEtcdTransport,
 		RegisterControlPointsHandler,
 		RegisterPreviewHandler,
 	),
@@ -32,10 +35,12 @@ var Module = fx.Options(
 // RegisterClientIn are parameters for InvokeClient function.
 type RegisterClientIn struct {
 	fx.In
-	Lc           fx.Lifecycle
-	Unmarshaller config.Unmarshaller
-	Handlers     *rpc.HandlerRegistry
-	ConnBuilder  grpcclient.ClientConnectionBuilder `name:"agent-functions"`
+	Lc                  fx.Lifecycle
+	Unmarshaller        config.Unmarshaller
+	Handlers            *rpc.HandlerRegistry
+	ConnBuilder         grpcclient.ClientConnectionBuilder `name:"agent-functions"`
+	EtcdTransportClient *transport.EtcTransportClient
+	EtcdClient          *etcdclient.Client
 }
 
 // RegisterClient registers a client which will allow calling agent functions from controller.
@@ -51,4 +56,8 @@ func RegisterClient(in RegisterClientIn) error {
 	}
 
 	return nil
+}
+
+func RegisterEtcdTransport(in RegisterClientIn) {
+	transport.RegisterWatcher(in.Lc, in.EtcdTransportClient, info.Hostname)
 }

--- a/pkg/cmd/controller.go
+++ b/pkg/cmd/controller.go
@@ -46,8 +46,12 @@ func (h *Handler) ListAgents(
 	ctx context.Context,
 	_ *emptypb.Empty,
 ) (*cmdv1.ListAgentsResponse, error) {
+	agents, err := h.agents.GetAgents()
+	if err != nil {
+		return nil, err
+	}
 	return &cmdv1.ListAgentsResponse{
-		Agents: h.agents.List(),
+		Agents: agents,
 	}, nil
 }
 

--- a/pkg/discovery/entities/entities-service.go
+++ b/pkg/discovery/entities/entities-service.go
@@ -27,7 +27,7 @@ type RegisterEntitiesServiceIn struct {
 	Server              *grpc.Server `name:"default"`
 	Cache               *Entities
 	Registry            *rpc.HandlerRegistry
-	EtcdTransportClient *transport.EtcTransportClient
+	EtcdTransportClient *transport.EtcdTransportClient
 }
 
 // RegisterEntitiesService registers a service for entity cache.

--- a/pkg/discovery/entities/entities-service.go
+++ b/pkg/discovery/entities/entities-service.go
@@ -11,6 +11,7 @@ import (
 
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	entitiesv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/discovery/entities/v1"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/rpc"
 )
 
@@ -23,9 +24,10 @@ type EntitiesService struct {
 // RegisterEntitiesServiceIn bundles and annotates parameters.
 type RegisterEntitiesServiceIn struct {
 	fx.In
-	Server   *grpc.Server `name:"default"`
-	Cache    *Entities
-	Registry *rpc.HandlerRegistry
+	Server              *grpc.Server `name:"default"`
+	Cache               *Entities
+	Registry            *rpc.HandlerRegistry
+	EtcdTransportClient *transport.EtcTransportClient
 }
 
 // RegisterEntitiesService registers a service for entity cache.
@@ -34,11 +36,11 @@ func RegisterEntitiesService(in RegisterEntitiesServiceIn) error {
 		entityCache: in.Cache,
 	}
 	entitiesv1.RegisterEntitiesServiceServer(in.Server, svc)
-	err := rpc.RegisterFunction(in.Registry, svc.ListDiscoveryEntities)
+	err := transport.RegisterFunction(in.EtcdTransportClient, svc.ListDiscoveryEntities)
 	if err != nil {
 		return err
 	}
-	err = rpc.RegisterFunction(in.Registry, svc.ListDiscoveryEntity)
+	err = transport.RegisterFunction(in.EtcdTransportClient, svc.ListDiscoveryEntity)
 	if err != nil {
 		return err
 	}

--- a/pkg/etcd/transport/client.go
+++ b/pkg/etcd/transport/client.go
@@ -1,0 +1,167 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/fx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
+	"github.com/fluxninja/aperture/v2/pkg/log"
+)
+
+var TransportClientModule = fx.Options(
+	fx.Provide(NewEtcdTransportClient),
+)
+
+type EtcTransportClient struct {
+	etcdClient *etcdclient.Client
+	Registry   *HandlerRegistry
+}
+
+func NewEtcdTransportClient(client *etcdclient.Client) *EtcTransportClient {
+	return &EtcTransportClient{
+		etcdClient: client,
+		Registry:   NewHandlerRegistry(),
+	}
+}
+
+type HandlerRegistry struct {
+	handlers map[protoreflect.FullName]untypedHandler
+}
+
+type untypedHandler func(context.Context, *anypb.Any) (proto.Message, error)
+
+// NewHandlerRegistry creates a new HandlerRegistry.
+func NewHandlerRegistry() *HandlerRegistry {
+	return &HandlerRegistry{
+		handlers: map[protoreflect.FullName]untypedHandler{},
+	}
+}
+
+func RegisterWatcher(lc fx.Lifecycle, t *EtcTransportClient, agentName string) {
+
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			go t.RegisterWatcher(agentName)
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			return nil
+		},
+	})
+}
+
+func (c *EtcTransportClient) RegisterWatcher(agentName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	path := path.Join(RPCBasePath, RPCRequestPath, agentName)
+	watchCh := c.etcdClient.Watch(ctx, path, clientv3.WithPrefix())
+	for watchResp := range watchCh {
+		if watchResp.Err() != nil {
+			log.Error().Err(watchResp.Err()).Msg("failed to watch etcd path")
+			continue
+		}
+
+		for _, event := range watchResp.Events {
+			if event.Type == clientv3.EventTypePut {
+				id, _ := strings.CutPrefix(string(event.Kv.Key), path)
+				request := Request{
+					ID:     id,
+					Data:   event.Kv.Value,
+					Client: agentName,
+				}
+				go c.handleRequest(ctx, request)
+			}
+		}
+	}
+}
+
+func (c *EtcTransportClient) handleRequest(ctx context.Context, req Request) {
+	var msg anypb.Any
+	err := proto.Unmarshal(req.Data, &msg)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response data")
+		return
+	}
+	result, _ := c.callHandler(ctx, &msg)
+	response := Response{
+		Client: req.Client,
+		Data:   result,
+		ID:     req.ID,
+	}
+	c.respond(ctx, response)
+}
+
+func (c *EtcTransportClient) callHandler(ctx context.Context, req *anypb.Any) ([]byte, error) {
+	handler, exists := c.Registry.handlers[req.MessageName()]
+	if !exists {
+		return nil, status.Error(
+			codes.Unavailable,
+			fmt.Sprintf("no handler for type %s", req.MessageName()),
+		)
+	}
+
+	resp, err := handler(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	serializedResp, err := proto.Marshal(resp)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return serializedResp, nil
+}
+
+func (c *EtcTransportClient) respond(ctx context.Context, resp Response) {
+
+	path := path.Join(RPCBasePath, RPCResponsePath, resp.Client, resp.ID)
+
+	lease, err := c.etcdClient.Grant(context.Background(), 30)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to grant lease")
+		return
+	}
+
+	_, err = c.etcdClient.Put(ctx, path, string(resp.Data), clientv3.WithLease(lease.ID))
+	if err != nil {
+		log.Error().Err(err).Msg("failed to write response to etcd")
+	}
+}
+
+// RegisterFunction register a function as a handler in the registry
+// Only one function for a given Req type can be registered.
+func RegisterFunction[Req, Resp proto.Message](
+	t *EtcTransportClient,
+	handler func(context.Context, Req) (Resp, error),
+) error {
+	var req Req // used only to pull out the message name from descriptor
+	name := req.ProtoReflect().Descriptor().FullName()
+	if _, exists := t.Registry.handlers[name]; exists {
+		log.Error().Err(fmt.Errorf("handler for %s already registered", name))
+		return fmt.Errorf("handler for %s already registered", name)
+	}
+
+	t.Registry.handlers[name] = func(ctx context.Context, anyreq *anypb.Any) (proto.Message, error) {
+		var nilReq Req
+		req := nilReq.ProtoReflect().New().Interface().(Req)
+		if err := anyreq.UnmarshalTo(req); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		return handler(ctx, req)
+	}
+
+	return nil
+}

--- a/pkg/etcd/transport/client.go
+++ b/pkg/etcd/transport/client.go
@@ -18,18 +18,18 @@ import (
 	"github.com/fluxninja/aperture/v2/pkg/log"
 )
 
-// TransportClientModule is the client fx provider for etcd transport
+// TransportClientModule is the client fx provider for etcd transport.
 var TransportClientModule = fx.Options(
 	fx.Provide(NewEtcdTransportClient),
 )
 
-// EtcdTransportClient is the client side for the etcd transport
+// EtcdTransportClient is the client side for the etcd transport.
 type EtcdTransportClient struct {
 	etcdClient *etcdclient.Client
 	Registry   *HandlerRegistry
 }
 
-// NewEtcdTransportClient creates and returns a new etcd transport client module
+// NewEtcdTransportClient creates and returns a new etcd transport client module.
 func NewEtcdTransportClient(client *etcdclient.Client) *EtcdTransportClient {
 	return &EtcdTransportClient{
 		etcdClient: client,
@@ -53,9 +53,8 @@ func NewHandlerRegistry() *HandlerRegistry {
 	}
 }
 
-// RegisterWatcher allows to register a client on the etcd transport
+// RegisterWatcher allows to register a client on the etcd transport.
 func RegisterWatcher(lc fx.Lifecycle, t *EtcdTransportClient, agentName string) {
-
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			go t.RegisterWatcher(agentName)
@@ -67,7 +66,7 @@ func RegisterWatcher(lc fx.Lifecycle, t *EtcdTransportClient, agentName string) 
 	})
 }
 
-// RegisterWatcher register an agent on the etcd transport client
+// RegisterWatcher register an agent on the etcd transport client.
 func (c *EtcdTransportClient) RegisterWatcher(agentName string) {
 	path := path.Join(RPCBasePath, RPCRequestPath, agentName)
 	watchCh := c.etcdClient.Watch(context.Background(), path, clientv3.WithPrefix())
@@ -130,7 +129,6 @@ func (c *EtcdTransportClient) callHandler(ctx context.Context, req *anypb.Any) (
 }
 
 func (c *EtcdTransportClient) respond(ctx context.Context, resp Response) {
-
 	path := path.Join(RPCBasePath, RPCResponsePath, resp.Client, resp.ID)
 
 	lease, err := c.etcdClient.Grant(context.Background(), 30)

--- a/pkg/etcd/transport/client.go
+++ b/pkg/etcd/transport/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path"
 	"strings"
-	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/fx"
@@ -62,11 +61,8 @@ func RegisterWatcher(lc fx.Lifecycle, t *EtcTransportClient, agentName string) {
 }
 
 func (c *EtcTransportClient) RegisterWatcher(agentName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	defer cancel()
-
 	path := path.Join(RPCBasePath, RPCRequestPath, agentName)
-	watchCh := c.etcdClient.Watch(ctx, path, clientv3.WithPrefix())
+	watchCh := c.etcdClient.Watch(context.Background(), path, clientv3.WithPrefix())
 	for watchResp := range watchCh {
 		if watchResp.Err() != nil {
 			log.Error().Err(watchResp.Err()).Msg("failed to watch etcd path")
@@ -81,7 +77,7 @@ func (c *EtcTransportClient) RegisterWatcher(agentName string) {
 					Data:   event.Kv.Value,
 					Client: agentName,
 				}
-				go c.handleRequest(ctx, request)
+				go c.handleRequest(context.Background(), request)
 			}
 		}
 	}

--- a/pkg/etcd/transport/paths.go
+++ b/pkg/etcd/transport/paths.go
@@ -1,0 +1,12 @@
+package transport
+
+const (
+	// RPCBasePath is the base path for all etc based RPCs.
+	RPCBasePath = "/rpc"
+
+	// RPCRequestPath is the path for RPC requests.
+	RPCRequestPath = "/request"
+
+	// RPCResponsePath is the path for RPC responses.
+	RPCResponsePath = "/response"
+)

--- a/pkg/etcd/transport/server.go
+++ b/pkg/etcd/transport/server.go
@@ -65,7 +65,8 @@ func SendRequests[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportS
 			if err != nil {
 				log.Error().Err(err).Msg("failed to send request to agent")
 				respCh <- &Response{
-					Error: err,
+					Client: agentName,
+					Error:  err,
 				}
 			} else {
 				respCh <- resp
@@ -152,7 +153,8 @@ func (t *EtcdTransportServer) waitForResponse(req Request) (*Response, error) {
 
 	if len(resp.Kvs) > 0 {
 		return &Response{
-			Data: resp.Kvs[0].Value,
+			Client: req.Client,
+			Data:   resp.Kvs[0].Value,
 		}, nil
 	}
 
@@ -170,7 +172,8 @@ func (t *EtcdTransportServer) waitForResponse(req Request) (*Response, error) {
 			for _, event := range watchResp.Events {
 				if event.Type == clientv3.EventTypePut {
 					return &Response{
-						Data: event.Kv.Value,
+						Client: req.Client,
+						Data:   event.Kv.Value,
 					}, nil
 				}
 			}

--- a/pkg/etcd/transport/server.go
+++ b/pkg/etcd/transport/server.go
@@ -65,7 +65,7 @@ type Response struct {
 // NewEtcdTransportServer creates a new server on the etcd transport.
 func NewEtcdTransportServer(client *etcdclient.Client) (*EtcdTransportServer, error) {
 	if client == nil {
-		return nil, errors.New("provided etc client is nil")
+		return nil, errors.New("provided etcd client is nil")
 	}
 	return &EtcdTransportServer{
 		etcdClient: client,
@@ -78,12 +78,6 @@ func SendRequests[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportS
 
 	for _, agent := range agents {
 		go func(agentName string) {
-			defer func() {
-				if r := recover(); r != nil {
-					log.Error().Err(fmt.Errorf("panic recovered: %v", r)).Msg("failed to send request to agent")
-					respCh <- &Response{Error: fmt.Errorf("panic recovered: %v", r)}
-				}
-			}()
 			resp, err := t.SendRequest(agentName, msg)
 			if err != nil {
 				log.Error().Err(err).Msg("failed to send request to agent")
@@ -143,7 +137,7 @@ func (t *EtcdTransportServer) SendRequest(client string, msg proto.Message) (*Re
 
 	rawReq, err := proto.Marshal(anyreq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf("failed to marshal request %v: %w", msg, err)
 	}
 
 	req := Request{

--- a/pkg/etcd/transport/server.go
+++ b/pkg/etcd/transport/server.go
@@ -18,37 +18,37 @@ import (
 	"github.com/fluxninja/aperture/v2/pkg/log"
 )
 
-// ExactMessage is like proto.Message, but known to point to T
+// ExactMessage is like proto.Message, but known to point to T.
 type ExactMessage[T any] interface {
 	proto.Message
 	*T
 }
 
-// TransportServerModule is the server fx provider for etcd transport
+// TransportServerModule is the server fx provider for etcd transport.
 var TransportServerModule = fx.Options(
 	fx.Provide(NewEtcdTransportServer),
 )
 
-// Result is a result from one agent
+// Result is a result from one agent.
 type Result[Resp any] struct {
 	Client  string
 	Success Resp
 	Err     error
 }
 
-// EtcdTransportServer is the server side of the etcd transport
+// EtcdTransportServer is the server side of the etcd transport.
 type EtcdTransportServer struct {
 	etcdClient *etcdclient.Client
 }
 
-// Request is the raw request on the etcd transport
+// Request is the raw request on the etcd transport.
 type Request struct {
 	ID     string
 	Client string
 	Data   []byte
 }
 
-// Response is the raw response on the etcd transport
+// Response is the raw response on the etcd transport.
 type Response struct {
 	ID     string
 	Client string
@@ -56,14 +56,14 @@ type Response struct {
 	Error  error
 }
 
-// NewEtcdTransportServer creates a new server on the etcd transport
+// NewEtcdTransportServer creates a new server on the etcd transport.
 func NewEtcdTransportServer(client *etcdclient.Client) *EtcdTransportServer {
 	return &EtcdTransportServer{
 		etcdClient: client,
 	}
 }
 
-// SendRequests allows consumers of the etcd transport to send requests to agents
+// SendRequests allows consumers of the etcd transport to send requests to agents.
 func SendRequests[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportServer, agents []string, msg proto.Message) ([]Result[*RespValue], error) {
 	respCh := make(chan *Response, len(agents))
 
@@ -101,7 +101,7 @@ func SendRequests[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportS
 	return resps, nil
 }
 
-// SendRequest allows consumers of the etcd transport to send single request to agents
+// SendRequest allows consumers of the etcd transport to send single request to agents.
 func SendRequest[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportServer, client string, msg proto.Message) (*RespValue, error) {
 	resp, err := t.SendRequest(client, msg)
 	if err != nil {
@@ -116,9 +116,8 @@ func SendRequest[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportSe
 	return &result, nil
 }
 
-// SendRequest sends a request to etcd, supposed to be consumed by an agent
+// SendRequest sends a request to etcd, supposed to be consumed by an agent.
 func (t *EtcdTransportServer) SendRequest(client string, msg proto.Message) (*Response, error) {
-
 	anyreq, err := anypb.New(msg)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/pkg/etcd/transport/server.go
+++ b/pkg/etcd/transport/server.go
@@ -1,0 +1,178 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/google/uuid"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/fx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
+	"github.com/fluxninja/aperture/v2/pkg/log"
+)
+
+type ExactMessage[T any] interface {
+	proto.Message
+	*T
+}
+
+var TransportModule = fx.Options(
+	fx.Provide(NewEtcdTransportServer),
+)
+
+type Result[Resp any] struct {
+	Client  string
+	Success Resp
+	Err     error
+}
+
+type EtcdTransportServer struct {
+	etcdClient *etcdclient.Client
+}
+
+type Request struct {
+	ID     string
+	Client string
+	Data   []byte
+}
+
+type Response struct {
+	ID     string
+	Client string
+	Data   []byte
+	Error  error
+}
+
+func NewEtcdTransportServer(client *etcdclient.Client) *EtcdTransportServer {
+	return &EtcdTransportServer{
+		etcdClient: client,
+	}
+}
+
+func SendRequests[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportServer, agents []string, msg proto.Message) ([]Result[*RespValue], error) {
+	respCh := make(chan *Response, len(agents))
+
+	for _, agent := range agents {
+		go func(agentName string) {
+			resp, err := t.SendRequest(agentName, msg)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to send request to agent")
+				resp.Error = err
+			}
+			respCh <- resp
+		}(agent)
+	}
+
+	resps := make([]Result[*RespValue], 0, len(agents))
+	for i := 0; i < len(agents); i++ {
+		resp := <-respCh
+		if resp.Error != nil {
+			return nil, resp.Error
+		}
+		var result RespValue
+		if err := proto.Unmarshal(resp.Data, Resp(&result)); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		resps = append(resps, Result[*RespValue]{
+			Client:  resp.Client,
+			Success: &result,
+		})
+	}
+
+	return resps, nil
+}
+
+func SendRequest[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportServer, client string, msg proto.Message) (*RespValue, error) {
+	resp, err := t.SendRequest(client, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	var result RespValue
+	if err := proto.Unmarshal(resp.Data, Resp(&result)); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (t *EtcdTransportServer) SendRequest(client string, msg proto.Message) (*Response, error) {
+
+	anyreq, err := anypb.New(msg)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	rawReq, err := proto.Marshal(anyreq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req := Request{
+		ID:     uuid.NewString(),
+		Client: client,
+		Data:   rawReq,
+	}
+
+	path := path.Join(RPCBasePath, RPCRequestPath, req.Client, req.ID)
+
+	lease, err := t.etcdClient.Grant(context.Background(), 30)
+	if err != nil {
+		return nil, fmt.Errorf("failed to grant lease: %w", err)
+	}
+
+	_, err = t.etcdClient.Put(context.Background(), path, string(rawReq), clientv3.WithLease(lease.ID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request to etcd: %w", err)
+	}
+
+	return t.waitForResponse(req)
+}
+
+func (t *EtcdTransportServer) waitForResponse(req Request) (*Response, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	responePath := path.Join(RPCBasePath, RPCResponsePath, req.Client, req.ID)
+
+	resp, err := t.etcdClient.Get(ctx, responePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get response from etcd: %w", err)
+	}
+
+	if len(resp.Kvs) > 0 {
+		return &Response{
+			Data: resp.Kvs[0].Value,
+		}, nil
+	}
+
+	watchCh := t.etcdClient.Watch(ctx, responePath)
+	for {
+		select {
+		case watchResp, ok := <-watchCh:
+			if !ok {
+				return nil, fmt.Errorf("watch channel closed")
+			}
+			if watchResp.Err() != nil {
+				return nil, fmt.Errorf("failed to watch etcd path: %w", watchResp.Err())
+			}
+
+			for _, event := range watchResp.Events {
+				if event.Type == clientv3.EventTypePut {
+					return &Response{
+						Data: event.Kv.Value,
+					}, nil
+				}
+			}
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context deadline exceeded")
+		}
+	}
+}

--- a/pkg/etcd/transport/server.go
+++ b/pkg/etcd/transport/server.go
@@ -64,9 +64,12 @@ func SendRequests[RespValue any, Resp ExactMessage[RespValue]](t *EtcdTransportS
 			resp, err := t.SendRequest(agentName, msg)
 			if err != nil {
 				log.Error().Err(err).Msg("failed to send request to agent")
-				resp.Error = err
+				respCh <- &Response{
+					Error: err,
+				}
+			} else {
+				respCh <- resp
 			}
-			respCh <- resp
 		}(agent)
 	}
 

--- a/pkg/policies/autoscale/kubernetes/service/controlpoints/control-points.go
+++ b/pkg/policies/autoscale/kubernetes/service/controlpoints/control-points.go
@@ -33,7 +33,7 @@ func (h *Handler) GetControlPoints(ctx context.Context, _ *emptypb.Empty) (*cont
 }
 
 // RegisterControlPointsHandler registers ControlPointsHandler in RPC handler registry.
-func RegisterControlPointsHandler(handler *Handler, t *transport.EtcTransportClient) error {
+func RegisterControlPointsHandler(handler *Handler, t *transport.EtcdTransportClient) error {
 	return transport.RegisterFunction(t, handler.ListAutoScaleControlPoints)
 }
 

--- a/pkg/policies/autoscale/kubernetes/service/controlpoints/control-points.go
+++ b/pkg/policies/autoscale/kubernetes/service/controlpoints/control-points.go
@@ -8,8 +8,8 @@ import (
 	controlpointsv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/autoscale/kubernetes/controlpoints/v1"
 	cmdv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/cmd/v1"
 	agentinfo "github.com/fluxninja/aperture/v2/pkg/agent-info"
+	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
 	"github.com/fluxninja/aperture/v2/pkg/policies/autoscale/kubernetes/discovery"
-	"github.com/fluxninja/aperture/v2/pkg/rpc"
 )
 
 // Handler is the gRPC server handler.
@@ -33,8 +33,8 @@ func (h *Handler) GetControlPoints(ctx context.Context, _ *emptypb.Empty) (*cont
 }
 
 // RegisterControlPointsHandler registers ControlPointsHandler in RPC handler registry.
-func RegisterControlPointsHandler(handler *Handler, registry *rpc.HandlerRegistry) error {
-	return rpc.RegisterFunction(registry, handler.ListAutoScaleControlPoints)
+func RegisterControlPointsHandler(handler *Handler, t *transport.EtcTransportClient) error {
+	return transport.RegisterFunction(t, handler.ListAutoScaleControlPoints)
 }
 
 // ListAutoScaleControlPoints lists currently discovered control points.


### PR DESCRIPTION
### Description of change

- Adds a new package for etcd based RPC
- Controller registers as a server and agents register as a client
- The etcd keys used to communicate have a lease and get auto deleted

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Introduced a new `transport` package to provide client-side and server-side communication with etcd transport. This includes registering handlers, starting a watcher, handling requests, and responding to requests.
- Enhanced the `Agents` struct in the `agent-functions` package to include `etcdTransport` and `etcdClient` fields. Updated associated functions to use these new fields for sending requests to agents.
- Added a new function `GetAgents` to retrieve the list of agents registered on etcd.
- Improved the `cmd` package to include error handling in the `ListAgents` function.

**Refactor:**
- Modified the `agent-functions` package to use the new `transport` package for registering functions and handlers.
- Updated the `discovery/entities` package to use the new `transport` package for registering services.

**Chore:**
- Reordered the modules in `cmd/aperture-controller/controller.go` to have "transport.TransportServerModule" before "agents.Module".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->