### PR TITLE
aperture_js: provide default credentials

### DIFF
--- a/sdks/aperture-js/package-lock.json
+++ b/sdks/aperture-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluxninja/aperture-js",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.5",

--- a/sdks/aperture-js/package.json
+++ b/sdks/aperture-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluxninja/aperture-js",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Flow control SDK that interfaces with FluxNinja Aperture Agents",
   "main": "./lib/index.js",
   "scripts": {

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -37,11 +37,11 @@ export class ApertureClient {
   constructor({
     address,
     agentAPIKey,
-    channelCredentials,
+    channelCredentials = grpc.credentials.createSsl(),
     channelOptions = {},
   }: {
     address: string;
-    channelCredentials: ChannelCredentials;
+    channelCredentials?: ChannelCredentials;
     channelOptions?: ChannelOptions;
     agentAPIKey?: string;
   }) {

--- a/sdks/aperture-js/sdk/consts.ts
+++ b/sdks/aperture-js/sdk/consts.ts
@@ -9,7 +9,7 @@ export const PROTO_PATH = path.resolve(
 );
 
 export const LIBRARY_NAME = "@fluxninjutsu/aperture-js";
-export const LIBRARY_VERSION = "2.23.1";
+export const LIBRARY_VERSION = "2.3.2";
 
 // Label to hold source of flow.
 export const SOURCE_LABEL = "aperture.source";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `ApertureClient` now supports optional channel credentials, defaulting to secure SSL if not provided.

- **Documentation**
  - Updated the `LIBRARY_VERSION` to reflect the new release version "2.3.2".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->