### PR TITLE
aperture-js: do not keep alive by default

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.5",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -4,19 +4,19 @@ import grpc, {
   connectivityState,
 } from "@grpc/grpc-js";
 import * as otelApi from "@opentelemetry/api";
-import {OTLPTraceExporter} from "@opentelemetry/exporter-trace-otlp-grpc";
-import {Resource} from "@opentelemetry/resources";
-import {BatchSpanProcessor, Tracer} from "@opentelemetry/sdk-trace-base";
-import {NodeTracerProvider} from "@opentelemetry/sdk-trace-node";
-import {SemanticResourceAttributes} from "@opentelemetry/semantic-conventions";
-import {serializeError} from "serialize-error";
-import {CheckRequest} from "./gen/aperture/flowcontrol/check/v1/CheckRequest.js";
-import {CheckResponse__Output} from "./gen/aperture/flowcontrol/check/v1/CheckResponse.js";
-import {FlowControlServiceClient} from "./gen/aperture/flowcontrol/check/v1/FlowControlService.js";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
+import { Resource } from "@opentelemetry/resources";
+import { BatchSpanProcessor, Tracer } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { serializeError } from "serialize-error";
+import { CheckRequest } from "./gen/aperture/flowcontrol/check/v1/CheckRequest.js";
+import { CheckResponse__Output } from "./gen/aperture/flowcontrol/check/v1/CheckResponse.js";
+import { FlowControlServiceClient } from "./gen/aperture/flowcontrol/check/v1/FlowControlService.js";
 
-import {LIBRARY_NAME, LIBRARY_VERSION, URL} from "./consts.js";
-import {Flow} from "./flow.js";
-import {fcs} from "./utils.js";
+import { LIBRARY_NAME, LIBRARY_VERSION, URL } from "./consts.js";
+import { Flow } from "./flow.js";
+import { fcs } from "./utils.js";
 
 export interface FlowParams {
   labels?: Record<string, string>;
@@ -41,13 +41,6 @@ export class ApertureClient {
     channelCredentials?: ChannelCredentials;
     channelOptions?: ChannelOptions;
   } = {}) {
-    const defaultChannelOptions = {
-      "grpc.keepalive_time_ms": 10000,
-      "grpc.keepalive_timeout_ms": 5000,
-    };
-
-    channelOptions = { ...defaultChannelOptions, ...channelOptions };
-
     this.fcsClient = new fcs.FlowControlService(
       URL,
       channelCredentials,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: The Aperture JavaScript SDK has undergone minor adjustments to improve code readability and maintainability. These changes include updates to import statements and variable names, and the removal of default channel options. Please note that these modifications do not alter the functionality or behavior of the SDK. Users will continue to experience the same reliable performance as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->