### PR TITLE
pypi publish workflow

### DIFF
--- a/sdks/aperture-py/.circleci/config.yml
+++ b/sdks/aperture-py/.circleci/config.yml
@@ -1,0 +1,62 @@
+version: 2.1
+
+orbs:
+  path-filtering: circleci/path-filtering@0.1.3
+  continuation: circleci/continuation@0.3.1
+
+jobs:
+  publish-release:
+    parameters:
+      dry-run:
+        type: boolean
+        default: false
+        description: If set to false, sdk will be published to pypi
+    docker:
+      - image: cimg/python:3.11.5
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Publish to pypi
+          command: |
+            poetry config pypi-token.pypi $PYPI_PASSWORD
+            poetry install
+            args=(--build)
+            if [[ "<< parameters.dry-run >>" == "true" ]]; then
+               args+=( --dry-run )
+            fi
+            poetry publish "${args[@]}"
+
+workflows:
+  version: 2
+
+  filter-paths-main:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - not:
+            matches:
+              &is_not_empty_tag {
+                value: << pipeline.git.tag >>,
+                pattern: "^.+$",
+              }
+        - not: &scheduled
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+    jobs:
+      - path-filtering/filter: &path_filtering_job
+          base-revision: << pipeline.git.base_revision >>
+          config-path: .circleci/continue-workflows.yml
+
+  publish-release:
+    when:
+      matches:
+        { value: << pipeline.git.tag >>, pattern: "^releases/.*$" }
+    jobs:
+      - publish-release:
+          context: pypi
+          # both this and workflow's when is needed
+          filters:
+            branches:
+              ignore: /.+/
+            tags:
+              only: /^releases\/.*$/

--- a/sdks/aperture-py/.circleci/continue-workflows.yml
+++ b/sdks/aperture-py/.circleci/continue-workflows.yml
@@ -1,0 +1,37 @@
+version: 2.1
+
+jobs:
+  publish-release:
+    parameters:
+      dry-run:
+        type: boolean
+        default: false
+        description: If set to false, sdk will be published to pypi
+    docker:
+      - image: cimg/python:3.11.5
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Publish to pypi
+          command: |
+            poetry config pypi-token.pypi $PYPI_PASSWORD
+            poetry install
+            args=(--build)
+            if [[ "<< parameters.dry-run >>" == "true" ]]; then
+               args+=( --dry-run )
+            fi
+            poetry publish "${args[@]}"
+
+workflows:
+  version: 2
+
+  publish-release:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+    jobs:
+      - publish-release:
+          name: verify-publish-release
+          context: pypi
+          dry-run: true

--- a/sdks/aperture-py/pyproject.toml
+++ b/sdks/aperture-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aperture-py"
-version = "2.16.0"
+version = "2.19.0"
 description = "SDK to interact with the Aperture Agent"
 authors = ["FluxNinja <support@fluxninja.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added a new CircleCI configuration for the Python project, introducing a job named `publish-release` that automates the process of publishing the project to PyPI. This job includes a `dry-run` parameter to control whether changes are actually pushed to PyPI.
- Implemented a workflow `filter-paths-main` that triggers based on changes in the `main` branch and filters paths based on Git repository changes.
- Introduced a workflow `publish-release` that triggers when a Git tag matches the pattern `^releases/.*$`, executing the `publish-release` job.
- Added a new job `publish-release` in the CI/CD pipeline, which is responsible for publishing the SDK to PyPI. This job uses the `cimg/python:3.11.5` Docker image, checks out the code, configures the PyPI token, installs dependencies using Poetry, and publishes the SDK to PyPI.
- The `publish-release` workflow triggers the `publish-release` job when the branch is `main` and sets the `dry-run` parameter to true, allowing for safe testing of the publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->