### PR TITLE
Docs: Replace installation with setup CLI section

### DIFF
--- a/.vscode/ltex.hiddenFalsePositives.en-US.txt
+++ b/.vscode/ltex.hiddenFalsePositives.en-US.txt
@@ -2,3 +2,4 @@
 {"rule":"MISSING_GENITIVE","sentence":"Prometheus metrics"}
 {"rule":"UPPERCASE_SENTENCE_START","sentence":"^\\Qkubectl\\E$"}
 {"rule":"AUTO_HYPHEN","sentence":"^\\QAuto Scale\\E$"}
+{"rule":"A_INSTALL","sentence":"^\\QBegin with aperturectl installation by heading over to the Install CLI section.\\E$"}

--- a/docs/content/concepts/classifier.md
+++ b/docs/content/concepts/classifier.md
@@ -306,6 +306,6 @@ rego:
   https://www.openpolicyagent.org/docs/latest/policy-reference/#reserved-names
 [control-point]: ./control-point.md
 [install-istio]: /integrations/istio/istio.md
-[aperturectl]: /get-started/installation/aperture-cli/aperture-cli.md
+[aperturectl]: /get-started/setup-cli/setup-cli.md
 [json-extractor]: /reference/configuration/spec.md#json-extractor
 [jwt-extractor]: /reference/configuration/spec.md#j-w-t-extractor

--- a/docs/content/get-started/aperture-cloud/personal-api-keys.md
+++ b/docs/content/get-started/aperture-cloud/personal-api-keys.md
@@ -30,5 +30,5 @@ You have [signed up][sign-up] on Aperture Cloud and created an organization.
 
 ![API Keys](./assets/personal-api-keys.gif "Creating Personal API Keys")
 
-[configure aperturectl]: /get-started/installation/configure-cli.md
+[configure aperturectl]: /get-started/setup-cli/setup-cli.md
 [sign-up]: /get-started/aperture-cloud/sign-up.md

--- a/docs/content/get-started/get-started.md
+++ b/docs/content/get-started/get-started.md
@@ -16,9 +16,7 @@ application.
 
 Aperture is accompanied by a tool called `aperturectl` that can be used to
 install [self-hosted Aperture](./self-hosting/self-hosting.md) in your
-Kubernetes cluster, generate a policy, apply a policy, list policies, etc. Begin
-with aperturectl installation by heading over to the
-[Install CLI](/get-started/setup-cli/install-cli.md) section.
+Kubernetes cluster, generate a policy, apply a policy, list policies, etc.
 
 ## [Set Up Your Application: Pick an integration](./set-up-application/set-up-application.md)
 

--- a/docs/content/get-started/get-started.md
+++ b/docs/content/get-started/get-started.md
@@ -12,20 +12,13 @@ you need to prepare your application to have Aperture integrated. Aperture can
 be integrated in multiple ways. You can choose the one that best suits your
 application.
 
-## [Install Aperture](./installation/installation.md)
+## [Set up CLI (aperturectl)](./setup-cli/setup-cli.md)
 
-1. [**`aperturectl`**](./installation/aperture-cli/aperture-cli.md)
-
-   Aperture is accompanied by a tool called `aperturectl` that can be used to
-   install Aperture in your Kubernetes cluster. Begin with Aperture installation
-   by heading over to the
-   [Installation](/get-started/installation/installation.md) section.
-
-2. Helm
-
-   Although there is a Helm chart available for installing Aperture, it is
-   recommended to use `aperturectl` as it provides an easier and less cumbersome
-   way to get started.
+Aperture is accompanied by a tool called `aperturectl` that can be used to
+install [self-hosted Aperture](./self-hosting/self-hosting.md) in your
+Kubernetes cluster, generate a policy, apply a policy, list policies, etc. Begin
+with aperturectl installation by heading over to the
+[Install CLI](/get-started/setup-cli/install-cli.md) section.
 
 ## [Set Up Your Application: Pick an integration](./set-up-application/set-up-application.md)
 

--- a/docs/content/get-started/policies/policies.md
+++ b/docs/content/get-started/policies/policies.md
@@ -128,8 +128,8 @@ the generated policies on the Aperture Cloud Controller.
 
 :::info
 
-See [aperturectl configuration](/get-started/installation/configure-cli.md) on
-how to configure what aperturectl should connect to.
+See [Set up CLI (aperturectl)](/get-started/setup-cli/setup-cli.md) for more
+information on how to configure what aperturectl should connect to.
 
 :::
 

--- a/docs/content/get-started/self-hosting/agent/kubernetes/namespace-scoped/namespace-scoped.md
+++ b/docs/content/get-started/self-hosting/agent/kubernetes/namespace-scoped/namespace-scoped.md
@@ -35,7 +35,7 @@ Install the tool of your choice using the following links:
       helm repo update
       ```
 
-2. [aperturectl](/get-started/installation/aperture-cli/aperture-cli.md)
+2. [aperturectl](/get-started/setup-cli/setup-cli.md)
 
    :::info Refer
 

--- a/docs/content/get-started/self-hosting/agent/kubernetes/operator/daemonset.md
+++ b/docs/content/get-started/self-hosting/agent/kubernetes/operator/daemonset.md
@@ -47,7 +47,7 @@ Install the tool of your choice using the following links:
       helm repo update
       ```
 
-2. [aperturectl](/get-started/installation/aperture-cli/aperture-cli.md)
+2. [aperturectl](/get-started/setup-cli/setup-cli.md)
 
    :::info Refer
 

--- a/docs/content/get-started/self-hosting/agent/kubernetes/operator/sidecar.md
+++ b/docs/content/get-started/self-hosting/agent/kubernetes/operator/sidecar.md
@@ -70,7 +70,7 @@ Install the tool of your choice using the following links:
       helm repo update
       ```
 
-2. [aperturectl](/get-started/installation/aperture-cli/aperture-cli.md)
+2. [aperturectl](/get-started/setup-cli/setup-cli.md)
 
    :::info Refer
 

--- a/docs/content/get-started/self-hosting/controller/kubernetes/kubernetes.md
+++ b/docs/content/get-started/self-hosting/controller/kubernetes/kubernetes.md
@@ -34,7 +34,7 @@ Install the tool of your choice using the following links:
       helm repo update
       ```
 
-2. [aperturectl](/get-started/installation/aperture-cli/aperture-cli.md)
+2. [aperturectl](/get-started/setup-cli/setup-cli.md)
 
    :::info Refer
 

--- a/docs/content/get-started/set-up-application/manual-control-points.md
+++ b/docs/content/get-started/set-up-application/manual-control-points.md
@@ -132,4 +132,4 @@ your needs. [See all SDKs](/integrations/sdk/sdk.md).
 <!-- vale on -->
 
 Once the feature control point is set in code, head over to
-[install Aperture](/get-started/installation/installation.md)
+[Set up CLI (aperturectl)](/get-started/setup-cli/setup-cli.md)

--- a/docs/content/get-started/set-up-application/middleware-insertions.md
+++ b/docs/content/get-started/set-up-application/middleware-insertions.md
@@ -92,5 +92,5 @@ examples available for each framework.
 
 <!-- vale on -->
 
-Once the middleware insertion is done, head over to
-[install Aperture](/get-started/installation/installation.md).
+Once the feature control point is set in code, head over to
+[Set up CLI (aperturectl)](/get-started/setup-cli/setup-cli.md)

--- a/docs/content/get-started/set-up-application/service-mesh-and-gateways.md
+++ b/docs/content/get-started/set-up-application/service-mesh-and-gateways.md
@@ -43,5 +43,5 @@ installation guide in
 
 <!-- vale on -->
 
-Once you complete the Service Mesh or API Gateway integration, head over to
-[install Aperture](/get-started/installation/installation.md).
+Once the feature control point is set in code, head over to
+[Set up CLI (aperturectl)](/get-started/setup-cli/setup-cli.md)

--- a/docs/content/get-started/setup-cli/configure-cli.md
+++ b/docs/content/get-started/setup-cli/configure-cli.md
@@ -1,8 +1,8 @@
 ---
-title: Configure CLI
+title: Configuration
 keywords:
   - cli
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 Configure aperturectl to point to your Aperture Cloud endpoint: Save the

--- a/docs/content/get-started/setup-cli/install-cli.md
+++ b/docs/content/get-started/setup-cli/install-cli.md
@@ -1,5 +1,5 @@
 ---
-title: Install CLI (aperturectl)
+title: Installation
 description: Aperture CLI for interacting with Aperture seamlessly.
 keywords:
   - cli
@@ -10,8 +10,8 @@ sidebar_position: 1
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import {apertureVersion, apertureVersionWithOutV} from '../../../apertureVersion.js';
-import {DownloadScript} from '../../self-hosting/agent/bare-metal.md';
+import {apertureVersion, apertureVersionWithOutV} from '../../apertureVersion.js';
+import {DownloadScript} from '../self-hosting/agent/bare-metal.md';
 ```
 
 ```mdx-code-block

--- a/docs/content/get-started/setup-cli/setup-cli.md
+++ b/docs/content/get-started/setup-cli/setup-cli.md
@@ -1,9 +1,11 @@
 ---
-title: Install Aperture
+title: Set up CLI
 keywords:
-  - install
+  - setup
+  - cli
+  - aperturectl
 sidebar_position: 1
-sidebar_label: Install Aperture
+sidebar_label: Set up CLI (aperturectl)
 ---
 
 Aperture Cloud has both the Aperture Controller and Aperture Agent

--- a/docs/content/guides/api-quota-management/openai.md
+++ b/docs/content/guides/api-quota-management/openai.md
@@ -60,8 +60,8 @@ Before you begin with this guide, verify the prerequisites are fulfilled.
 
 - Aperture is installed and running. If not, follow the
   [get started guide](../../get-started/get-started.md).
-- `aperturectl` is installed and configured. If not, follow the
-  [aperturectl installation guide](../../get-started/installation/aperture-cli/aperture-cli.md).
+- `aperturectl` is installed and configured. If not, head over to
+  [Set up CLI (aperturectl) guide](../../get-started/setup-cli/setup-cli.md).
 
 ## Configuration
 

--- a/docs/content/integrations/istio/istio.md
+++ b/docs/content/integrations/istio/istio.md
@@ -317,7 +317,7 @@ Install the tool of your choice using the following links:
       helm repo update
       ```
 
-2. [aperturectl](/get-started/installation/aperture-cli/aperture-cli.md)
+2. [aperturectl](/get-started/setup-cli/setup-cli.md)
 
    :::info Refer
 

--- a/docs/content/introduction.md
+++ b/docs/content/introduction.md
@@ -78,7 +78,7 @@ To sign-up to Aperture Cloud, [click here][sign-up].
 ## ✨ Get started {#get-started}
 
 - [**Setting up your application**](get-started/set-up-application/set-up-application.md)
-- [**Install Aperture**](get-started/installation/installation.md)
+- [**Set up CLI (aperturectl)**](get-started/setup-cli/setup-cli.md)
 - [**Your first policy**](get-started/policies/policies.md)
 - [**Guides**](guides/guides.md)
 

--- a/docs/content/reference/aperturectl/aperturectl.md
+++ b/docs/content/reference/aperturectl/aperturectl.md
@@ -10,7 +10,7 @@ keywords:
 
 :::info
 
-For installation instructions, see [installing aperturectl](/get-started/installation/aperture-cli/aperture-cli.md).
+For installation instructions, see [Set up CLI (aperturectl)](/get-started/setup-cli/setup-cli.md).
 
 :::
 

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -47,5 +47,5 @@ environment variable to switch between different projects and organizations.
 :::
 
 [toml]: https://toml.io/
-[configure-aperturectl]: /get-started/installation/configure-cli.md
+[configure-aperturectl]: /get-started/setup-cli/configure-cli.md
 [cloud-controller]: /reference/fluxninja.md#cloud-controller

--- a/docs/tools/aperturectl/generate-docs/generate-docs.go
+++ b/docs/tools/aperturectl/generate-docs/generate-docs.go
@@ -122,7 +122,7 @@ keywords:
 	if strings.HasSuffix(filename, "aperturectl.md") {
 		template += `:::info
 
-For installation instructions, see [installing aperturectl](/get-started/installation/aperture-cli/aperture-cli.md).
+For installation instructions, see [setup aperturectl](/get-started/setup-cli/setup-cli.md).
 
 :::
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Documentation:
- Revised the Aperture integration process, recommending the use of `aperturectl` for installation in a Kubernetes cluster instead of the Helm chart.
- Updated multiple documentation files to reflect the change from "Install Aperture" to "Set up CLI (aperturectl)".
- Modified hyperlinks across the documentation to direct users to the new "Set up CLI (aperturectl)" section.
- Updated instructions for setting up feature control points in the code and setting up the CLI (aperturectl).
- Improved organization and clarity by updating titles and sidebar positions of CLI setup-related documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->