### PR TITLE
Make uri non-mandatory field in blueprints

### DIFF
--- a/api/buf.lock
+++ b/api/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: 27615d1d1f70409a96cd3280a0ec3010
-    digest: shake256:eb562cae3f959c9cc080b4effc5689d4357791b2b957020c6aa5a31071225c301ec766340c661f81ed89d2023fb0dba2583bc12679e403e09496e612a2bff246
+    commit: 732c4688b93c46ac880e26bb2ddbd664
+    digest: shake256:04be2d6c49185696082af4ec662c69cae74791ca23d35c65ff9bf7a7079bee7b87e29a000f84106bc05f3acfd1d7aa8fa18020e3c87baeae783b89c6a34004c1
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate

--- a/blueprints/auto-scaling/pod-auto-scaler/gen/definitions.json
+++ b/blueprints/auto-scaling/pod-auto-scaler/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "auto-scaling/pod-auto-scaler blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/auto-scaling/pod-auto-scaler/gen/values.yaml
+++ b/blueprints/auto-scaling/pod-auto-scaler/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/auto-scaling/pod-auto-scaler
 blueprint: auto-scaling/pod-auto-scaler
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/blueprint-assets-generator.py
+++ b/blueprints/blueprint-assets-generator.py
@@ -487,7 +487,6 @@ additionalProperties: false
 required:
 {%- if not is_dynamic_config %}
 - blueprint
-- uri
 {% endif %}
 {% for child_name in nested_parameters.required_children %}- {{ child_name }}
 {% endfor %}
@@ -519,7 +518,6 @@ YAML_TPL = """
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/{{ blueprint_name }}
 blueprint: {{ blueprint_name }}
-uri: github.com/fluxninja/aperture/blueprints@latest
 {%- endif %}
 {%- macro render_value(value, level) %}
 {%- if value is mapping %}

--- a/blueprints/load-ramping/base/gen/definitions.json
+++ b/blueprints/load-ramping/base/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "load-ramping/base blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/load-ramping/base/gen/values.yaml
+++ b/blueprints/load-ramping/base/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-ramping/base
 blueprint: load-ramping/base
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/load-scheduling/average-latency/gen/definitions.json
+++ b/blueprints/load-scheduling/average-latency/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "load-scheduling/average-latency blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/load-scheduling/average-latency/gen/values.yaml
+++ b/blueprints/load-scheduling/average-latency/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-scheduling/average-latency
 blueprint: load-scheduling/average-latency
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/load-scheduling/elasticsearch/gen/definitions.json
+++ b/blueprints/load-scheduling/elasticsearch/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "load-scheduling/elasticsearch blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/load-scheduling/elasticsearch/gen/values.yaml
+++ b/blueprints/load-scheduling/elasticsearch/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-scheduling/elasticsearch
 blueprint: load-scheduling/elasticsearch
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/load-scheduling/java-gc-generic/gen/definitions.json
+++ b/blueprints/load-scheduling/java-gc-generic/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "load-scheduling/java-gc-generic blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/load-scheduling/java-gc-generic/gen/values.yaml
+++ b/blueprints/load-scheduling/java-gc-generic/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-scheduling/java-gc-generic
 blueprint: load-scheduling/java-gc-generic
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/load-scheduling/java-gc-k8s/gen/definitions.json
+++ b/blueprints/load-scheduling/java-gc-k8s/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "load-scheduling/java-gc-k8s blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/load-scheduling/java-gc-k8s/gen/values.yaml
+++ b/blueprints/load-scheduling/java-gc-k8s/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-scheduling/java-gc-k8s
 blueprint: load-scheduling/java-gc-k8s
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/load-scheduling/postgresql/gen/definitions.json
+++ b/blueprints/load-scheduling/postgresql/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "load-scheduling/postgresql blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/load-scheduling/postgresql/gen/values.yaml
+++ b/blueprints/load-scheduling/postgresql/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-scheduling/postgresql
 blueprint: load-scheduling/postgresql
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/load-scheduling/promql/gen/definitions.json
+++ b/blueprints/load-scheduling/promql/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "load-scheduling/promql blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/load-scheduling/promql/gen/values.yaml
+++ b/blueprints/load-scheduling/promql/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/load-scheduling/promql
 blueprint: load-scheduling/promql
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/quota-scheduling/base/gen/definitions.json
+++ b/blueprints/quota-scheduling/base/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "quota-scheduling/base blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/quota-scheduling/base/gen/values.yaml
+++ b/blueprints/quota-scheduling/base/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/quota-scheduling/base
 blueprint: quota-scheduling/base
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/blueprints/rate-limiting/base/gen/definitions.json
+++ b/blueprints/rate-limiting/base/gen/definitions.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "rate-limiting/base blueprint",
   "additionalProperties": false,
-  "required": ["blueprint", "uri", "policy"],
+  "required": ["blueprint", "policy"],
   "properties": {
     "blueprint": {
       "description": "Blueprint name",

--- a/blueprints/rate-limiting/base/gen/values.yaml
+++ b/blueprints/rate-limiting/base/gen/values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/rate-limiting/base
 blueprint: rate-limiting/base
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/cmd/aperturectl/cmd/blueprints/generate.go
+++ b/cmd/aperturectl/cmd/blueprints/generate.go
@@ -155,7 +155,7 @@ func Generate(valuesFile string, overrideBlueprintsURI string, overrideBlueprint
 	if overrideBlueprintsVersion == "" && overrideBlueprintsURI == "" {
 		blueprintsURI, ok = values["uri"].(string)
 		if !ok {
-			return nil, fmt.Errorf("values file does not contain uri field")
+			log.Info().Msgf("using default blueprints uri: %s@%s", DefaultBlueprintsRepo, LatestTag)
 		}
 	} else {
 		blueprintsURI = overrideBlueprintsURI

--- a/docs/content/get-started/policies/assets/raw_values.yaml
+++ b/docs/content/get-started/policies/assets/raw_values.yaml
@@ -2,7 +2,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/rate-limiting/base
 blueprint: rate-limiting/base
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/docs/content/get-started/policies/assets/values.yaml
+++ b/docs/content/get-started/policies/assets/values.yaml
@@ -3,7 +3,6 @@
 # Documentation/Reference for objects and parameters can be found at:
 # https://docs.fluxninja.com/reference/blueprints/rate-limiting/base
 blueprint: rate-limiting/base
-uri: github.com/fluxninja/aperture/blueprints@latest
 
 policy:
   # Name of the policy.

--- a/docs/content/guides/api-quota-management/openai.md
+++ b/docs/content/guides/api-quota-management/openai.md
@@ -270,7 +270,6 @@ control point labels.
 # https://docs.fluxninja.com/reference/blueprints/quota-scheduling/base
 
 blueprint: quota-scheduling/base
-uri: github.com/fluxninja/aperture/blueprints@latest
 policy:
   # Name of the policy.
   # Type: string
@@ -317,7 +316,6 @@ policy:
 # https://docs.fluxninja.com/reference/blueprints/quota-scheduling/base
 
 blueprint: quota-scheduling/base
-uri: github.com/fluxninja/aperture/blueprints@latest
 policy:
   # Name of the policy.
   # Type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: The `uri` parameter, previously required in the blueprint configuration, has been removed. This simplifies the configuration process and reduces potential errors.
- New Feature: If the "uri" field is not found in the values file, the system will now use a default blueprints URI. This change enhances the software's reliability by ensuring a fallback option is always available.
- Documentation: Updates have been made to the `quota-scheduling/base` blueprint documentation to reflect the removal of the `uri` field. This ensures that our documentation remains accurate and up-to-date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->