### PR TITLE
blueprints --dir flag

### DIFF
--- a/cmd/aperturectl/cmd/cloud/blueprints/apply.go
+++ b/cmd/aperturectl/cmd/cloud/blueprints/apply.go
@@ -16,7 +16,7 @@ import (
 
 func init() {
 	BlueprintsApplyCmd.Flags().StringVar(&valuesFile, "values-file", "", "Values file to use for blueprint")
-	BlueprintsApplyCmd.Flags().StringVar(&dir, "dir", "", "Path to directory containing blueprint values files")
+	BlueprintsApplyCmd.Flags().StringVar(&valuesDir, "values-dir", "", "Path to directory containing blueprint values files")
 }
 
 // BlueprintsApplyCmd is the command to apply a blueprint from the Cloud Controller.
@@ -27,15 +27,15 @@ var BlueprintsApplyCmd = &cobra.Command{
 	SilenceErrors: true,
 	Example:       `aperturectl cloud blueprints apply --value-file=values.yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if valuesFile == "" && dir == "" {
+		if valuesFile == "" && valuesDir == "" {
 			return fmt.Errorf("either --values-file or --dir is required")
 		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Handle directory with multiple values files
-		if dir != "" {
-			err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if valuesDir != "" {
+			err := filepath.Walk(valuesDir, func(path string, info os.FileInfo, err error) error {
 				if !info.IsDir() {
 					if err := applyBlueprint(path); err != nil {
 						return err

--- a/cmd/aperturectl/cmd/cloud/blueprints/apply.go
+++ b/cmd/aperturectl/cmd/cloud/blueprints/apply.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -14,6 +16,7 @@ import (
 
 func init() {
 	BlueprintsApplyCmd.Flags().StringVar(&valuesFile, "values-file", "", "Values file to use for blueprint")
+	BlueprintsApplyCmd.Flags().StringVar(&dir, "dir", "", "Path to directory containing blueprint values files")
 }
 
 // BlueprintsApplyCmd is the command to apply a blueprint from the Cloud Controller.
@@ -24,62 +27,87 @@ var BlueprintsApplyCmd = &cobra.Command{
 	SilenceErrors: true,
 	Example:       `aperturectl cloud blueprints apply --value-file=values.yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if valuesFile == "" {
-			return fmt.Errorf("--values-file is required")
+		if valuesFile == "" && dir == "" {
+			return fmt.Errorf("either --values-file or --dir is required")
 		}
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		valuesMap, err := blueprints.Generate(valuesFile, "", "", "", false)
-		if err != nil {
-			return err
+		// Handle directory with multiple values files
+		if dir != "" {
+			err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+				if !info.IsDir() {
+					if err := applyBlueprint(path); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("failed to apply blueprints: %w", err)
+			}
+			return nil
 		}
 
-		policy, ok := valuesMap["policy"].(map[string]any)
-		if !ok {
-			return fmt.Errorf("policy not found in blueprint values")
-		}
-
-		policyName, ok := policy["policy_name"].(string)
-		if !ok {
-			return fmt.Errorf("policy_name not found in blueprint values")
-		}
-
-		blueprintName, ok := valuesMap["blueprint"].(string)
-		if !ok {
-			return fmt.Errorf("blueprint not found in blueprint values")
-		}
-
-		uri, ok := valuesMap["uri"].(string)
-		if !ok {
-			return fmt.Errorf("uri not found in blueprint values")
-		}
-
-		var version string
-		uriSlice := strings.Split(uri, "@")
-		if len(uriSlice) != 2 {
-			version = "latest"
-		} else {
-			version = uriSlice[1]
-		}
-
-		valuesFileContent, err := json.Marshal(valuesMap)
-		if err != nil {
-			return err
-		}
-
-		_, err = client.Apply(context.Background(), &cloudv1.ApplyRequest{
-			Blueprint: &cloudv1.Blueprint{
-				PolicyName:     policyName,
-				Version:        version,
-				Values:         valuesFileContent,
-				BlueprintsName: blueprintName,
-			},
-		})
-		if err != nil {
+		// Handle single values file
+		if err := applyBlueprint(valuesFile); err != nil {
 			return fmt.Errorf("failed to apply blueprint: %w", err)
 		}
 
 		return nil
 	},
+}
+
+func applyBlueprint(valuesFile string) error {
+	valuesMap, err := blueprints.Generate(valuesFile, "", "", "", false)
+	if err != nil {
+		return err
+	}
+
+	policy, ok := valuesMap["policy"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("policy not found in blueprint values")
+	}
+
+	policyName, ok := policy["policy_name"].(string)
+	if !ok {
+		return fmt.Errorf("policy_name not found in blueprint values")
+	}
+
+	blueprintName, ok := valuesMap["blueprint"].(string)
+	if !ok {
+		return fmt.Errorf("blueprint not found in blueprint values")
+	}
+
+	uri, ok := valuesMap["uri"].(string)
+	if !ok {
+		return fmt.Errorf("uri not found in blueprint values")
+	}
+
+	var version string
+	uriSlice := strings.Split(uri, "@")
+	if len(uriSlice) != 2 {
+		version = "latest"
+	} else {
+		version = uriSlice[1]
+	}
+
+	valuesFileContent, err := json.Marshal(valuesMap)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Apply(context.Background(), &cloudv1.ApplyRequest{
+		Blueprint: &cloudv1.Blueprint{
+			PolicyName:     policyName,
+			Version:        version,
+			Values:         valuesFileContent,
+			BlueprintsName: blueprintName,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to apply blueprint: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/aperturectl/cmd/cloud/blueprints/globals.go
+++ b/cmd/aperturectl/cmd/cloud/blueprints/globals.go
@@ -10,5 +10,5 @@ var (
 	client     utils.CloudBlueprintsClient
 
 	valuesFile string
-	dir        string
+	valuesDir  string
 )

--- a/cmd/aperturectl/cmd/cloud/blueprints/globals.go
+++ b/cmd/aperturectl/cmd/cloud/blueprints/globals.go
@@ -10,4 +10,5 @@ var (
 	client     utils.CloudBlueprintsClient
 
 	valuesFile string
+	dir        string
 )

--- a/docs/content/reference/aperturectl/cloud/blueprints/apply/apply.md
+++ b/docs/content/reference/aperturectl/cloud/blueprints/apply/apply.md
@@ -29,6 +29,7 @@ aperturectl cloud blueprints apply --value-file=values.yaml
 ### Options
 
 ```
+      --dir string           Path to directory containing blueprint values files
   -h, --help                 help for apply
       --values-file string   Values file to use for blueprint
 ```

--- a/docs/content/reference/aperturectl/cloud/blueprints/apply/apply.md
+++ b/docs/content/reference/aperturectl/cloud/blueprints/apply/apply.md
@@ -29,8 +29,8 @@ aperturectl cloud blueprints apply --value-file=values.yaml
 ### Options
 
 ```
-      --dir string           Path to directory containing blueprint values files
   -h, --help                 help for apply
+      --values-dir string    Path to directory containing blueprint values files
       --values-file string   Values file to use for blueprint
 ```
 


### PR DESCRIPTION
### Description of change

Add `--dir` flag to allow multiple blueprints to be applied

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Added a new `--dir` flag to the `BlueprintsApplyCmd` command, enabling users to apply multiple blueprint values files from a specified directory, enhancing the efficiency of blueprint application.

Documentation:
- Updated the `apply.md` documentation to include the new `--dir` option, providing clear guidance on its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->