### PR TITLE
Register archive sub-command

### DIFF
--- a/cmd/aperturectl/cmd/cloud/blueprints/archive.go
+++ b/cmd/aperturectl/cmd/cloud/blueprints/archive.go
@@ -12,7 +12,7 @@ import (
 // BlueprintsArchiveCmd is the command to archive a blueprint from the Cloud Controller.
 var BlueprintsArchiveCmd = &cobra.Command{
 	Use:           "archive POLICY_NAME",
-	Short:         "Cloud Blueprints Achieve for the given Policy Name",
+	Short:         "Cloud Blueprints Archive for the given Policy Name",
 	Long:          `Archive cloud blueprint.`,
 	SilenceErrors: true,
 	Args:          cobra.ExactArgs(1),

--- a/cmd/aperturectl/cmd/cloud/blueprints/root.go
+++ b/cmd/aperturectl/cmd/cloud/blueprints/root.go
@@ -13,6 +13,7 @@ func init() {
 	BlueprintsCmd.AddCommand(BlueprintsGetCmd)
 	BlueprintsCmd.AddCommand(BlueprintsDeleteCmd)
 	BlueprintsCmd.AddCommand(BlueprintsApplyCmd)
+	BlueprintsCmd.AddCommand(BlueprintsArchiveCmd)
 }
 
 // BlueprintsCmd is the command to apply a policy to the Cloud Controller.

--- a/cmd/aperturectl/cmd/cloud/policy/root.go
+++ b/cmd/aperturectl/cmd/cloud/policy/root.go
@@ -22,6 +22,7 @@ func init() {
 	PolicyCmd.AddCommand(GetCmd)
 	PolicyCmd.AddCommand(ListCmd)
 	PolicyCmd.AddCommand(DeleteCmd)
+	PolicyCmd.AddCommand(ArchiveCmd)
 }
 
 // PolicyCmd is the command to apply a policy to the Cloud Controller.

--- a/docs/content/reference/aperturectl/cloud/blueprints/archive/archive.md
+++ b/docs/content/reference/aperturectl/cloud/blueprints/archive/archive.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: Archive
+hide_title: true
+keywords:
+  - aperturectl
+  - aperturectl_cloud_blueprints_archive
+---
+
+<!-- markdownlint-disable -->
+
+## aperturectl cloud blueprints archive
+
+Cloud Blueprints Achieve for the given Policy Name
+
+### Synopsis
+
+Archive cloud blueprint.
+
+```
+aperturectl cloud blueprints archive POLICY_NAME [flags]
+```
+
+### Examples
+
+```
+aperturectl cloud blueprints archive rate-limiting
+```
+
+### Options
+
+```
+  -h, --help   help for archive
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string        Aperture Cloud User API Key to be used when using Cloud Controller
+      --config string         Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
+      --controller string     Address of Aperture Cloud Controller
+      --insecure              Allow connection to controller running without TLS
+      --project-name string   Aperture Cloud Project Name to be used when using Cloud Controller
+      --skip-verify           Skip TLS certificate verification while connecting to controller
+```
+
+### SEE ALSO
+
+- [aperturectl cloud blueprints](/reference/aperturectl/cloud/blueprints/blueprints.md) - Cloud Blueprints

--- a/docs/content/reference/aperturectl/cloud/blueprints/archive/archive.md
+++ b/docs/content/reference/aperturectl/cloud/blueprints/archive/archive.md
@@ -10,7 +10,7 @@ keywords:
 
 ## aperturectl cloud blueprints archive
 
-Cloud Blueprints Achieve for the given Policy Name
+Cloud Blueprints Archive for the given Policy Name
 
 ### Synopsis
 

--- a/docs/content/reference/aperturectl/cloud/blueprints/blueprints.md
+++ b/docs/content/reference/aperturectl/cloud/blueprints/blueprints.md
@@ -32,7 +32,7 @@ Interact with cloud blueprints.
 
 - [aperturectl cloud](/reference/aperturectl/cloud/cloud.md) - Commands to communicate with the Cloud Controller
 - [aperturectl cloud blueprints apply](/reference/aperturectl/cloud/blueprints/apply/apply.md) - Cloud Blueprints Apply
-- [aperturectl cloud blueprints archive](/reference/aperturectl/cloud/blueprints/archive/archive.md) - Cloud Blueprints Achieve for the given Policy Name
+- [aperturectl cloud blueprints archive](/reference/aperturectl/cloud/blueprints/archive/archive.md) - Cloud Blueprints Archive for the given Policy Name
 - [aperturectl cloud blueprints delete](/reference/aperturectl/cloud/blueprints/delete/delete.md) - Cloud Blueprints Delete for the given Policy Name
 - [aperturectl cloud blueprints get](/reference/aperturectl/cloud/blueprints/get/get.md) - Cloud Blueprints Get
 - [aperturectl cloud blueprints list](/reference/aperturectl/cloud/blueprints/list/list.md) - Cloud Blueprints List

--- a/docs/content/reference/aperturectl/cloud/blueprints/blueprints.md
+++ b/docs/content/reference/aperturectl/cloud/blueprints/blueprints.md
@@ -32,6 +32,7 @@ Interact with cloud blueprints.
 
 - [aperturectl cloud](/reference/aperturectl/cloud/cloud.md) - Commands to communicate with the Cloud Controller
 - [aperturectl cloud blueprints apply](/reference/aperturectl/cloud/blueprints/apply/apply.md) - Cloud Blueprints Apply
+- [aperturectl cloud blueprints archive](/reference/aperturectl/cloud/blueprints/archive/archive.md) - Cloud Blueprints Achieve for the given Policy Name
 - [aperturectl cloud blueprints delete](/reference/aperturectl/cloud/blueprints/delete/delete.md) - Cloud Blueprints Delete for the given Policy Name
 - [aperturectl cloud blueprints get](/reference/aperturectl/cloud/blueprints/get/get.md) - Cloud Blueprints Get
 - [aperturectl cloud blueprints list](/reference/aperturectl/cloud/blueprints/list/list.md) - Cloud Blueprints List

--- a/docs/content/reference/aperturectl/cloud/policy/archive/archive.md
+++ b/docs/content/reference/aperturectl/cloud/policy/archive/archive.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: Archive
+hide_title: true
+keywords:
+  - aperturectl
+  - aperturectl_cloud_policy_archive
+---
+
+<!-- markdownlint-disable -->
+
+## aperturectl cloud policy archive
+
+Archive Aperture Policy from the Aperture Cloud Controller
+
+### Synopsis
+
+Use this command to archive the Aperture Policy from the Aperture Cloud Controller.
+
+```
+aperturectl cloud policy archive POLICY_NAME [flags]
+```
+
+### Examples
+
+```
+aperturectl cloud policy archive POLICY_NAME
+```
+
+### Options
+
+```
+  -h, --help   help for archive
+```
+
+### Options inherited from parent commands
+
+```
+      --api-key string        Aperture Cloud User API Key to be used when using Cloud Controller
+      --config string         Path to the Aperture config file. Defaults to '~/.aperturectl/config' or $APERTURE_CONFIG
+      --controller string     Address of Aperture Cloud Controller
+      --insecure              Allow connection to controller running without TLS
+      --project-name string   Aperture Cloud Project Name to be used when using Cloud Controller
+      --skip-verify           Skip TLS certificate verification while connecting to controller
+```
+
+### SEE ALSO
+
+- [aperturectl cloud policy](/reference/aperturectl/cloud/policy/policy.md) - Aperture Policy related commands for the Cloud Controller

--- a/docs/content/reference/aperturectl/cloud/policy/policy.md
+++ b/docs/content/reference/aperturectl/cloud/policy/policy.md
@@ -32,6 +32,7 @@ Use this command to manage the Aperture Policies to the Cloud Controller.
 
 - [aperturectl cloud](/reference/aperturectl/cloud/cloud.md) - Commands to communicate with the Cloud Controller
 - [aperturectl cloud policy apply](/reference/aperturectl/cloud/policy/apply/apply.md) - Apply Aperture Policy to the Aperture Cloud Controller
+- [aperturectl cloud policy archive](/reference/aperturectl/cloud/policy/archive/archive.md) - Archive Aperture Policy from the Aperture Cloud Controller
 - [aperturectl cloud policy delete](/reference/aperturectl/cloud/policy/delete/delete.md) - Delete Aperture Policy from the Aperture Cloud Controller
 - [aperturectl cloud policy get](/reference/aperturectl/cloud/policy/get/get.md) - Get Aperture Policy from the Aperture Cloud Controller
 - [aperturectl cloud policy list](/reference/aperturectl/cloud/policy/list/list.md) - List all Aperture Policies from the Aperture Cloud Controller


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added the `aperturectl cloud blueprints archive` command, allowing users to archive cloud blueprints based on a specific policy name.
- New Feature: Introduced the `aperturectl cloud policy archive` command, enabling users to archive an Aperture Policy from the Aperture Cloud Controller.
- Documentation: Created new documentation files for the newly added commands, providing usage examples, options, and related commands.
- Bug Fix: Corrected the command description from "Cloud Blueprints Achieve" to "Cloud Blueprints Archive" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->