### PR TITLE
refactor get agents

### DIFF
--- a/pkg/agent-functions/agents/agents.go
+++ b/pkg/agent-functions/agents/agents.go
@@ -13,10 +13,7 @@ import (
 	peersv1 "github.com/fluxninja/aperture/v2/api/gen/proto/go/aperture/peers/v1"
 	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
 	"github.com/fluxninja/aperture/v2/pkg/etcd/transport"
-)
-
-const (
-	etcPath = "/peers/aperture-agent/"
+	"github.com/fluxninja/aperture/v2/pkg/policies/paths"
 )
 
 // Module is fx module for controlling Agents on controller side.
@@ -102,7 +99,7 @@ func (a Agents) PreviewHTTPRequests(
 
 // GetAgents lists the agents registered on etcd under /peers/aperture-agent.
 func (a Agents) GetAgents() ([]string, error) {
-	resp, err := a.etcdClient.Client.KV.Get(context.Background(), "/peers/aperture-agent/", clientv3.WithPrefix())
+	resp, err := a.etcdClient.Client.KV.Get(context.Background(), paths.AgentPeerPath, clientv3.WithPrefix())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent-functions/agents/agents.go
+++ b/pkg/agent-functions/agents/agents.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/fx"
@@ -110,7 +111,8 @@ func (a Agents) GetAgents() ([]string, error) {
 
 	agents := []string{}
 	for _, kv := range resp.Kvs {
-		agents = append(agents, re.ReplaceAllString(string(kv.Key), ""))
+		agent := re.ReplaceAllString(string(kv.Key), "")
+		agents = append(agents, agent[:strings.LastIndex(agent, ":")])
 	}
 	return agents, nil
 }

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fluxninja/aperture/v2/pkg/net/listener"
 	"github.com/fluxninja/aperture/v2/pkg/notifiers"
 	peersconfig "github.com/fluxninja/aperture/v2/pkg/peers/config"
+	"github.com/fluxninja/aperture/v2/pkg/policies/paths"
 	"github.com/fluxninja/aperture/v2/pkg/status"
 )
 
@@ -39,10 +40,7 @@ const (
 	watcherFxTag     = "peer-discovery-watcher"
 )
 
-var (
-	peerDiscoverySyncPath = path.Join(config.DefaultTempDirectory, "peers")
-	etcdPath              = path.Join("/peers")
-)
+var peerDiscoverySyncPath = path.Join(config.DefaultTempDirectory, "peers")
 
 // Constructor holds fields to create and configure PeerDiscovery.
 type Constructor struct {
@@ -170,7 +168,7 @@ func NewPeerDiscovery(
 			Peers: make(map[string]*peersv1.Peer),
 		},
 		watchers:        watchers,
-		etcdPath:        path.Join(etcdPath, prefix),
+		etcdPath:        path.Join(paths.PeersPrefix, prefix),
 		client:          client,
 		sessionScopedKV: sessionScopedKV,
 	}

--- a/pkg/policies/paths/paths.go
+++ b/pkg/policies/paths/paths.go
@@ -48,6 +48,10 @@ var (
 	SamplerConfigPath = path.Join(ConfigPrefix, "sampler")
 	// SamplerDecisionsPath is decision path in etcd for sampler decisions.
 	SamplerDecisionsPath = path.Join(DecisionsPrefix, "sampler")
+	// PeersPrefix is the prefix for peers path in etcd.
+	PeersPrefix = path.Join("/peers")
+	// AgentPeerPath is path in etcd for agent peers.
+	AgentPeerPath = path.Join(PeersPrefix, "aperture-agent")
 )
 
 // AgentGroupPrefix returns the prefix for an agent group.


### PR DESCRIPTION
### Description of change

- Refactor GetAgents for the change in peer keys in etcd

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Improved the 'GetAgents' function to enhance data extraction, making it more efficient and reliable.
- New Feature: Introduced new variables `PeersPrefix` and `AgentPeerPath` to standardize paths in the system, improving code maintainability.
- Refactor: Streamlined the 'PeerDiscovery' struct by directly assigning the value to the 'etcdPath' field, enhancing code readability.
- Refactor: Moved the 'peerDiscoverySyncPath' constant outside of the var block for better code organization.

These changes primarily improve the backend code structure and efficiency, leading to more reliable performance. They do not introduce new user-facing features or alter existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->