### PR TITLE
Move new chart parameters to the end

### DIFF
--- a/blueprints/grafana/utils/bar_chart_panel.libsonnet
+++ b/blueprints/grafana/utils/bar_chart_panel.libsonnet
@@ -1,6 +1,6 @@
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v9.4.0/main.libsonnet';
 
-function(title, dsName, query, strFilters, h=10, w=24, description='', legendFormat='', queryFormat='time_series', instantQuery=false, range=true, labelSpacing=0, axisGridshow=true, axisPlacement='hidden', unit='short', mode='single', sort='sort') {
+function(title, dsName, query, strFilters, h=10, w=24, legendFormat='', queryFormat='time_series', instantQuery=false, range=true, labelSpacing=0, axisGridshow=true, axisPlacement='hidden', mode='single', sort='sort', unit='short', description='') {
   local barChartPanel =
     g.panel.barChart.new(title)
     + g.panel.barChart.panelOptions.withDescription(description)

--- a/blueprints/grafana/utils/time_series_panel.libsonnet
+++ b/blueprints/grafana/utils/time_series_panel.libsonnet
@@ -1,6 +1,6 @@
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v9.4.0/main.libsonnet';
 
-function(title, dsName, query, strFilters, axisLabel='', unit='', description='', h=10, w=24, targets=[]) {
+function(title, dsName, query, strFilters, axisLabel='', unit='', h=10, w=24, targets=[], description='') {
   local timeseries =
     g.panel.timeSeries.new(title)
     + g.panel.timeSeries.panelOptions.withDescription(description)


### PR DESCRIPTION
### Description of change
Moved new chart parameters to the end so that it doesn't break existing grafana panels that don't use named parameters

Resolves https://github.com/fluxninja/cloud/issues/11552

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Refactor: Updated Function Signatures in Grafana Utilities

- The function parameters in `bar_chart_panel.libsonnet` and `time_series_panel.libsonnet` have been reordered for improved readability and maintainability. 
- This change does not introduce any new features or affect the functionality of existing ones, but developers will need to adjust the order of arguments when calling these functions.
- Please refer to the updated documentation for the correct parameter order."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->