### PR TITLE
Make the policy hash stable

### DIFF
--- a/api/aperture/policy/sync/v1/common_attributes.proto
+++ b/api/aperture/policy/sync/v1/common_attributes.proto
@@ -6,6 +6,10 @@ message CommonAttributes {
   // Name of the Policy.
   string policy_name = 1;
   // Hash of the entire Policy spec.
+  //
+  // This is the sha256 sum of the policy, as stored in etcd. This hash will
+  // never change after applying policy.  For k8s-managed policies, the hash
+  // might change with new version of the controller.
   string policy_hash = 2;
   // The id of Component within the circuit.
   string component_id = 3;

--- a/api/aperture/policy/sync/v1/common_attributes.proto
+++ b/api/aperture/policy/sync/v1/common_attributes.proto
@@ -7,9 +7,9 @@ message CommonAttributes {
   string policy_name = 1;
   // Hash of the entire Policy spec.
   //
-  // This is the sha256 sum of the policy, as stored in etcd. This hash will
-  // never change after applying policy.  For k8s-managed policies, the hash
-  // might change with new version of the controller.
+  // This is the 128 bits of sha256 sum of the policy, as stored in etcd. This
+  // hash will never change after applying policy.  For k8s-managed policies,
+  // the hash might change with new version of the controller.
   string policy_hash = 2;
   // The id of Component within the circuit.
   string component_id = 3;

--- a/api/gen/proto/go/aperture/policy/sync/v1/common_attributes.pb.go
+++ b/api/gen/proto/go/aperture/policy/sync/v1/common_attributes.pb.go
@@ -29,9 +29,9 @@ type CommonAttributes struct {
 	PolicyName string `protobuf:"bytes,1,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
 	// Hash of the entire Policy spec.
 	//
-	// This is the sha256 sum of the policy, as stored in etcd. This hash will
-	// never change after applying policy.  For k8s-managed policies, the hash
-	// might change with new version of the controller.
+	// This is the 128 bits of sha256 sum of the policy, as stored in etcd. This
+	// hash will never change after applying policy.  For k8s-managed policies,
+	// the hash might change with new version of the controller.
 	PolicyHash string `protobuf:"bytes,2,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
 	// The id of Component within the circuit.
 	ComponentId string `protobuf:"bytes,3,opt,name=component_id,json=componentId,proto3" json:"component_id,omitempty"`

--- a/api/gen/proto/go/aperture/policy/sync/v1/common_attributes.pb.go
+++ b/api/gen/proto/go/aperture/policy/sync/v1/common_attributes.pb.go
@@ -28,6 +28,10 @@ type CommonAttributes struct {
 	// Name of the Policy.
 	PolicyName string `protobuf:"bytes,1,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
 	// Hash of the entire Policy spec.
+	//
+	// This is the sha256 sum of the policy, as stored in etcd. This hash will
+	// never change after applying policy.  For k8s-managed policies, the hash
+	// might change with new version of the controller.
 	PolicyHash string `protobuf:"bytes,2,opt,name=policy_hash,json=policyHash,proto3" json:"policy_hash,omitempty"`
 	// The id of Component within the circuit.
 	ComponentId string `protobuf:"bytes,3,opt,name=component_id,json=componentId,proto3" json:"component_id,omitempty"`

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -1040,9 +1040,9 @@ definitions:
                 description: |-
                     Hash of the entire Policy spec.
 
-                    This is the sha256 sum of the policy, as stored in etcd. This hash will
-                    never change after applying policy.  For k8s-managed policies, the hash
-                    might change with new version of the controller.
+                    This is the 128 bits of sha256 sum of the policy, as stored in etcd. This
+                    hash will never change after applying policy.  For k8s-managed policies,
+                    the hash might change with new version of the controller.
                 type: string
             policy_name:
                 description: Name of the Policy.

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -1037,7 +1037,12 @@ definitions:
                 description: The id of Component within the circuit.
                 type: string
             policy_hash:
-                description: Hash of the entire Policy spec.
+                description: |-
+                    Hash of the entire Policy spec.
+
+                    This is the sha256 sum of the policy, as stored in etcd. This hash will
+                    never change after applying policy.  For k8s-managed policies, the hash
+                    might change with new version of the controller.
                 type: string
             policy_name:
                 description: Name of the Policy.

--- a/pkg/policies/controlplane/policy-service.go
+++ b/pkg/policies/controlplane/policy-service.go
@@ -194,7 +194,7 @@ func unmarshalStoredPolicy(policyBytes []byte) (p *policylangv1.Policy, hash str
 		// Remove this code in v3.0.0.
 		err = proto.Unmarshal(policyBytes, &policy)
 		if err != nil {
-			return
+			return nil, "", err
 		}
 
 		// Hash the policy in legacy format as if it was converted to

--- a/pkg/policies/controlplane/policy-service.go
+++ b/pkg/policies/controlplane/policy-service.go
@@ -113,7 +113,7 @@ func (s *PolicyService) GetPolicy(ctx context.Context, request *policylangv1.Get
 //
 // localPolicy can be nil.
 func getPolicyResponse(remoteBytes []byte, localPolicy *policysyncv1.PolicyWrapper) *policylangv1.GetPolicyResponse {
-	remotePolicy, err := unmarshalStoredPolicy(remoteBytes)
+	remotePolicy, remoteHash, err := unmarshalStoredPolicy(remoteBytes)
 	if err != nil {
 		if localPolicy == nil {
 			return &policylangv1.GetPolicyResponse{
@@ -133,15 +133,6 @@ func getPolicyResponse(remoteBytes []byte, localPolicy *policysyncv1.PolicyWrapp
 			Policy: remotePolicy,
 			Status: policylangv1.GetPolicyResponse_NOT_LOADED,
 			Reason: "not loaded into controller",
-		}
-	}
-
-	remoteHash, err := HashPolicy(remotePolicy)
-	if err != nil {
-		return &policylangv1.GetPolicyResponse{
-			Policy: localPolicy.Policy,
-			Status: policylangv1.GetPolicyResponse_OUTDATED,
-			Reason: fmt.Sprintf("failed to compute remote policy hash: %s", err),
 		}
 	}
 
@@ -176,13 +167,13 @@ func getLocalOnlyPolicyResponse(localPolicy *policysyncv1.PolicyWrapper) *policy
 	}
 }
 
-// unmarshalStoredPolicy unmarshals a policy stored in etcd or serialized by crwatcher.
-func unmarshalStoredPolicy(policyBytes []byte) (*policylangv1.Policy, error) {
+// unmarshalStoredPolicy unmarshals a policy stored in etcd or serialized by
+// crwatcher and computes its canonical hash.
+func unmarshalStoredPolicy(policyBytes []byte) (p *policylangv1.Policy, hash string, err error) {
 	// Right now we store policies in api/policies only in json, but some
 	// controller version in the past stored in protowire, so we need to take
 	// in account both cases when deserializing.
 	var policy policylangv1.Policy
-	var err error
 
 	// We're sniffing the first byte to detect format – JSON policy always
 	// starts with `{` and protowire never starts with `{` byte for proto3
@@ -194,17 +185,28 @@ func unmarshalStoredPolicy(policyBytes []byte) (*policylangv1.Policy, error) {
 		// * json.Unmarshal won't handle correctly defaults for new fields that
 		//   were added after policy was stored in etcd.
 		err = config.UnmarshalJSON(policyBytes, &policy)
+		if err != nil {
+			return nil, "", err
+		}
+		return &policy, HashStoredPolicy(policyBytes), err
 	} else {
 		// Deprecated: v3.0.0. Older way of string policy on etcd.
 		// Remove this code in v3.0.0.
 		err = proto.Unmarshal(policyBytes, &policy)
-	}
+		if err != nil {
+			return
+		}
 
-	if err != nil {
-		return nil, err
-	}
+		// Hash the policy in legacy format as if it was converted to
+		// JSON. This way, when policy gets reapplied in JSON format,
+		// it won't change its hash.
+		jsonBytes, err := json.Marshal(&policy)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to marshal policy for hashing: %s", err)
+		}
 
-	return &policy, nil
+		return &policy, HashStoredPolicy(jsonBytes), err
+	}
 }
 
 // UpsertPolicy creates/updates policy to the system.
@@ -235,11 +237,6 @@ func (s *PolicyService) UpsertPolicy(ctx context.Context, req *policylangv1.Upse
 		return nil, status.Errorf(codes.Internal, "failed to marshal policy: %s", err)
 	}
 
-	hash, err := HashPolicy(newPolicy)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to hash policy: %s", err)
-	}
-
 	putResp, err := s.etcdClient.PutSync(
 		ctx,
 		path.Join(paths.PoliciesAPIConfigPath, req.PolicyName),
@@ -256,7 +253,7 @@ func (s *PolicyService) UpsertPolicy(ctx context.Context, req *policylangv1.Upse
 		log.Info().Str("policy", req.PolicyName).Msg("Policy created in etcd")
 	}
 
-	return &policylangv1.UpsertPolicyResponse{PolicyHash: hash}, nil
+	return &policylangv1.UpsertPolicyResponse{PolicyHash: HashStoredPolicy(newPolicyString)}, nil
 }
 
 // PostDynamicConfig updates dynamic config to the system.

--- a/pkg/policies/controlplane/policy.go
+++ b/pkg/policies/controlplane/policy.go
@@ -2,12 +2,12 @@ package controlplane
 
 import (
 	"context"
-	"encoding/base64"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"time"
 
-	goObjectHash "github.com/benlaurie/objecthash/go/objecthash"
 	"go.uber.org/fx"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -16,7 +16,6 @@ import (
 	policysyncv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/policy/sync/v1"
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	"github.com/fluxninja/aperture/v2/pkg/jobs"
-	"github.com/fluxninja/aperture/v2/pkg/log"
 	"github.com/fluxninja/aperture/v2/pkg/notifiers"
 	"github.com/fluxninja/aperture/v2/pkg/policies/controlplane/circuitfactory"
 	"github.com/fluxninja/aperture/v2/pkg/policies/controlplane/iface"
@@ -82,11 +81,15 @@ func newPolicyOptions(wrapperMessage *policysyncv1.PolicyWrapper, registry statu
 
 // CompilePolicy takes policyMessage and returns a compiled policy. This is a helper method for standalone consumption of policy compiler.
 func CompilePolicy(policyMessage *policylangv1.Policy, policyName string, registry status.Registry) (*circuitfactory.Circuit, error) {
-	wrapperMessage, err := hashAndPolicyWrap(policyMessage, policyName)
-	if err != nil {
-		return nil, err
+	policyWrapper := policysyncv1.PolicyWrapper{
+		Policy: policyMessage,
+		CommonAttributes: &policysyncv1.CommonAttributes{
+			PolicyName: policyName,
+			PolicyHash: "dummy-hash",
+		},
 	}
-	_, circuit, _, err := compilePolicyWrapper(wrapperMessage, registry)
+
+	_, circuit, _, err := compilePolicyWrapper(&policyWrapper, registry)
 	if err != nil {
 		return nil, err
 	}
@@ -300,40 +303,12 @@ func (policy *Policy) GetStatusRegistry() status.Registry {
 	return policy.registry
 }
 
-// hashAndPolicyWrap wraps a proto message with a config properties wrapper and hashes it.
-func hashAndPolicyWrap(policyMessage *policylangv1.Policy, policyName string) (*policysyncv1.PolicyWrapper, error) {
-	hash, err := HashPolicy(policyMessage)
-	if err != nil {
-		return nil, err
-	}
-
-	return &policysyncv1.PolicyWrapper{
-		Policy: policyMessage,
-		CommonAttributes: &policysyncv1.CommonAttributes{
-			PolicyName: policyName,
-			PolicyHash: hash,
-		},
-	}, nil
-}
-
-// HashPolicy returns hash of the policy.
-func HashPolicy(policy *policylangv1.Policy) (string, error) {
-	// FIXME: The "Deterministic" is still not deterministic enough for our
-	// purposes – output may change with different version of aperture.
-	dat, err := proto.MarshalOptions{Deterministic: true}.Marshal(policy)
-	if err != nil {
-		log.Error().Err(err).Msgf("Failed to marshal proto message %+v", policy)
-		return "", err
-	}
-
-	log.Trace().Msgf("Policy message: %s", string(dat))
-	// FIXME: Use sha256.Sum256() directly instead of goObjectHash. This will
-	// result in different though.
-	hashBytes, hashErr := goObjectHash.ObjectHash(dat)
-	if hashErr != nil {
-		log.Warn().Err(hashErr).Msgf("Failed to hash json serialized proto message %s", string(dat))
-		return "", hashErr
-	}
-
-	return base64.StdEncoding.EncodeToString(hashBytes[:]), nil
+// HashStoredPolicy returns sha256 of JSON-serialized policy.
+//
+// As the JSON repr of policy is not perfectly stable (it depends whether we've
+// applied defaults yet or not, and could change when adding new fields), we
+// should hash policies which are stored somewhere (e.g. in etcd).
+func HashStoredPolicy(policyJSON []byte) string {
+	sum := sha256.Sum256(policyJSON)
+	return hex.EncodeToString(sum[:])
 }

--- a/pkg/policies/controlplane/policy.go
+++ b/pkg/policies/controlplane/policy.go
@@ -303,12 +303,12 @@ func (policy *Policy) GetStatusRegistry() status.Registry {
 	return policy.registry
 }
 
-// HashStoredPolicy returns sha256 of JSON-serialized policy.
+// HashStoredPolicy returns sha256 of JSON-serialized policy, truncated to 128 bits.
 //
 // As the JSON repr of policy is not perfectly stable (it depends whether we've
 // applied defaults yet or not, and could change when adding new fields), we
 // should hash policies which are stored somewhere (e.g. in etcd).
 func HashStoredPolicy(policyJSON []byte) string {
 	sum := sha256.Sum256(policyJSON)
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:16])
 }


### PR DESCRIPTION
Policy hashing logic was changed to not depend on aperture version. The policy spec is
now hashed directly – as stored as JSON in etcd. This ensures that after
applying policy, its hash will never change.

The sha256 was chosen so that it's easy to compute manually, in case of
debugging.

Note: Because of change in hashing logic, all policies will now report new
hashes, so it's a breaking change wrt. policy hashes. Hopefully, a last one.

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added
- [x] Breaking changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a unique identifier for policies, `policy_hash`, enhancing the tracking and management of policies. This identifier is a SHA256 hash of the policy and will remain constant after applying the policy. However, for Kubernetes-managed policies, the hash might change with a new version of the controller.
- Refactor: Improved the policy hashing process by introducing the `HashStoredPolicy` function, which calculates the SHA256 hash of a JSON-serialized policy. This change enhances the stability and determinism of policy hashing.
- Refactor: Streamlined the handling of policy messages and their wrappers in the `setupPoliciesNotifier` function, improving the clarity and efficiency of the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->