### PR TITLE
Add link to Agent API Key creation from SDK docs

### DIFF
--- a/docs/content/get-started/aperture-cloud/agent-api-keys.md
+++ b/docs/content/get-started/aperture-cloud/agent-api-keys.md
@@ -11,8 +11,9 @@ import Zoom from 'react-medium-image-zoom';
 ```
 
 Aperture Cloud uses API keys to authenticate requests coming from
-[Agents][Agents] and [Controllers][Controllers]. You can create API keys for
-your project in the Aperture Cloud UI.
+[SDK integrations](/integrations/sdk/sdk.md), [self-hosted Agents][Agents] and
+[self-hosted Controllers][Controllers]. You can create API keys for your project
+in the Aperture Cloud UI.
 
 ## Pre-requisites
 
@@ -23,8 +24,8 @@ You have [signed up][sign-up] on Aperture Cloud and created a project.
 1. In the Aperture Cloud UI, navigate to your project. _API keys are
    project-specific. You need to create a new API key for each project._
 2. Now, from the left sidebar, click **Aperture**.
-3. Click **API Keys** tab.
-4. Click **Create API Key**.
+3. Click **Agent API Keys** tab.
+4. Click **Create new agent API key**.
 5. Copy the API key and save it in a secure location.
 
 ![API Keys](./assets/api-keys.gif "Creating API Keys for sudhanshu-demo-docs project")

--- a/docs/content/integrations/sdk/go/manual.md
+++ b/docs/content/integrations/sdk/go/manual.md
@@ -17,6 +17,14 @@ SDK</a> can be used to manually set feature control points within a Go service.
 
 To do so, first create an instance of ApertureClient:
 
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
+
 ```go
   agentAddress = "ORGANIZATION.app.fluxninja.com:443"
   agentAPIKey = "AGENT_API_KEY"

--- a/docs/content/integrations/sdk/java/armeria.md
+++ b/docs/content/integrations/sdk/java/armeria.md
@@ -16,12 +16,19 @@ keywords:
 All requests handled by an Armeria application can have Aperture SDK calls
 automatically added into them using [Aperture Instrumentation Agent][javaagent].
 
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
+
 ### Armeria Decorators
 
-<a
-href={`https://search.maven.org/artifact/com.fluxninja.aperture/aperture-java-armeria`}>Aperture
-Java SDK Armeria package</a> contains Armeria decorators that automatically set
-traffic control points for decorated services:
+[Aperture Java SDK Armeria package](https://search.maven.org/artifact/com.fluxninja.aperture/aperture-java-armeria)
+contains Armeria decorators that automatically set traffic control points for
+decorated services:
 
 ```java
     public static HttpService createHelloHTTPService() {

--- a/docs/content/integrations/sdk/java/auto-instrumentation.md
+++ b/docs/content/integrations/sdk/java/auto-instrumentation.md
@@ -29,6 +29,14 @@ found [here][aperture-javaagent].
 
 :::
 
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
+
 ## Running the java agent
 
 To statically load the java agent when running some application `.jar`, use the

--- a/docs/content/integrations/sdk/java/manual.md
+++ b/docs/content/integrations/sdk/java/manual.md
@@ -16,12 +16,18 @@ description:
   guide covers best practices and provides examples for implementation.
 ---
 
-<a
-href={`https://search.maven.org/artifact/com.fluxninja.aperture/aperture-java-core`}>Aperture
-Java SDK core library</a> can be used to manually set feature control points
-within a Java service.
+[Aperture Java SDK core library](https://search.maven.org/artifact/com.fluxninja.aperture/aperture-java-core)
+can be used to manually set feature control points within a Java service.
 
 To do so, first create an instance of ApertureSDK:
+
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
 
 ```java
     String agentAddress = "ORGANIZATION.app.fluxninja.com:443";

--- a/docs/content/integrations/sdk/java/netty.md
+++ b/docs/content/integrations/sdk/java/netty.md
@@ -16,12 +16,19 @@ keywords:
 All Netty pipelines can have an Aperture Handler automatically added into them
 using [Aperture Instrumentation Agent][javaagent].
 
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
+
 ### Netty Handler
 
-<a
-href={`https://search.maven.org/artifact/com.fluxninja.aperture/aperture-java-netty`}>Aperture
-Java SDK Netty package</a> contains a Handler that automatically creates traffic
-flows for requests in a given pipeline:
+[Aperture Java SDK Netty package](https://search.maven.org/artifact/com.fluxninja.aperture/aperture-java-netty)
+contains a Handler that automatically creates traffic flows for requests in a
+given pipeline:
 
 ```java
 import com.fluxninja.aperture.netty.ApertureServerHandler;

--- a/docs/content/integrations/sdk/java/springboot.md
+++ b/docs/content/integrations/sdk/java/springboot.md
@@ -18,6 +18,14 @@ keywords:
 contains Aperture Filter that can be registered in Spring Boot application to
 automatically set traffic control points for relevant services:
 
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
+
 ```java
 
 import com.fluxninja.aperture.servlet.jakarta.ApertureFilter;

--- a/docs/content/integrations/sdk/java/tomcat.md
+++ b/docs/content/integrations/sdk/java/tomcat.md
@@ -17,6 +17,14 @@ keywords:
 contains Aperture Filter that can be added to the web.xml file to automatically
 set traffic control points for relevant services:
 
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
+
 ```xml
     <filter>
         <filter-name>ApertureFilter</filter-name>

--- a/docs/content/integrations/sdk/javascript/manual.md
+++ b/docs/content/integrations/sdk/javascript/manual.md
@@ -12,13 +12,18 @@ keywords:
   - manual
 ---
 
-<a href={`https://www.npmjs.com/package/@fluxninja/aperture-js`}>Aperture
-JavaScript SDK</a> can be used to manually set feature control points within a
-JavaScript service.
+[Aperture JavaScript SDK](https://www.npmjs.com/package/@fluxninja/aperture-js)
+can be used to manually set feature control points within a JavaScript service.
 
-To do so, first create an instance of ApertureClient. Agent host and port will
-be read from environment variables `APERTURE_AGENT_HOST` and
-`APERTURE_AGENT_PORT`, defaulting to localhost:8089.
+To do so, first create an instance of ApertureClient:
+
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
 
 ```javascript
 export const apertureClient = new ApertureClient({

--- a/docs/content/integrations/sdk/python/manual.md
+++ b/docs/content/integrations/sdk/python/manual.md
@@ -13,9 +13,17 @@ keywords:
 ---
 
 [Aperture Python SDK][pythonsdk] can be used to manually set feature control
-points within a Go service.
+points within a Python service.
 
 To do so, first create an instance of ApertureClient:
+
+:::info Agent API Key
+
+You can create an Agent API key for your project in the Aperture Cloud UI. For
+more information, refer to
+[Agent API Keys](/get-started/aperture-cloud/agent-api-keys.md).
+
+:::
 
 ```python
   from aperture_sdk import ApertureClient


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Documentation:
- Updated instructions for creating API keys in Aperture Cloud, reflecting changes in the UI.
- Added information and links about creating an Agent API key across various SDK documentation (Go, Java, JavaScript, Python), enhancing user understanding and ease of use.
- Updated links to SDK packages and provided examples of usage in Java and JavaScript documentation.
- Corrected language-specific text in Python SDK documentation for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->