### PR TITLE
aperture-js: expose grpc call and channel options

### DIFF
--- a/sdks/aperture-js/Dockerfile
+++ b/sdks/aperture-js/Dockerfile
@@ -22,6 +22,9 @@ RUN npm link
 RUN cd example && npm ci && npm link @fluxninja/aperture-js && npm run build
 
 HEALTHCHECK --interval=5s --timeout=60s --retries=3 --start-period=5s \
-   CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8080/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8080/health || exit 1
 
+# uncomment to enable grpc debug logging
+#ENV GRPC_VERBOSITY=DEBUG
+#ENV GRPC_TRACE=all
 CMD [ "node", "./example/dist/example.js" ]

--- a/sdks/aperture-js/example/example.ts
+++ b/sdks/aperture-js/example/example.ts
@@ -1,10 +1,10 @@
 import express from "express";
 import http from "http";
-import { createHttpTerminator } from "http-terminator";
+import {createHttpTerminator} from "http-terminator";
 
-import { connectedRouter } from "./routes/connected.js";
-import { healthRouter } from "./routes/health.js";
-import { apertureClient, apertureRoute } from "./routes/use_aperture.js";
+import {connectedRouter} from "./routes/connected.js";
+import {healthRouter} from "./routes/health.js";
+import {apertureClient, apertureRoute} from "./routes/use_aperture.js";
 
 const host = "localhost";
 const port = process.env.FN_APP_PORT ? process.env.FN_APP_PORT : "8080";

--- a/sdks/aperture-js/example/routes/use_aperture.ts
+++ b/sdks/aperture-js/example/routes/use_aperture.ts
@@ -12,6 +12,8 @@ apertureRoute.get("/", function (_: express.Request, res: express.Response) {
     user: "kenobi",
   };
 
+  const startTimestamp = Date.now();
+
   // StartFlow performs a flowcontrolv1.Check call to Aperture Agent. It returns a Flow and an error if any.
   apertureClient
     .StartFlow("awesome-feature", {
@@ -20,6 +22,8 @@ apertureRoute.get("/", function (_: express.Request, res: express.Response) {
       rampMode: false,
     })
     .then((flow) => {
+      const endTimestamp = Date.now();
+      console.log(`Flow took ${endTimestamp - startTimestamp}ms`);
       // See whether flow was accepted by Aperture Agent.
       if (flow.ShouldRun()) {
         // Simulate work being done

--- a/sdks/aperture-js/example/routes/use_aperture.ts
+++ b/sdks/aperture-js/example/routes/use_aperture.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import { ApertureClient, FlowStatusEnum } from "@fluxninja/aperture-js";
+import {ApertureClient, FlowStatusEnum} from "@fluxninja/aperture-js";
 
 // Create aperture client
 export const apertureClient = new ApertureClient();
@@ -18,7 +18,9 @@ apertureRoute.get("/", function (_: express.Request, res: express.Response) {
   apertureClient
     .StartFlow("awesome-feature", {
       labels: labels,
-      timeoutMilliseconds: 300000,
+      grpcCallOptions: {
+        deadline: Date.now() + 30000,
+      },
       rampMode: false,
     })
     .then((flow) => {

--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.5",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -9,6 +9,7 @@ import {Resource} from "@opentelemetry/resources";
 import {BatchSpanProcessor, Tracer} from "@opentelemetry/sdk-trace-base";
 import {NodeTracerProvider} from "@opentelemetry/sdk-trace-node";
 import {SemanticResourceAttributes} from "@opentelemetry/semantic-conventions";
+import {serializeError} from "serialize-error";
 import {CheckRequest} from "./gen/aperture/flowcontrol/check/v1/CheckRequest.js";
 import {CheckResponse__Output} from "./gen/aperture/flowcontrol/check/v1/CheckResponse.js";
 import {FlowControlServiceClient} from "./gen/aperture/flowcontrol/check/v1/FlowControlService.js";
@@ -21,6 +22,7 @@ export interface FlowParams {
   labels?: Record<string, string>;
   rampMode?: boolean;
   grpcCallOptions?: grpc.CallOptions;
+  tryConnect?: boolean;
 }
 
 export class ApertureClient {
@@ -96,6 +98,26 @@ export class ApertureClient {
       };
 
       try {
+        // check connection state
+        // if not ready, return flow with fail-to-wire semantics
+        // if ready, call check
+        if (params.tryConnect === undefined || params.tryConnect == false) {
+          const state = this.fcsClient.getChannel().getConnectivityState(true);
+          if (
+            state != connectivityState.READY &&
+            state != connectivityState.IDLE
+          ) {
+            resolveFlow(
+              null,
+              serializeError(
+                new Error(
+                  `connection with Aperture Agent is not established, state: ${state}`,
+                ),
+              ),
+            );
+            return;
+          }
+        }
         let labelsBaggage = {} as Record<string, string>;
         let baggage = otelApi.propagation.getBaggage(otelApi.context.active());
 

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -40,7 +40,6 @@ export class ApertureClient {
     channelOptions?: ChannelOptions;
   } = {}) {
     const defaultChannelOptions = {
-      "grpc.enable_retries": 1,
       "grpc.keepalive_time_ms": 10000,
       "grpc.keepalive_timeout_ms": 5000,
     };

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -1,24 +1,26 @@
-import grpc, { connectivityState } from "@grpc/grpc-js";
+import grpc, {
+  ChannelCredentials,
+  ChannelOptions,
+  connectivityState,
+} from "@grpc/grpc-js";
 import * as otelApi from "@opentelemetry/api";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
-import { Resource } from "@opentelemetry/resources";
-import { BatchSpanProcessor, Tracer } from "@opentelemetry/sdk-trace-base";
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
-import { serializeError } from "serialize-error";
-import { CheckRequest } from "./gen/aperture/flowcontrol/check/v1/CheckRequest.js";
-import { CheckResponse__Output } from "./gen/aperture/flowcontrol/check/v1/CheckResponse.js";
-import { FlowControlServiceClient } from "./gen/aperture/flowcontrol/check/v1/FlowControlService.js";
+import {OTLPTraceExporter} from "@opentelemetry/exporter-trace-otlp-grpc";
+import {Resource} from "@opentelemetry/resources";
+import {BatchSpanProcessor, Tracer} from "@opentelemetry/sdk-trace-base";
+import {NodeTracerProvider} from "@opentelemetry/sdk-trace-node";
+import {SemanticResourceAttributes} from "@opentelemetry/semantic-conventions";
+import {CheckRequest} from "./gen/aperture/flowcontrol/check/v1/CheckRequest.js";
+import {CheckResponse__Output} from "./gen/aperture/flowcontrol/check/v1/CheckResponse.js";
+import {FlowControlServiceClient} from "./gen/aperture/flowcontrol/check/v1/FlowControlService.js";
 
-import { LIBRARY_NAME, LIBRARY_VERSION, URL } from "./consts.js";
-import { Flow } from "./flow.js";
-import { fcs } from "./utils.js";
+import {LIBRARY_NAME, LIBRARY_VERSION, URL} from "./consts.js";
+import {Flow} from "./flow.js";
+import {fcs} from "./utils.js";
 
 export interface FlowParams {
   labels?: Record<string, string>;
-  timeoutMilliseconds?: number;
   rampMode?: boolean;
-  tryConnect?: boolean;
+  grpcCallOptions?: grpc.CallOptions;
 }
 
 export class ApertureClient {
@@ -30,11 +32,26 @@ export class ApertureClient {
 
   private readonly tracer: Tracer;
 
-  constructor({ channelCredentials = grpc.credentials.createInsecure() } = {}) {
-    this.fcsClient = new fcs.FlowControlService(URL, channelCredentials, {
+  constructor({
+    channelCredentials = grpc.credentials.createInsecure(),
+    channelOptions = {},
+  }: {
+    channelCredentials?: ChannelCredentials;
+    channelOptions?: ChannelOptions;
+  } = {}) {
+    const defaultChannelOptions = {
+      "grpc.enable_retries": 1,
       "grpc.keepalive_time_ms": 10000,
       "grpc.keepalive_timeout_ms": 5000,
-    });
+    };
+
+    channelOptions = { ...defaultChannelOptions, ...channelOptions };
+
+    this.fcsClient = new fcs.FlowControlService(
+      URL,
+      channelCredentials,
+      channelOptions,
+    );
 
     this.exporter = new OTLPTraceExporter({
       url: URL,
@@ -63,9 +80,7 @@ export class ApertureClient {
 
   // StartFlow takes a control point and labels that get passed to Aperture Agent via flowcontrolv1.Check call.
   // Return value is a Flow.
-  // The call returns immediately in case connection with Aperture Agent is not established.
   // The default semantics are fail-to-wire. If StartFlow fails, calling Flow.ShouldRun() on returned Flow returns as true.
-  // For FlowParams set defaults - labels = {}, timeoutMilliseconds = 0, rampMode = false using Pick.
   async StartFlow(
     controlPoint: string,
     params: FlowParams = {},
@@ -82,27 +97,6 @@ export class ApertureClient {
       };
 
       try {
-        // check connection state
-        // if not ready, return flow with fail-to-wire semantics
-        // if ready, call check
-        if (params.tryConnect === undefined || params.tryConnect == false) {
-          const state = this.fcsClient.getChannel().getConnectivityState(true);
-          if (
-            state != connectivityState.READY &&
-            state != connectivityState.IDLE
-          ) {
-            resolveFlow(
-              null,
-              serializeError(
-                new Error(
-                  `connection with Aperture Agent is not established, state: ${state}`,
-                ),
-              ),
-            );
-            return;
-          }
-        }
-
         let labelsBaggage = {} as Record<string, string>;
         let baggage = otelApi.propagation.getBaggage(otelApi.context.active());
 
@@ -120,14 +114,6 @@ export class ApertureClient {
           rampMode: params.rampMode,
         };
 
-        const grpcParams: grpc.CallOptions = {
-          deadline:
-            params.timeoutMilliseconds != undefined &&
-            params.timeoutMilliseconds > 0
-              ? new Date(Date.now() + params.timeoutMilliseconds)
-              : undefined,
-        };
-
         const cb: grpc.requestCallback<CheckResponse__Output> = (
           err: any,
           response: any,
@@ -136,7 +122,11 @@ export class ApertureClient {
           return;
         };
 
-        this.fcsClient.Check(request, grpcParams, cb);
+        if (params.grpcCallOptions === undefined) {
+          params.grpcCallOptions = {};
+        }
+
+        this.fcsClient.Check(request, params.grpcCallOptions, cb);
       } catch (err: any) {
         resolveFlow(null, err);
       }


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `ApertureClient` class in the Aperture JS SDK for better flexibility and configurability. This includes the ability to specify gRPC call options and channel options.
- Improvement: Updated the Dockerfile to use `wget` for health checks, improving the reliability of the application's health status.
- Improvement: Added functionality to log the duration of network calls in the example usage of the Aperture JS SDK. This provides users with more visibility into the performance of their network operations.
- Style: Reformatted import statements across multiple files for better code readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->