### PR TITLE
Delete policy as Custom Resource when on kube

### DIFF
--- a/cmd/aperturectl/cmd/policy/delete.go
+++ b/cmd/aperturectl/cmd/policy/delete.go
@@ -1,12 +1,18 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fluxninja/aperture/v2/cmd/aperturectl/cmd/utils"
+	"github.com/fluxninja/aperture/v2/operator/api"
+	policyv1alpha1 "github.com/fluxninja/aperture/v2/operator/api/policy/v1alpha1"
 	"github.com/fluxninja/aperture/v2/pkg/log"
 )
 
@@ -25,9 +31,47 @@ var DeleteCmd = &cobra.Command{
 
 // deletePolicy deletes the policy from the cluster.
 func deletePolicy(policyName string) error {
-	err := utils.DeletePolicyUsingAPI(client, policyName)
-	if err != nil {
-		return fmt.Errorf("failed to delete policy: %w", err)
+	if Controller.IsKube() {
+		deployment, err := utils.GetControllerDeployment(Controller.GetKubeRestConfig(), controllerNs)
+		if err != nil {
+			return err
+		}
+
+		err = api.AddToScheme(scheme.Scheme)
+		if err != nil {
+			return fmt.Errorf("failed to connect to Kubernetes: %w", err)
+		}
+
+		kubeClient, err := k8sclient.New(Controller.GetKubeRestConfig(), k8sclient.Options{
+			Scheme: scheme.Scheme,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create Kubernetes client: %w", err)
+		}
+
+		policyCR := &policyv1alpha1.Policy{}
+		policyCR.Name = policyName
+		policyCR.Namespace = deployment.GetNamespace()
+		err = kubeClient.Delete(context.Background(), policyCR)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info().Str("policy", policyName).Msg("Policy not found in Kubernetes")
+				return nil
+			}
+
+			if utils.IsNoMatchError(err) {
+				err = utils.DeletePolicyUsingAPI(client, policyName)
+			}
+
+			if err != nil {
+				return fmt.Errorf("failed to delete policy from Kubernetes: %w", err)
+			}
+		}
+	} else {
+		err := utils.DeletePolicyUsingAPI(client, policyName)
+		if err != nil {
+			return fmt.Errorf("failed to delete policy: %w", err)
+		}
 	}
 
 	log.Info().Str("policy", policyName).Msg("Deleted Policy successfully")


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the policy deletion process in the Aperture Control Command. Now, it can handle policy deletions directly from Kubernetes, improving the overall user experience.
- Improvement: Added conditions to verify if the controller is running in Kubernetes, ensuring smoother operations.
- Improvement: Enhanced error handling for different scenarios during the policy deletion process, increasing the system's reliability.
- New Feature: Added logging statements to provide more transparency about the policy deletion process, aiding in troubleshooting and system monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->