### PR TITLE
Add inframeter to missing receiver dashboard queries

### DIFF
--- a/blueprints/grafana/panels/elasticsearch/es_time_series.libsonnet
+++ b/blueprints/grafana/panels/elasticsearch/es_time_series.libsonnet
@@ -142,38 +142,35 @@ function(policyName, infraMeterName, datasource, extraFilters) {
   local docsData = timeSeriesPanel('Documents State', datasource.name, '', stringFilters, 'short', targets=DocsQueries),
 
   // Total Docs
-  local totalDocsQuery = [
+  local totalDocsQuery =
     g.query.prometheus.new(datasource.name, 'sum(increase(elasticsearch_node_ingest_documents_total{ %(filters)s, infra_meter_name="%(infra_meter)s"}[$__range]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('Total Docs'),
-  ],
 
-  local totalDocs = timeSeriesPanel('Total Ingested Documents', datasource.name, '', stringFilters, 'short', targets=totalDocsQuery),
+  local totalDocs = timeSeriesPanel('Total Ingested Documents', datasource.name, '', stringFilters, 'short', targets=[totalDocsQuery]),
 
   // Current Docs
-  local currentDocsQuery = [
+  local currentDocsQuery =
     g.query.prometheus.new(datasource.name, 'sum(increase(elasticsearch_node_ingest_documents_current{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__range]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('Current Docs'),
-  ],
 
-  local currentDocs = timeSeriesPanel('Current Ingested Documents', datasource.name, '', stringFilters, 'short', targets=currentDocsQuery),
+  local currentDocs = timeSeriesPanel('Current Ingested Documents', datasource.name, '', stringFilters, 'short', targets=[currentDocsQuery]),
 
-  local translogOperationsQuery = [
+  local translogOperationsQuery =
     g.query.prometheus.new(datasource.name, 'sum(rate(elasticsearch_node_translog_operations_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('Translog Operations'),
-  ],
 
-  local translogOperations = timeSeriesPanel('Translog Operations', datasource.name, '', stringFilters, 'short', targets=translogOperationsQuery),
+  local translogOperations = timeSeriesPanel('Translog Operations', datasource.name, '', stringFilters, 'short', targets=[translogOperationsQuery]),
 
   // Active Threads for All Thread Pools
-  local activeThreadsQueries = [
+  local activeThreadsQueries =
     g.query.prometheus.new(datasource.name, 'sum(rate(elasticsearch_node_thread_pool_threads{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('{{threadpool}} Active Threads'),
-  ],
-  local activeThreads = timeSeriesPanel('Active Threads', datasource.name, '', stringFilters, 'short', targets=activeThreadsQueries),
+
+  local activeThreads = timeSeriesPanel('Active Threads', datasource.name, '', stringFilters, 'short', targets=[activeThreadsQueries]),
 
   local httpConnectionsQuery = g.query.prometheus.new(datasource.name, 'sum(elasticsearch_node_http_connections{%(filters)s, infra_meter_name="%(infra_meter)s"})' % { filters: stringFilters, infra_meter: infraMeterName })
                                + g.query.prometheus.withIntervalFactor(1)
@@ -206,20 +203,20 @@ function(policyName, infraMeterName, datasource, extraFilters) {
   local avgDiskUsage = timeSeriesPanel('Average Disk Usage', datasource.name, '', stringFilters, '%', targets=[avgDiskUsageQuery]),
 
   // Tasks Queued for All Thread Pools
-  local tasksQueuedQueries = [
-    g.query.prometheus.new(datasource.name, 'sum(rate(elasticsearch_node_thread_pool_tasks_queued{%(filters)s}[$__rate_interval]))' % { filters: stringFilters })
+  local tasksQueuedQueries =
+    g.query.prometheus.new(datasource.name, 'sum(rate(elasticsearch_node_thread_pool_tasks_queued{%(filters)s , infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('{{threadpool}} Tasks Queued'),
-  ],
-  local tasksQueued = timeSeriesPanel('Tasks Queued', datasource.name, '', stringFilters, 'short', targets=tasksQueuedQueries),
+
+  local tasksQueued = timeSeriesPanel('Tasks Queued', datasource.name, '', stringFilters, 'short', targets=[tasksQueuedQueries]),
 
   // Tasks Throughput for All Thread Pools
-  local tasksThroughputQueries = [
-    g.query.prometheus.new(datasource.name, 'sum(rate(elasticsearch_node_thread_pool_tasks_finished_total{%(filters)s}[$__rate_interval]))' % { filters: stringFilters })
+  local tasksThroughputQueries =
+    g.query.prometheus.new(datasource.name, 'sum(rate(elasticsearch_node_thread_pool_tasks_finished_total{%(filters)s , infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('{{threadpool}} Tasks Throughput'),
-  ],
-  local tasksThroughput = timeSeriesPanel('Tasks Throughput', datasource.name, '', stringFilters, 'ops', targets=tasksThroughputQueries),
+
+  local tasksThroughput = timeSeriesPanel('Tasks Throughput', datasource.name, '', stringFilters, 'ops', targets=[tasksThroughputQueries]),
 
   // GC Collections (young and old)
   local youngGcCollectionsQuery = g.query.prometheus.new(datasource.name, 'sum(rate(jvm_gc_collections_count_total{name="young",%(filters)s,infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })

--- a/blueprints/grafana/panels/pgsql/pgsql_static.libsonnet
+++ b/blueprints/grafana/panels/pgsql/pgsql_static.libsonnet
@@ -42,7 +42,7 @@ function(policyName, infraMeterName, datasource, extraFilters) {
 
   local maxConnections = statPanel('Max Connections',
                                    datasource.name,
-                                   'postgresql_connection_max{%(filters)s,infra_meter_name="%(infra_meter)s"} / postgresql_database_count' % { filters: stringFilters, infra_meter: infraMeterName },
+                                   'postgresql_connection_max{%(filters)s,infra_meter_name="%(infra_meter)s"} / postgresql_database_count{%(filters)s,infra_meter_name="%(infra_meter)s"}' % { filters: stringFilters, infra_meter: infraMeterName },
                                    stringFilters,
                                    instantQuery=true,
                                    range=false,

--- a/blueprints/grafana/panels/pgsql/pgsql_time_series.libsonnet
+++ b/blueprints/grafana/panels/pgsql/pgsql_time_series.libsonnet
@@ -69,22 +69,23 @@ function(policyName, infraMeterName, datasource, extraFilters) {
   local operations = timeSeriesPanel('Database Operations', datasource.name, 'operations/sec', stringFilters, targets=operationsTargets),
 
   local bufferWritesTargets = [
-    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,source="backend"}[$__rate_interval]))' % { filters: stringFilters })
+    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,infra_meter_name="%(infra_meter)s",source="backend"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('Backend'),
 
-    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,source="backend_fsync"}[$__rate_interval]))' % { filters: stringFilters })
+    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,infra_meter_name="%(infra_meter)s",source="backend_fsync"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('Backend Fsync'),
 
-    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,source="bgwriter"}[$__rate_interval]))' % { filters: stringFilters })
+    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,infra_meter_name="%(infra_meter)s",source="bgwriter"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('Bgwriter'),
 
-    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,source="checkpoints"}[$__rate_interval]))' % { filters: stringFilters })
+    g.query.prometheus.new(datasource.name, 'sum(rate(postgresql_bgwriter_buffers_writes_total{%(filters)s,infra_meter_name="%(infra_meter)s",source="checkpoints"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
     + g.query.prometheus.withIntervalFactor(1)
     + g.query.prometheus.withLegendFormat('Checkpoints'),
   ],
+
 
   local bufferWrites = timeSeriesPanel('Buffer Writes', datasource.name, 'writes/sec', stringFilters, targets=bufferWritesTargets),
 

--- a/blueprints/grafana/panels/rabbitmq/rmq_static.libsonnet
+++ b/blueprints/grafana/panels/rabbitmq/rmq_static.libsonnet
@@ -6,36 +6,36 @@ function(policyName, infraMeterName, datasource, extraFilters) {
 
   local ready = statPanel('Ready Messages',
                           datasource.name,
-                          'sum(rabbitmq_message_current{%(filters)s, state="ready"})' % { filters: stringFilters },
+                          'sum(rabbitmq_message_current{%(filters)s, infra_meter_name="%(infra_meter)s", state="ready"})' % { filters: stringFilters, infra_meter: infraMeterName },
                           stringFilters,
                           instantQuery=true,
                           range=false),
 
   local unacknowledged = statPanel('Unacknowledged Messages',
                                    datasource.name,
-                                   'sum(rabbitmq_message_current{%(filters)s, state="unacknowledged"})' % { filters: stringFilters },
+                                   'sum(rabbitmq_message_current{%(filters)s, infra_meter_name="%(infra_meter)s", state="unacknowledged"})' % { filters: stringFilters, infra_meter: infraMeterName },
                                    stringFilters,
                                    instantQuery=true,
                                    panelColor='red',
                                    range=false),
 
-  local incoming = statPanel('Rate of Incoming Messages',
+  local incoming = statPanel('Incoming Messages',
                              datasource.name,
-                             'sum(rate(rabbitmq_message_published_total{%(filters)s}[$__range]))' % { filters: stringFilters },
+                             'sum(rate(rabbitmq_message_published_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__range]))' % { filters: stringFilters, infra_meter: infraMeterName },
                              stringFilters,
                              instantQuery=true,
                              range=false),
 
-  local outgoing = statPanel('Rate of Outgoing Messages',
+  local outgoing = statPanel('Outgoing Messages',
                              datasource.name,
-                             'sum(rate(rabbitmq_message_delivered_total{%(filters)s}[$__range])) + sum(rate(rabbitmq_message_acknowledged_total{%(filters)s}[$__range]))' % { filters: stringFilters },
+                             'sum(rate(rabbitmq_message_delivered_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__range])) + sum(rate(rabbitmq_message_acknowledged_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__range]))' % { filters: stringFilters, infra_meter: infraMeterName },
                              stringFilters,
                              instantQuery=true,
                              range=false),
 
   local consumers = statPanel('Consumers',
                               datasource.name,
-                              'sum(rabbitmq_consumer_count{%(filters)s})' % { filters: stringFilters },
+                              'sum(rabbitmq_consumer_count{%(filters)s, infra_meter_name="%(infra_meter)s"})' % { filters: stringFilters, infra_meter: infraMeterName },
                               stringFilters,
                               instantQuery=true,
                               panelColor='blue',
@@ -43,7 +43,7 @@ function(policyName, infraMeterName, datasource, extraFilters) {
 
   local queues = statPanel('Queues',
                            datasource.name,
-                           'count without(rabbitmq_queue_name) (rabbitmq_message_published_total{%(filters)s})' % { filters: stringFilters },
+                           'count without(rabbitmq_queue_name) (rabbitmq_message_published_total{%(filters)s, infra_meter_name="%(infra_meter)s"})' % { filters: stringFilters, infra_meter: infraMeterName },
                            stringFilters,
                            instantQuery=true,
                            panelColor='blue',
@@ -55,5 +55,4 @@ function(policyName, infraMeterName, datasource, extraFilters) {
   outgoing: outgoing.panel,
   consumers: consumers.panel,
   queues: queues.panel,
-
 }

--- a/blueprints/grafana/panels/rabbitmq/rmq_time_series.libsonnet
+++ b/blueprints/grafana/panels/rabbitmq/rmq_time_series.libsonnet
@@ -1,67 +1,54 @@
 local utils = import '../../utils/policy_utils.libsonnet';
 local timeSeriesPanel = import '../../utils/time_series_panel.libsonnet';
-
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v9.4.0/main.libsonnet';
 
 function(policyName, infraMeterName, datasource, extraFilters) {
-
   local stringFilters = utils.dictToPrometheusFilter(extraFilters { policy_name: policyName }),
 
-  local readyQuery = g.query.prometheus.new(datasource, 'sum(rabbitmq_message_current{%(filters)s, state="ready"})' % { filters: stringFilters })
+  local readyQuery = g.query.prometheus.new(datasource.name, 'sum(rabbitmq_message_current{%(filters)s, infra_meter_name="%(infra_meter)s", state="ready"})' % { filters: stringFilters, infra_meter: infraMeterName })
                      + g.query.prometheus.withIntervalFactor(1)
                      + g.query.prometheus.withLegendFormat('Ready'),
-
   local ready = timeSeriesPanel('Messages Ready For Consumers', datasource.name, '', stringFilters, 'Count', targets=[readyQuery]),
 
-  local acknowledgedQuery = g.query.prometheus.new(datasource, 'sum(rate(rabbitmq_message_acknowledged_total{%(filters)s}[$__rate_interval]))' % { filters: stringFilters })
+  local acknowledgedQuery = g.query.prometheus.new(datasource.name, 'sum(rate(rabbitmq_message_acknowledged_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
                             + g.query.prometheus.withIntervalFactor(1)
                             + g.query.prometheus.withLegendFormat('Acknowledged'),
-
   local acknowledged = timeSeriesPanel('Messages Acknowledged By Consumers', datasource.name, '', stringFilters, 'Count', targets=[acknowledgedQuery]),
 
-  local unacknowledgedQuery = g.query.prometheus.new(datasource, 'sum(rabbitmq_message_current{%(filters)s, state="unacknowledged"})' % { filters: stringFilters })
+  local unacknowledgedQuery = g.query.prometheus.new(datasource.name, 'sum(rabbitmq_message_current{%(filters)s, infra_meter_name="%(infra_meter)s", state="unacknowledged"})' % { filters: stringFilters, infra_meter: infraMeterName })
                               + g.query.prometheus.withIntervalFactor(1)
                               + g.query.prometheus.withLegendFormat('Unacknowledged'),
-
   local unacknowledged = timeSeriesPanel('Messages Unacknowledged By Consumers', datasource.name, '', stringFilters, 'Count', targets=[unacknowledgedQuery]),
 
-
-  local readyQueryPerVhost = g.query.prometheus.new(datasource, 'sum by(rabbitmq_vhost_name) (rabbitmq_message_current{%(filters)s, state="ready"})' % { filters: stringFilters })
+  local readyQueryPerVhost = g.query.prometheus.new(datasource.name, 'sum by(rabbitmq_vhost_name) (rabbitmq_message_current{%(filters)s, infra_meter_name="%(infra_meter)s", state="ready"})' % { filters: stringFilters, infra_meter: infraMeterName })
                              + g.query.prometheus.withIntervalFactor(1)
                              + g.query.prometheus.withLegendFormat('{{rabbitmq_vhost_name}}'),
-
   local readyPerVhost = timeSeriesPanel('Messages Ready For Consumers Per Vhost', datasource.name, '', stringFilters, 'Count', targets=[readyQueryPerVhost]),
 
-  local acknowledgedQueryPerVhost = g.query.prometheus.new(datasource, 'sum by(rabbitmq_vhost_name) (rate(rabbitmq_message_acknowledged_total{%(filters)s}[$__rate_interval]))' % { filters: stringFilters })
+  local acknowledgedQueryPerVhost = g.query.prometheus.new(datasource.name, 'sum by(rabbitmq_vhost_name) (rate(rabbitmq_message_acknowledged_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
                                     + g.query.prometheus.withIntervalFactor(1)
                                     + g.query.prometheus.withLegendFormat('{{rabbitmq_vhost_name}}'),
-
   local acknowledgedPerVhost = timeSeriesPanel('Messages Acknowledged By Consumers Per Vhost', datasource.name, '', stringFilters, 'Count', targets=[acknowledgedQueryPerVhost]),
 
-  local unacknowledgedQueryPerVhost = g.query.prometheus.new(datasource, 'sum by(rabbitmq_vhost_name) (rabbitmq_message_current{%(filters)s, state="unacknowledged"})' % { filters: stringFilters })
+  local unacknowledgedQueryPerVhost = g.query.prometheus.new(datasource.name, 'sum by(rabbitmq_vhost_name) (rabbitmq_message_current{%(filters)s, infra_meter_name="%(infra_meter)s", state="unacknowledged"})' % { filters: stringFilters, infra_meter: infraMeterName })
                                       + g.query.prometheus.withIntervalFactor(1)
                                       + g.query.prometheus.withLegendFormat('{{rabbitmq_vhost_name}}'),
-
   local unacknowledgedPerVhost = timeSeriesPanel('Messages Unacknowledged By Consumers Per Vhost', datasource.name, '', stringFilters, 'Count', targets=[unacknowledgedQueryPerVhost]),
 
-  local queuesGrowthQuery = g.query.prometheus.new(datasource, 'sum by (rabbitmq_queue_name) (rate(rabbitmq_message_published_total{%(filters)s}[$__rate_interval])) - sum by (rabbitmq_queue_name) (rate(rabbitmq_message_acknowledged_total{%(filters)s}[$__rate_interval]))' % { filters: stringFilters })
+  local queuesGrowthQuery = g.query.prometheus.new(datasource.name, 'sum by (rabbitmq_queue_name) (rate(rabbitmq_message_published_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval])) - sum by (rabbitmq_queue_name) (rate(rabbitmq_message_acknowledged_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
                             + g.query.prometheus.withIntervalFactor(1)
                             + g.query.prometheus.withLegendFormat('{{rabbitmq_queue_name}}'),
-
   local queuesGrowth = timeSeriesPanel('Queues Growth', datasource.name, '', stringFilters, 'Messages/Second', targets=[queuesGrowthQuery]),
 
-  local publishedQuery = g.query.prometheus.new(datasource, 'sum(rate(rabbitmq_message_published_total{%(filters)s}[$__rate_interval]))' % { filters: stringFilters })
+  local publishedQuery = g.query.prometheus.new(datasource.name, 'sum(rate(rabbitmq_message_published_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
                          + g.query.prometheus.withIntervalFactor(1)
                          + g.query.prometheus.withLegendFormat('Published'),
-
   local published = timeSeriesPanel('Messages Published', datasource.name, '', stringFilters, 'Messages/Second', targets=[publishedQuery]),
 
-  local deliveredQuery = g.query.prometheus.new(datasource, 'sum(rate(rabbitmq_message_delivered_total{%(filters)s}[$__rate_interval]))' % { filters: stringFilters })
+  local deliveredQuery = g.query.prometheus.new(datasource.name, 'sum(rate(rabbitmq_message_delivered_total{%(filters)s, infra_meter_name="%(infra_meter)s"}[$__rate_interval]))' % { filters: stringFilters, infra_meter: infraMeterName })
                          + g.query.prometheus.withIntervalFactor(1)
                          + g.query.prometheus.withLegendFormat('Delivered'),
-
   local delivered = timeSeriesPanel('Messages Delivered', datasource.name, '', stringFilters, 'Messages/Second', targets=[deliveredQuery]),
-
 
   ready: ready.panel,
   acknowledged: acknowledged.panel,
@@ -72,5 +59,4 @@ function(policyName, infraMeterName, datasource, extraFilters) {
   queuesGrowth: queuesGrowth.panel,
   published: published.panel,
   delivered: delivered.panel,
-
 }


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Improved code readability and maintainability in `es_time_series.libsonnet` by defining queries as separate variables.
- New Feature: Added `infra_meter_name` filter to queries in `es_time_series.libsonnet`, `pgsql_static.libsonnet`, `pgsql_time_series.libsonnet`, `rmq_static.libsonnet`, and `rmq_time_series.libsonnet` for more accurate metric calculations.
- Refactor: Modified `datasource` parameter handling in `rmq_time_series.libsonnet` for better data filtering based on `infra_meter_name` and `state` fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->