### PR TITLE
Reserve 'aperture-cloud' agent group for cloud agent

### DIFF
--- a/api/aperture/policy/language/v1/flowcontrol.proto
+++ b/api/aperture/policy/language/v1/flowcontrol.proto
@@ -1114,7 +1114,7 @@ message Selector {
   // form a peer to peer cluster to constantly share state.
   //
   // :::
-  string agent_group = 2; // @gotags: default:"default"
+  string agent_group = 2; // @gotags: default:"aperture-cloud"
 
   // The Fully Qualified Domain Name of the
   // [service](/concepts/selector.md) to select.

--- a/api/buf.lock
+++ b/api/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: 732c4688b93c46ac880e26bb2ddbd664
-    digest: shake256:04be2d6c49185696082af4ec662c69cae74791ca23d35c65ff9bf7a7079bee7b87e29a000f84106bc05f3acfd1d7aa8fa18020e3c87baeae783b89c6a34004c1
+    commit: 1acb1bb6ebc9499aae128620b886f837
+    digest: shake256:164015e733ffc28a8a8b08d2c71056267e4850c7a0caa853a9f38a1597360c0475cf4143301a7e9a5c13a0c3753c927cfc02ef22d9d9dd946a58d373423c868f
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate

--- a/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/flowcontrol.pb.go
@@ -2149,7 +2149,7 @@ type Selector struct {
 	// form a peer to peer cluster to constantly share state.
 	//
 	// :::
-	AgentGroup string `protobuf:"bytes,2,opt,name=agent_group,json=agentGroup,proto3" json:"agent_group,omitempty" default:"default"` // @gotags: default:"default"
+	AgentGroup string `protobuf:"bytes,2,opt,name=agent_group,json=agentGroup,proto3" json:"agent_group,omitempty" default:"aperture-cloud"` // @gotags: default:"aperture-cloud"
 	// The Fully Qualified Domain Name of the
 	// [service](/concepts/selector.md) to select.
 	//

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -3452,10 +3452,10 @@
       "description": "Selects flows based on control point, flow labels, agent group and the service\nthat the flow control component\nwill operate on.\n\n:::info\n\nSee also [Selector overview](/concepts/selector.md).\n\n:::\n\nExample:\n```yaml\ncontrol_point: ingress\nlabel_matcher:\n  match_labels:\n    user_tier: gold\n  match_expressions:\n    - key: query\n      operator: In\n      values:\n        - insert\n        - delete\n  expression:\n    label_matches:\n        - label: user_agent\n          regex: ^(?!.*Chrome).*Safari\n```",
       "properties": {
         "agent_group": {
-          "default": "default",
+          "default": "aperture-cloud",
           "description": "[_Agent Group_](/concepts/selector.md#agent-group) this\nselector applies to.\n\n:::info\n\nAgent Groups are used to scope policies to a subset of agents connected to the same controller.\nThe agents within an agent group receive exact same policy configuration and\nform a peer to peer cluster to constantly share state.\n\n:::\n\n",
           "type": "string",
-          "x-go-tag-default": "default"
+          "x-go-tag-default": "aperture-cloud"
         },
         "control_point": {
           "description": "[Control Point](/concepts/control-point.md)\nidentifies location within services where policies can act on flows.\nFor an SDK based insertion,\na _Control Point_ can represent a particular feature or execution\nblock within a service. In case of service mesh or middleware insertion, a\n_Control Point_ can identify ingress or egress calls or distinct listeners\nor filter chains.\n\n",

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -3736,7 +3736,7 @@ definitions:
             ```
         properties:
             agent_group:
-                default: default
+                default: aperture-cloud
                 description: |+
                     [_Agent Group_](/concepts/selector.md#agent-group) this
                     selector applies to.
@@ -3750,7 +3750,7 @@ definitions:
                     :::
 
                 type: string
-                x-go-tag-default: default
+                x-go-tag-default: aperture-cloud
             control_point:
                 description: |+
                     [Control Point](/concepts/control-point.md)

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -4396,7 +4396,7 @@ definitions:
             ```
         properties:
             agent_group:
-                default: default
+                default: aperture-cloud
                 description: |+
                     [_Agent Group_](/concepts/selector.md#agent-group) this
                     selector applies to.
@@ -4410,7 +4410,7 @@ definitions:
                     :::
 
                 type: string
-                x-go-tag-default: default
+                x-go-tag-default: aperture-cloud
             control_point:
                 description: |+
                     [Control Point](/concepts/control-point.md)

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -1521,7 +1521,8 @@ Interval between each heartbeat.
 
 <!-- vale off -->
 
-(string, one of: `KUBERNETES_SIDECAR | KUBERNETES_DAEMONSET | LINUX_BARE_METAL`,
+(string, one of:
+`KUBERNETES_SIDECAR | KUBERNETES_DAEMONSET | LINUX_BARE_METAL | CLOUD_AGENT`,
 default: `"LINUX_BARE_METAL"`)
 
 <!-- vale on -->

--- a/docs/content/reference/configuration/controller.md
+++ b/docs/content/reference/configuration/controller.md
@@ -1040,7 +1040,8 @@ Interval between each heartbeat.
 
 <!-- vale off -->
 
-(string, one of: `KUBERNETES_SIDECAR | KUBERNETES_DAEMONSET | LINUX_BARE_METAL`,
+(string, one of:
+`KUBERNETES_SIDECAR | KUBERNETES_DAEMONSET | LINUX_BARE_METAL | CLOUD_AGENT`,
 default: `"LINUX_BARE_METAL"`)
 
 <!-- vale on -->

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -8615,7 +8615,7 @@ label_matcher:
 
 <!-- vale off -->
 
-(string, default: `"default"`)
+(string, default: `"aperture-cloud"`)
 
 <!-- vale on -->
 

--- a/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
+++ b/docs/gen/config/extensions/fluxninja/extension-swagger.yaml
@@ -158,12 +158,13 @@ definitions:
                     - KUBERNETES_SIDECAR
                     - KUBERNETES_DAEMONSET
                     - LINUX_BARE_METAL
+                    - CLOUD_AGENT
                 type: string
                 x-go-name: InstallationMode
                 x-go-tag-default: LINUX_BARE_METAL
                 x-go-tag-json: installation_mode
-                x-go-tag-validate: oneof=KUBERNETES_SIDECAR KUBERNETES_DAEMONSET LINUX_BARE_METAL
-                x-oneof: KUBERNETES_SIDECAR | KUBERNETES_DAEMONSET | LINUX_BARE_METAL
+                x-go-tag-validate: oneof=KUBERNETES_SIDECAR KUBERNETES_DAEMONSET LINUX_BARE_METAL CLOUD_AGENT
+                x-oneof: KUBERNETES_SIDECAR | KUBERNETES_DAEMONSET | LINUX_BARE_METAL | CLOUD_AGENT
         title: FluxNinjaExtensionConfig is the configuration for [FluxNinja integration](/reference/fluxninja.md).
         type: object
         x-go-package: github.com/fluxninja/aperture/v2/extensions/fluxninja/extconfig

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -3650,7 +3650,7 @@ definitions:
             ```
         properties:
             agent_group:
-                default: default
+                default: aperture-cloud
                 description: |+
                     [_Agent Group_](/concepts/selector.md#agent-group) this
                     selector applies to.
@@ -3664,7 +3664,7 @@ definitions:
                     :::
 
                 type: string
-                x-go-tag-default: default
+                x-go-tag-default: aperture-cloud
             control_point:
                 description: |+
                     [Control Point](/concepts/control-point.md)

--- a/extensions/fluxninja/extconfig/extconfig.go
+++ b/extensions/fluxninja/extconfig/extconfig.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/fx"
 
+	agentinfo "github.com/fluxninja/aperture/v2/pkg/agent-info"
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	etcdclient "github.com/fluxninja/aperture/v2/pkg/etcd/client"
 	"github.com/fluxninja/aperture/v2/pkg/net/grpc"
@@ -31,7 +32,7 @@ type FluxNinjaExtensionConfig struct {
 	// API Key for this agent. If this key is not set, the extension won't be enabled.
 	AgentAPIKey string `json:"agent_api_key"`
 	// Installation mode describes on which underlying platform the Agent or the Controller is being run.
-	InstallationMode string `json:"installation_mode" validate:"oneof=KUBERNETES_SIDECAR KUBERNETES_DAEMONSET LINUX_BARE_METAL" default:"LINUX_BARE_METAL"`
+	InstallationMode string `json:"installation_mode" validate:"oneof=KUBERNETES_SIDECAR KUBERNETES_DAEMONSET LINUX_BARE_METAL CLOUD_AGENT" default:"LINUX_BARE_METAL"`
 	// Whether to connect to [Aperture Cloud Controller](/reference/fluxninja.md).
 	//
 	// Enabling this flag configures various agent components to point to the
@@ -66,6 +67,7 @@ func Module() fx.Option {
 		fx.Provide(provideConfig),
 		fx.Provide(provideEtcdConfigOverride),
 		fx.Provide(providePrometheusConfigOverride),
+		fx.Provide(provideAgentInfoConfigOverride),
 	)
 }
 
@@ -76,6 +78,12 @@ func provideConfig(unmarshaller config.Unmarshaller) (*FluxNinjaExtensionConfig,
 		return nil, err
 	}
 	return &extensionConfig, nil
+}
+
+func provideAgentInfoConfigOverride(extensionConfig *FluxNinjaExtensionConfig) *agentinfo.InstallationModeConfig {
+	return &agentinfo.InstallationModeConfig{
+		InstallationMode: extensionConfig.InstallationMode,
+	}
 }
 
 func provideEtcdConfigOverride(extensionConfig *FluxNinjaExtensionConfig) *etcdclient.ConfigOverride {

--- a/operator/controllers/agent/deployment_test.go
+++ b/operator/controllers/agent/deployment_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Agent Deployment", func() {
 				Spec: agentv1alpha1.AgentSpec{
 					DeploymentConfigSpec: agentv1alpha1.DeploymentConfigSpec{
 						Replicas: 1,
+						Type:     "Deployment",
 					},
 					ConfigSpec: agentv1alpha1.AgentConfigSpec{
 						CommonConfigSpec: common.CommonConfigSpec{
@@ -208,10 +209,6 @@ var _ = Describe("Agent Deployment", func() {
 													FieldPath:  "spec.nodeName",
 												},
 											},
-										},
-										{
-											Name:  "APERTURE_AGENT_SERVICE_DISCOVERY_KUBERNETES_ENABLED",
-											Value: "true",
 										},
 									},
 									EnvFrom:   []corev1.EnvFromSource{},
@@ -503,10 +500,6 @@ var _ = Describe("Agent Deployment", func() {
 													FieldPath:  "spec.nodeName",
 												},
 											},
-										},
-										{
-											Name:  "APERTURE_AGENT_SERVICE_DISCOVERY_KUBERNETES_ENABLED",
-											Value: "true",
 										},
 									},
 									EnvFrom: []corev1.EnvFromSource{

--- a/operator/controllers/agent/hook_test.go
+++ b/operator/controllers/agent/hook_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/fluxninja/aperture/v2/operator/controllers"
+	"github.com/fluxninja/aperture/v2/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/admission/v1"
@@ -60,7 +61,7 @@ var _ = Describe("Agent Hook Tests", Ordered, func() {
 			for _, patch := range res.Patches {
 				if patch.Operation == "add" && patch.Path == "/spec/config/fluxninja" {
 					changes := patch.Value.(map[string]interface{})
-					patchFound = changes["installation_mode"] == "KUBERNETES_DAEMONSET"
+					patchFound = changes["installation_mode"] == utils.InstallationModeKubernetesDaemonSet
 				}
 			}
 			Expect(patchFound).To(Equal(true))

--- a/operator/controllers/agent/reconciler_test.go
+++ b/operator/controllers/agent/reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	. "github.com/fluxninja/aperture/v2/operator/controllers"
+	"github.com/fluxninja/aperture/v2/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -245,7 +246,7 @@ var _ = Describe("Agent Reconcile", Ordered, func() {
 			Expect(instance.Finalizers).To(Equal([]string{FinalizerName}))
 			Expect(instance.Spec.Secrets.FluxNinjaExtension.Create).To(BeFalse())
 			Expect(instance.Spec.Secrets.FluxNinjaExtension.Value).To(Equal(""))
-			Expect(instance.Spec.ConfigSpec.FluxNinja.InstallationMode).To(Equal("KUBERNETES_DAEMONSET"))
+			Expect(instance.Spec.ConfigSpec.FluxNinja.InstallationMode).To(Equal(utils.InstallationModeKubernetesDaemonSet))
 
 			Expect(K8sClient.Delete(Ctx, ns)).To(Succeed())
 			Expect(K8sClient.Delete(Ctx, ns1)).To(Succeed())

--- a/operator/controllers/mutatingwebhook/agent_pod.go
+++ b/operator/controllers/mutatingwebhook/agent_pod.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/fluxninja/aperture/v2/operator/controllers"
+	"github.com/fluxninja/aperture/v2/pkg/utils"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -142,6 +143,10 @@ func agentPod(instance *v1alpha1.Agent, pod *corev1.Pod) error {
 	agentGroup := ""
 	if pod.Annotations != nil {
 		agentGroup = pod.Annotations[controllers.AgentGroupKey]
+	}
+
+	if agentGroup == utils.ApertureCloudAgentGroup {
+		return fmt.Errorf("'%s' is a reserved group name for FluxNinja Cloud Agents. Please use a different agent group name", utils.ApertureCloudAgentGroup)
 	}
 
 	container := corev1.Container{}

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -237,10 +237,12 @@ func AgentEnv(instance *agentv1alpha1.Agent, agentGroup string) []corev1.EnvVar 
 				},
 			},
 		})
-		envs = append(envs, corev1.EnvVar{
-			Name:  "APERTURE_AGENT_SERVICE_DISCOVERY_KUBERNETES_ENABLED",
-			Value: "true",
-		})
+		if spec.DeploymentConfigSpec.Type != "Deployment" {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "APERTURE_AGENT_SERVICE_DISCOVERY_KUBERNETES_ENABLED",
+				Value: "true",
+			})
+		}
 	}
 
 	if instance.Spec.Secrets.FluxNinjaExtension.Create || instance.Spec.Secrets.FluxNinjaExtension.SecretKeyRef.Name != "" {

--- a/pkg/agent-info/agent-info.go
+++ b/pkg/agent-info/agent-info.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fluxninja/aperture/v2/pkg/config"
 	"github.com/fluxninja/aperture/v2/pkg/utils"
+	"go.uber.org/fx"
 )
 
 const (
@@ -40,14 +41,22 @@ type AgentInfo struct {
 	agentGroup string
 }
 
+// AgentInfoIn holds parameters for ProvideAgentInfo.
+type AgentInfoIn struct {
+	fx.In
+
+	Unmarshaller           config.Unmarshaller
+	InstallationModeConfig *InstallationModeConfig `optional:"true"`
+}
+
 // ProvideAgentInfo provides the agent info via Fx.
-func ProvideAgentInfo(unmarshaller config.Unmarshaller, configOverride *InstallationModeConfig) (*AgentInfo, error) {
+func ProvideAgentInfo(in AgentInfoIn) (*AgentInfo, error) {
 	var config AgentInfoConfig
-	if err := unmarshaller.UnmarshalKey(configKey, &config); err != nil {
+	if err := in.Unmarshaller.UnmarshalKey(configKey, &config); err != nil {
 		return nil, err
 	}
 
-	if configOverride != nil && configOverride.InstallationMode != utils.InstallationModeCloudAgent && config.AgentGroup == utils.ApertureCloudAgentGroup {
+	if in.InstallationModeConfig != nil && in.InstallationModeConfig.InstallationMode != utils.InstallationModeCloudAgent && config.AgentGroup == utils.ApertureCloudAgentGroup {
 		return nil, fmt.Errorf("'%s' is a reserved group name for FluxNinja Cloud Agents. Please use a different agent group name", utils.ApertureCloudAgentGroup)
 	}
 

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -1,7 +1,20 @@
 package utils
 
-// Aperture service names.
 const (
-	ApertureAgent      = "aperture-agent"
+	// ApertureAgent is the service name for Agent.
+	ApertureAgent = "aperture-agent"
+	// ApertureController is the service name for Controller.
 	ApertureController = "aperture-controller"
+
+	// ApertureCloudAgentGroup agent group name for Cloud Agents.
+	ApertureCloudAgentGroup = "aperture-cloud"
+
+	// InstallationModeKubernetesSidecar for sidecar installation mode.
+	InstallationModeKubernetesSidecar = "KUBERNETES_SIDECAR"
+	// InstallationModeKubernetesDaemonSet for Kubernetes DaemonSet installation mode.
+	InstallationModeKubernetesDaemonSet = "KUBERNETES_DAEMONSET"
+	// InstallationModeLinuxBareMetal for bare metal installation mode.
+	InstallationModeLinuxBareMetal = "LINUX_BARE_METAL"
+	// InstallationModeCloudAgent for Cloud Agents.
+	InstallationModeCloudAgent = "CLOUD_AGENT"
 )

--- a/playground/tanka/apps/aperture-agent/mixins.libsonnet
+++ b/playground/tanka/apps/aperture-agent/mixins.libsonnet
@@ -25,7 +25,7 @@ local apertureAgentMixin =
         createUninstallHook: false,
         config+: {
           agent_info+: {
-            agent_group: if cloudController then agentGroup else 'default',
+            agent_group: 'aperture-cloud',
           },
           fluxninja+: {
             enable_cloud_controller: cloudController,

--- a/playground/tanka/apps/aperture-agent/mixins.libsonnet
+++ b/playground/tanka/apps/aperture-agent/mixins.libsonnet
@@ -25,7 +25,7 @@ local apertureAgentMixin =
         createUninstallHook: false,
         config+: {
           agent_info+: {
-            agent_group: 'aperture-cloud',
+            agent_group: if cloudController then agentGroup else 'default',
           },
           fluxninja+: {
             enable_cloud_controller: cloudController,


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced a new option, `CLOUD_AGENT`, for the `heartbeat_interval` and `heartbeat_mode` parameters, providing more flexibility for different deployment scenarios.
- Update: Changed the default agent group for the peer-to-peer cluster from "default" to "aperture-cloud".
- Update: Added validation checks to prevent the use of reserved group names and ensure appropriate configuration settings.
- New Feature: Added a new field `Type` to the `DeploymentConfigSpec` struct, allowing for more precise deployment configurations.
- Update: Improved code readability by replacing string literals with constants in several places.
- Documentation: Updated various documentation files to reflect the new changes and options.
  
These changes enhance the software's flexibility and usability, particularly in different deployment scenarios. They also improve code readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->