### PR TITLE
Add promql query used in the adaptive load scheduling blueprint docs

### DIFF
--- a/docs/content/reference/blueprints/load-scheduling/average-latency.md
+++ b/docs/content/reference/blueprints/load-scheduling/average-latency.md
@@ -34,6 +34,13 @@ At a high level, this policy works as follows:
   decreases) the token bucket fill rates based on the incoming token rate
   observed at each agent.
 
+The following PromQL query (with appropriate filters) is used as `SIGNAL` for
+the load scheduler:
+
+```promql
+sum(increase(flux_meter_sum))/sum(increase(flux_meter_count))
+```
+
 :::info
 
 See reference for the

--- a/docs/content/reference/blueprints/load-scheduling/elasticsearch.md
+++ b/docs/content/reference/blueprints/load-scheduling/elasticsearch.md
@@ -18,7 +18,12 @@ All the Elasticsearch related metrics are collected by the
 so if the system under observation requires using different metrics for the
 overload confirmation, the
 [list of available metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/elasticsearchreceiver/metadata.yaml)
-can be used to configure the policy.
+can be used to configure the policy. The following PromQL query (with
+appropriate filters) is used as `SIGNAL` for the load scheduler:
+
+```promql
+avg(elasticsearch_node_thread_pool_tasks_queued)
+```
 
 <!-- Configuration Marker -->
 

--- a/docs/content/reference/blueprints/load-scheduling/java-gc-generic.md
+++ b/docs/content/reference/blueprints/load-scheduling/java-gc-generic.md
@@ -6,6 +6,13 @@ sidebar_position: 3
 sidebar_label: Load Scheduling based on Java garbage collection times
 ---
 
+The following PromQL query (with appropriate filters) is used as `SIGNAL` for
+the load scheduler:
+
+```promql
+avg(java_lang_G1_Young_Generation_LastGcInfo_duration)
+```
+
 <!-- Configuration Marker -->
 
 ```mdx-code-block

--- a/docs/content/reference/blueprints/load-scheduling/java-gc-k8s.md
+++ b/docs/content/reference/blueprints/load-scheduling/java-gc-k8s.md
@@ -7,6 +7,13 @@ sidebar_label:
   Load Scheduling based on Java garbage collection times (Kubernetes)
 ---
 
+The following PromQL query (with appropriate filters) is used as `SIGNAL` for
+the load scheduler:
+
+```promql
+avg(java_lang_G1_Young_Generation_LastGcInfo_duration)
+```
+
 <!-- Configuration Marker -->
 
 ```mdx-code-block

--- a/docs/content/reference/blueprints/load-scheduling/postgresql.md
+++ b/docs/content/reference/blueprints/load-scheduling/postgresql.md
@@ -22,7 +22,12 @@ can be used to configure the policy.
 An AIAD controller calculates a proportional response to limit the accepted
 token rate. The token rate is reduced by an additive factor when the service is
 overloaded, and increased by an additive factor while the service is no longer
-overloaded.
+overloaded. The following PromQL query (with appropriate filters) is used as
+`SIGNAL` for the load scheduler:
+
+```promql
+(sum(postgresql_backends) / sum(postgresql_connection_max)) * 100
+```
 
 :::info
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Documentation:
- Added a new PromQL query to the load scheduler documentation, which calculates the ratio of the sum of the increase in `flux_meter_sum` to the sum of the increase in `flux_meter_count`. This will help in adjusting the token bucket fill rates based on the incoming token rate observed at each agent.
- Updated the Elasticsearch receiver documentation with a PromQL query that calculates the average value of the `elasticsearch_node_thread_pool_tasks_queued` metric.
- Enhanced the load scheduling documentation for Java garbage collection times with a PromQL query that calculates the average duration of the `java_lang_G1_Young_Generation_LastGcInfo_duration` metric.
- Introduced a new PromQL query in the AIAD controller documentation for load scheduling in PostgreSQL. This query calculates the percentage of PostgreSQL backends in use compared to the maximum allowed connections, aiding in adjusting the token rate in the load scheduler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->