### PR TITLE
Enable introspection client for cloud

### DIFF
--- a/cmd/aperturectl/cmd/cloud/autoscale/control-points.go
+++ b/cmd/aperturectl/cmd/cloud/autoscale/control-points.go
@@ -18,6 +18,6 @@ var ControlPointsCmd = &cobra.Command{
 			return err
 		}
 
-		return utils.ParseControlPoints(client)
+		return utils.ParseAutoScaleControlPoints(client)
 	},
 }

--- a/cmd/aperturectl/cmd/cloud/utils/controller.go
+++ b/cmd/aperturectl/cmd/cloud/utils/controller.go
@@ -169,7 +169,7 @@ func (c *ControllerConn) CloudPolicyClient() (utils.CloudPolicyClient, error) {
 
 // IntrospectionClient returns Controller IntrospectionClient, connecting to controller if not yet connected.
 func (c *ControllerConn) IntrospectionClient() (utils.IntrospectionClient, error) {
-	return nil, errors.New("this subcommand cannot be used with the Cloud Controller")
+	return c.client()
 }
 
 // StatusClient returns Controller StatusClient, connecting to controller if not yet connected.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the function call in `control-points.go` from `utils.ParseControlPoints(client)` to `utils.ParseAutoScaleControlPoints(client)` for better clarity and specificity in autoscaling operations.
- Bug Fix: Modified the `IntrospectionClient` function in `controller.go` to call the `client()` method instead of returning an error. This change ensures a smoother user experience by providing the Controller's introspection client directly, reducing potential error occurrences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->