### PR TITLE
Simplify newer version behaviour for aperturectl

### DIFF
--- a/cmd/aperturectl/cmd/blueprints/pull.go
+++ b/cmd/aperturectl/cmd/blueprints/pull.go
@@ -38,7 +38,7 @@ func PullRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	blueprintsCacheRoot = filepath.Join(userHomeDir, ".aperturectl", "blueprints")
+	blueprintsCacheRoot = filepath.Join(userHomeDir, utils.AperturectlRootDir, "blueprints")
 	err = os.MkdirAll(blueprintsCacheRoot, os.ModePerm)
 	if err != nil {
 		return err

--- a/cmd/aperturectl/cmd/build/root.go
+++ b/cmd/aperturectl/cmd/build/root.go
@@ -64,7 +64,7 @@ var BuildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		builderCacheRoot = filepath.Join(userHomeDir, ".aperturectl", "build")
+		builderCacheRoot = filepath.Join(userHomeDir, utils.AperturectlRootDir, utils.BuilderCacheRoot)
 		err = os.MkdirAll(builderCacheRoot, os.ModePerm)
 		if err != nil {
 			return err

--- a/cmd/aperturectl/cmd/cloud/utils/controller.go
+++ b/cmd/aperturectl/cmd/cloud/utils/controller.go
@@ -53,7 +53,7 @@ type ControllerConn struct {
 	conn              *grpc.ClientConn
 }
 
-// CloudInitFlags sets up flags for Cloud Controller.
+// InitFlags sets up flags for Cloud Controller.
 func (c *ControllerConn) InitFlags(flags *flag.FlagSet) {
 	flags.StringVar(
 		&c.controllerAddr,
@@ -104,7 +104,7 @@ func (c *ControllerConn) PreRunE(_ *cobra.Command, _ []string) error {
 	if c.config == "" {
 		homeDir, err := os.UserHomeDir()
 		if err == nil {
-			c.config = filepath.Join(homeDir, ".aperturectl", "config")
+			c.config = filepath.Join(homeDir, utils.AperturectlRootDir, "config")
 			if _, err := os.Stat(c.config); err != nil {
 				c.config = ""
 			}
@@ -167,18 +167,18 @@ func (c *ControllerConn) CloudPolicyClient() (utils.CloudPolicyClient, error) {
 	return c.policyServiceClient()
 }
 
-// client returns Controller IntrospectionClient, connecting to controller if not yet connected.
+// IntrospectionClient returns Controller IntrospectionClient, connecting to controller if not yet connected.
 func (c *ControllerConn) IntrospectionClient() (utils.IntrospectionClient, error) {
 	return nil, errors.New("this subcommand cannot be used with the Cloud Controller")
 }
 
-// client returns Controller StatusClient, connecting to controller if not yet connected.
+// StatusClient returns Controller StatusClient, connecting to controller if not yet connected.
 func (c *ControllerConn) StatusClient() (utils.StatusClient, error) {
 	// StatusClient has no restrictions.
 	return c.client()
 }
 
-// client returns Controller PolicyClient, connecting to controller if not yet connected.
+// PolicyClient returns Controller PolicyClient, connecting to controller if not yet connected.
 func (c *ControllerConn) PolicyClient() (utils.PolicyClient, error) {
 	// PolicyClient has no restrictions.
 	return c.client()

--- a/cmd/aperturectl/cmd/root.go
+++ b/cmd/aperturectl/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -95,14 +96,24 @@ func Execute() {
 		log.Error().Err(err).Msg("Failed to check if current version is newer")
 	}
 	if newer {
-		err = blueprints.RemoveRunE(nil, nil)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to remove latest blueprints")
-		} else {
-			err = utils.UpdateVersionFile(info.Version)
+		var userHomeDir string
+		userHomeDir, err = os.UserHomeDir()
+		if err == nil {
+			aperturectlRootDir := filepath.Join(userHomeDir, utils.AperturectlRootDir)
+			aperturectlBlueprintsCacheRoot := filepath.Join(aperturectlRootDir, utils.BlueprintsCacheRoot)
+			err = os.RemoveAll(aperturectlBlueprintsCacheRoot)
 			if err != nil {
-				log.Error().Err(err).Msg("Failed to update version file")
+				log.Error().Err(err).Msg("Failed to remove latest blueprints")
 			}
+			aperturectlBuilderCacheRoot := filepath.Join(aperturectlRootDir, utils.BuilderCacheRoot)
+			err = os.RemoveAll(aperturectlBuilderCacheRoot)
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to remove builder cache")
+			}
+		}
+		err = utils.UpdateVersionFile(info.Version)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to update version file")
 		}
 	}
 

--- a/cmd/aperturectl/cmd/utils/globals.go
+++ b/cmd/aperturectl/cmd/utils/globals.go
@@ -1,3 +1,17 @@
 package utils
 
-var AllowDeprecated = false
+import (
+	"path/filepath"
+)
+
+var (
+	// AllowDeprecated is a flag to allow deprecated blueprints to be listed.
+	AllowDeprecated = false
+
+	// AperturectlRootDir is the root directory for aperturectl.
+	AperturectlRootDir = ".aperturectl"
+	// BlueprintsCacheRoot is the root directory for blueprints cache.
+	BlueprintsCacheRoot = filepath.Join(AperturectlRootDir, "blueprints")
+	// BuilderCacheRoot is the root directory for builder cache.
+	BuilderCacheRoot = filepath.Join(AperturectlRootDir, "build")
+)

--- a/cmd/aperturectl/cmd/utils/version.go
+++ b/cmd/aperturectl/cmd/utils/version.go
@@ -15,7 +15,7 @@ func init() {
 	if err != nil {
 		userHomeDir = os.TempDir()
 	}
-	versionFilePath = filepath.Join(userHomeDir, ".aperturectl", "version")
+	versionFilePath = filepath.Join(userHomeDir, AperturectlRootDir, "version")
 }
 
 // CreateVersionFileIfNotExists creates a version file if it does not exist.


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the assignment of `blueprintsCacheRoot` and `builderCacheRoot` variables in `PullRunE` and `BuildCmd` functions respectively, replacing hardcoded paths with dynamic ones for better flexibility and maintainability.
- Refactor: Renamed and updated several functions in the Cloud Controller for clarity and error handling improvements.
- New Feature: Added logic to remove cache directories if the current version is newer, improving system cleanliness.
- New Feature: Introduced global variables in the `utils` package for better code modularity.
- Refactor: Updated the `versionFilePath` assignment to use a dynamic path, enhancing code flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->