### PR TITLE
Upload images to dockerhub for dev changes

### DIFF
--- a/.circleci/continue-workflows.yml
+++ b/.circleci/continue-workflows.yml
@@ -107,6 +107,10 @@ jobs:
       dockerhub-image:
         type: string
         description: A name for your Docker image
+      dockerhub-ops-image:
+        type: string
+        description: A name for your Docker image to push under fluxninjaops
+        default: ""
       gcr-registry:
         type: string
         description: Google Container Registry to push images to
@@ -201,6 +205,17 @@ jobs:
       - gcp-gcr/push-image:
           image: <<parameters.gcr-image>>
           tag: <<parameters.tag>>
+      - when:
+          condition:
+            not:
+              equal: ["", <<parameters.dockerhub-ops-image>>]
+          steps:
+            run:
+              name: Push images to DockerHub ops account
+              command: |
+                docker tag <<parameters.dockerhub-image>>:<<parameters.tag>> <<parameters.dockerhub-ops-image>>:<<parameters.tag>>
+                docker login -u "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
+                docker push <<parameters.dockerhub-ops-image>>:<<parameters.tag>>
       - when:
           condition:
             equal: [main, << pipeline.git.branch >>]
@@ -1195,6 +1210,7 @@ workflows:
       - build-push-add-tag:
           name: image-build-aperture-agent
           dockerhub-image: fluxninja/aperture-agent
+          dockerhub-ops-image: fluxninjaops/aperture-agent
           gcr-registry: gcr.io/devel-309501
           gcr-image: cf-fn/aperture-agent
           docker-context: .
@@ -1216,6 +1232,7 @@ workflows:
       - build-push-add-tag:
           name: image-build-aperture-controller
           dockerhub-image: fluxninja/aperture-controller
+          dockerhub-ops-image: fluxninjaops/aperture-controller
           gcr-registry: gcr.io/devel-309501
           gcr-image: cf-fn/aperture-controller
           docker-context: .
@@ -1329,6 +1346,7 @@ workflows:
       - build-push-add-tag:
           name: image-build-aperture-operator
           dockerhub-image: fluxninja/aperture-operator
+          dockerhub-ops-image: fluxninjaops/aperture-operator
           gcr-registry: gcr.io/devel-309501
           gcr-image: cf-fn/aperture-operator
           docker-context: .


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added a new parameter `dockerhub-ops-image` to the CircleCI workflows. This allows for specifying a Docker image name for pushing to the `fluxninjaops` DockerHub account. If this parameter is provided, the workflow will tag and push the image to the `fluxninjaops` DockerHub account. This feature has been implemented for the `aperture-agent`, `aperture-controller`, and `aperture-operator` workflows.

**Style:**
- Updated the log message in `controller.go` from "Failed to close controller connection" to "Fail to close controller connection". This change does not affect the functionality of the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->