### PR TITLE
Fix checkout depth in workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 100
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Modified the GitHub Actions workflow for creating releases. The `actions/checkout` step now fetches the complete history of the repository, enhancing the accuracy of generated changelogs and release notes by considering all commits rather than the last 100. This change does not impact end-user functionality but improves the development and release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->