### PR TITLE
Made version mandatory for aperturectl install and uninstall

### DIFF
--- a/cmd/aperturectl/cmd/installation/install.go
+++ b/cmd/aperturectl/cmd/installation/install.go
@@ -17,7 +17,7 @@ import (
 func init() {
 	InstallCmd.PersistentFlags().StringVar(&kubeConfig, "kube-config", "", "Path to the Kubernetes cluster config. Defaults to '~/.kube/config'")
 	InstallCmd.PersistentFlags().StringVar(&valuesFile, "values-file", "", "Values YAML file containing parameters to customize the installation")
-	InstallCmd.PersistentFlags().StringVar(&version, "version", latestTag, "Version of the Aperture")
+	InstallCmd.PersistentFlags().StringVar(&version, "version", "", "Version of the Aperture")
 	InstallCmd.PersistentFlags().StringVar(&namespace, "namespace", defaultNS, "Namespace in which the component will be installed. Defaults to 'default' namespace")
 	InstallCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "If set to true, only the manifests will be generated and no installation will be performed")
 
@@ -35,6 +35,10 @@ Use this command to install Aperture Controller and Agent on your Kubernetes clu
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
+
+		if version == "" {
+			return fmt.Errorf("--version flag is required")
+		}
 
 		if !dryRun {
 			kubeRestConfig, err = utils.GetKubeConfig(kubeConfig)
@@ -58,10 +62,6 @@ Use this command to install Aperture Controller and Agent on your Kubernetes clu
 			if err != nil {
 				return err
 			}
-		}
-
-		if version == "" {
-			version = latestTag
 		}
 
 		return nil

--- a/cmd/aperturectl/cmd/installation/uninstall.go
+++ b/cmd/aperturectl/cmd/installation/uninstall.go
@@ -16,7 +16,7 @@ import (
 
 func init() {
 	UnInstallCmd.PersistentFlags().StringVar(&kubeConfig, "kube-config", "", "Path to the Kubernetes cluster config. Defaults to '~/.kube/config'")
-	UnInstallCmd.PersistentFlags().StringVar(&version, "version", latestTag, "Version of the Aperture")
+	UnInstallCmd.PersistentFlags().StringVar(&version, "version", "", "Version of the Aperture")
 	UnInstallCmd.PersistentFlags().StringVar(&valuesFile, "values-file", "", "Values YAML file containing parameters to customize the installation")
 	UnInstallCmd.PersistentFlags().StringVar(&namespace, "namespace", defaultNS, "Namespace from which the component will be uninstalled. Defaults to 'default' namespace")
 	UnInstallCmd.PersistentFlags().IntVar(&timeout, "timeout", 300, "Timeout of waiting for uninstallation hooks completion")
@@ -36,6 +36,10 @@ Use this command to uninstall Aperture Controller and Agent from your Kubernetes
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
+		if version == "" {
+			return fmt.Errorf("--version flag is required")
+		}
+
 		kubeRestConfig, err = utils.GetKubeConfig(kubeConfig)
 		if err != nil {
 			return err
@@ -52,9 +56,6 @@ Use this command to uninstall Aperture Controller and Agent from your Kubernetes
 			return fmt.Errorf("failed to create Kubernetes client: %w", err)
 		}
 
-		if version == "" {
-			version = latestTag
-		}
 		return nil
 	},
 }

--- a/docs/content/reference/aperturectl/install/agent/agent.md
+++ b/docs/content/reference/aperturectl/install/agent/agent.md
@@ -42,7 +42,7 @@ aperturectl install agent --values-file=values.yaml --namespace=aperture
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/install/controller/controller.md
+++ b/docs/content/reference/aperturectl/install/controller/controller.md
@@ -43,7 +43,7 @@ aperturectl install controller --values-file=values.yaml --namespace=aperture
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/install/install.md
+++ b/docs/content/reference/aperturectl/install/install.md
@@ -24,7 +24,7 @@ Use this command to install Aperture Controller and Agent on your Kubernetes clu
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/install/istioconfig/istioconfig.md
+++ b/docs/content/reference/aperturectl/install/istioconfig/istioconfig.md
@@ -42,7 +42,7 @@ aperturectl install istioconfig --values-file=values.yaml --namespace=istio-syst
       --kube-config string   Path to the Kubernetes cluster config. Defaults to '~/.kube/config'
       --namespace string     Namespace in which the component will be installed. Defaults to 'default' namespace (default "default")
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/uninstall/agent/agent.md
+++ b/docs/content/reference/aperturectl/uninstall/agent/agent.md
@@ -41,7 +41,7 @@ aperturectl uninstall agent --namespace=aperture
       --namespace string     Namespace from which the component will be uninstalled. Defaults to 'default' namespace (default "default")
       --timeout int          Timeout of waiting for uninstallation hooks completion (default 300)
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/uninstall/controller/controller.md
+++ b/docs/content/reference/aperturectl/uninstall/controller/controller.md
@@ -41,7 +41,7 @@ aperturectl uninstall controller --namespace=aperture
       --namespace string     Namespace from which the component will be uninstalled. Defaults to 'default' namespace (default "default")
       --timeout int          Timeout of waiting for uninstallation hooks completion (default 300)
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/uninstall/istioconfig/istioconfig.md
+++ b/docs/content/reference/aperturectl/uninstall/istioconfig/istioconfig.md
@@ -41,7 +41,7 @@ aperturectl uninstall istioconfig --namespace=istio-system
       --namespace string     Namespace from which the component will be uninstalled. Defaults to 'default' namespace (default "default")
       --timeout int          Timeout of waiting for uninstallation hooks completion (default 300)
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/aperturectl/uninstall/uninstall.md
+++ b/docs/content/reference/aperturectl/uninstall/uninstall.md
@@ -24,7 +24,7 @@ Use this command to uninstall Aperture Controller and Agent from your Kubernetes
       --namespace string     Namespace from which the component will be uninstalled. Defaults to 'default' namespace (default "default")
       --timeout int          Timeout of waiting for uninstallation hooks completion (default 300)
       --values-file string   Values YAML file containing parameters to customize the installation
-      --version string       Version of the Aperture (default "latest")
+      --version string       Version of the Aperture
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
We cannot publish a chart with version as latest as it doesn't consider it as a valid semver.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- **Change**: The `--version` flag in the `aperturectl install` and `aperturectl uninstall` commands now requires explicit input from the user. The default value of "latest" has been removed.
- **Impact**: This change enhances the precision of the installation and uninstallation process, ensuring users have full control over the version of Aperture they are managing. It prevents unintentional installations or uninstallations of the latest version when a specific version is intended.
- **Documentation**: Updated command references in the documentation to reflect this change. Users are now guided to provide a specific version when using these commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->