### PR TITLE
Update Agent API key creation instructions in Dot Net SDK doc

### DIFF
--- a/docs/content/sdk/dotnet/manual.md
+++ b/docs/content/sdk/dotnet/manual.md
@@ -22,10 +22,10 @@ To do so, first create an instance of ApertureClient:
 
 :::info Agent API Key
 
-You can create an Agent API key for your project in the Aperture Cloud UI for
+You can create an Agent API key for your project in the Aperture Cloud UI for a
 given organization by navigating to the **`Aperture`** tab in the sidebar menu.
-From there, select **`Agent API Keys`** in the top bar. This is where you can
-find and copy the **`AGENT_API_KEY`** or create a new key.
+From there, select the **`Agent API Keys`** in the top bar. This is where you
+can find and copy the **`AGENT_API_KEY`** or create a new key.
 
 :::
 

--- a/docs/content/sdk/dotnet/manual.md
+++ b/docs/content/sdk/dotnet/manual.md
@@ -24,8 +24,8 @@ To do so, first create an instance of ApertureClient:
 
 You can create an Agent API key for your project in the Aperture Cloud UI for a
 given organization by navigating to the **`Aperture`** tab in the sidebar menu.
-From there, select the **`Agent API Keys`** in the top bar. This is where you
-can find and copy the **`AGENT_API_KEY`** or create a new key.
+From there, select **`Agent API Keys`** in the top bar. This is where you can
+find and copy the **`AGENT_API_KEY`** or create a new key.
 
 :::
 

--- a/docs/content/sdk/dotnet/manual.md
+++ b/docs/content/sdk/dotnet/manual.md
@@ -22,9 +22,10 @@ To do so, first create an instance of ApertureClient:
 
 :::info Agent API Key
 
-You can create an Agent API key for your project in the Aperture Cloud UI. For
-more information, refer to
-[Define Control Points](/get-started/define-control-points.md).
+You can create an Agent API key for your project in the Aperture Cloud UI for
+given organization by navigating to the **`Aperture`** tab in the sidebar menu.
+From there, select **`Agent API Keys`** in the top bar. This is where you can
+find and copy the **`AGENT_API_KEY`** or create a new key.
 
 :::
 


### PR DESCRIPTION
manual.md

### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the manual with new instructions for creating and accessing Agent API keys in the Aperture Cloud UI.
	- Clarified the navigation process to the **`Aperture`** tab and the **`Agent API Keys`** section.
	- Removed outdated reference to "Define Control Points" and provided current steps to obtain the **`AGENT_API_KEY`**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->