### PR TITLE
Update aperturectl config docs

### DIFF
--- a/docs/content/reference/aperture-cli/configure-cli.md
+++ b/docs/content/reference/aperture-cli/configure-cli.md
@@ -10,7 +10,7 @@ following as `~/.aperturectl/config`:
 
 ```toml
 [controller]
-url = "ORGANIZATION_NAME.app.fluxninja.com"
+url = "ORGANIZATION_NAME.app.fluxninja.com:443"
 project_name = "PROJECT_NAME"
 api_key = "PERSONAL_API_KEY"
 ```

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -9,7 +9,7 @@ it from corresponding go structs from cmd/aperturectl/cmd/utils/controller.go --
 
 ## Location
 
-To avoid specifying `--controller` and `--api-key` in every `aperturectl`
+To avoid specifying `--controller`, `--api-key` and `--project-name` in every `aperturectl`
 invocation, aperturectl can use a configuration file located in
 `~/.aperturectl/config`.
 
@@ -18,8 +18,8 @@ variable and `--config` option (with the command-line option having higher
 precedence).
 
 When any explicit flag related to controller location (e.g., `--kube`,
-`--controller`, or `--api-key`) is used, the _entire_ configuration file is
-ignored.
+`--controller`, `--api-key` or `--project-name`) is used, the value from the
+configuration file are ignored for the flag.
 
 If the configuration file is not specified nor present at the default location,
 aperturectl will try to find the controller at the local Kubernetes cluster (as
@@ -31,9 +31,15 @@ The aperturectl configuration file uses the following [TOML][toml] syntax:
 
 ```toml
 [controller]
-url = "controller hostname:port"
-api_key = "api key for the controller"
+url = "ORGANIZATION_NAME.app.fluxninja.com:443"
+project_name = "PROJECT_NAME"
+api_key = "PERSONAL_API_KEY"
 ```
+
+Replace `ORGANIZATION_NAME` with the Aperture Cloud organization name and
+`PERSONAL_API_KEY` with the Personal API key linked to the user. If a Personal
+API key has not been created, generate a new one through the Aperture Cloud UI.
+Refer to [Personal API Keys][api-keys] for additional information.
 
 All the fields are required (although the file itself is not). See [Configuring
 aperturectl][configure-aperturectl] for an example on how to configure
@@ -49,3 +55,4 @@ environment variable to switch between different projects and organizations.
 [toml]: https://toml.io/
 [configure-aperturectl]: /reference/aperture-cli/configure-cli.md
 [cloud-controller]: /reference/fluxninja.md#cloud-controller
+[api-keys]: /reference/aperture-cli/personal-api-keys.md

--- a/docs/content/reference/configuration/aperturectl.md
+++ b/docs/content/reference/configuration/aperturectl.md
@@ -19,7 +19,7 @@ precedence).
 
 When any explicit flag related to controller location (e.g., `--kube`,
 `--controller`, `--api-key` or `--project-name`) is used, the value from the
-configuration file are ignored for the flag.
+configuration file is ignored for the flag.
 
 If the configuration file is not specified nor present at the default location,
 aperturectl will try to find the controller at the local Kubernetes cluster (as


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the URL in the configuration file to use HTTPS protocol on port 443.
	- Added a new `project_name` field to the configuration file and instructions on how to use it.
	- Introduced an explicit `--project-name` flag to override the configuration file value.
	- Updated the example configuration file with placeholders for organization name, project name, and personal API key.
	- Provided references to additional documentation for configuring `aperturectl` and generating personal API keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->