### PR TITLE
Fix link to spec.md

### DIFF
--- a/docs/content/concepts/scheduler/load-scheduler.md
+++ b/docs/content/concepts/scheduler/load-scheduler.md
@@ -107,6 +107,6 @@ _Range-Driven Load Scheduler_ is a high-level [circuit](../advanced/circuit.md)
 component that uses the _Load Scheduler_ internally.
 
 This component has `signal` and `overload_confirmation` ports. It uses the
-[polynomial range function](../../reference/configuration/spec#polynomial-range-function)
+[polynomial range function](../../reference/configuration/spec.md#polynomial-range-function)
 to throttle the token rate based on the range of the `signal`, attempting to
 keep it between `low_throttle_threshold` and `high_throttle_threshold`.


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Documentation: Fixed a broken link in the scheduler documentation. The link now correctly directs users to the `spec.md` file, enhancing the usability and accuracy of our documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->