### PR TITLE
Add nil check for InstallationModeConfig

### DIFF
--- a/pkg/secretmanager/provide.go
+++ b/pkg/secretmanager/provide.go
@@ -37,7 +37,7 @@ type SecretManagerClient struct {
 }
 
 func provideSecretManagerClient(in SecretManagerClientIn) (*SecretManagerClient, error) {
-	if in.InstallationModeConfig.InstallationMode != utils.InstallationModeCloudAgent {
+	if in.InstallationModeConfig == nil || in.InstallationModeConfig.InstallationMode != utils.InstallationModeCloudAgent {
 		return nil, nil
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the secret manager client to prevent crashes when the Installation Mode Configuration is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->