### PR TITLE
Add default value for rate limiter limit_by_label_key in config files

### DIFF
--- a/blueprints/quota-scheduling/base/config.libsonnet
+++ b/blueprints/quota-scheduling/base/config.libsonnet
@@ -15,7 +15,7 @@ commonConfig {
       fill_amount: '__REQUIRED_FIELD__',
       selectors: commonConfig.selectors_defaults,
       rate_limiter: {
-        limit_by_label_key: '',
+        limit_by_label_key: 'limit_key',
         interval: '__REQUIRED_FIELD__',
       },
       scheduler: {

--- a/blueprints/quota-scheduling/base/gen/definitions.json
+++ b/blueprints/quota-scheduling/base/gen/definitions.json
@@ -79,7 +79,7 @@
               "description": "Rate Limiter Parameters.",
               "default": {
                 "interval": "__REQUIRED_FIELD__",
-                "limit_by_label_key": ""
+                "limit_by_label_key": "limit_key"
               },
               "type": "object",
               "$ref": "../../../gen/jsonschema/_definitions.json#/definitions/RateLimiterParameters"

--- a/blueprints/quota-scheduling/base/gen/values.yaml
+++ b/blueprints/quota-scheduling/base/gen/values.yaml
@@ -34,7 +34,7 @@ policy:
     # Required: True
     rate_limiter:
       interval: __REQUIRED_FIELD__
-      limit_by_label_key: ""
+      limit_by_label_key: "limit_key"
     # Scheduler configuration.
     # Type: aperture.spec.v1.Scheduler
     scheduler:

--- a/blueprints/rate-limiting/base/config.libsonnet
+++ b/blueprints/rate-limiting/base/config.libsonnet
@@ -15,7 +15,7 @@ commonConfig {
       fill_amount: '__REQUIRED_FIELD__',
       selectors: commonConfig.selectors_defaults,
       parameters: {
-        limit_by_label_key: '',
+        limit_by_label_key: 'limit_key',
         interval: '__REQUIRED_FIELD__',
       },
       request_parameters: {},

--- a/blueprints/rate-limiting/base/gen/definitions.json
+++ b/blueprints/rate-limiting/base/gen/definitions.json
@@ -79,7 +79,7 @@
               "description": "Parameters.",
               "default": {
                 "interval": "__REQUIRED_FIELD__",
-                "limit_by_label_key": ""
+                "limit_by_label_key": "limit_key"
               },
               "type": "object",
               "$ref": "../../../gen/jsonschema/_definitions.json#/definitions/RateLimiterParameters"

--- a/blueprints/rate-limiting/base/gen/values.yaml
+++ b/blueprints/rate-limiting/base/gen/values.yaml
@@ -34,7 +34,7 @@ policy:
     # Required: True
     parameters:
       interval: __REQUIRED_FIELD__
-      limit_by_label_key: ""
+      limit_by_label_key: "limit_key"
     # Request Parameters.
     # Type: aperture.spec.v1.RateLimiterRequestParameters
     request_parameters: {}

--- a/docs/content/reference/aperture-cli/policies/assets/raw_values.yaml
+++ b/docs/content/reference/aperture-cli/policies/assets/raw_values.yaml
@@ -34,7 +34,7 @@ policy:
     # Required: True
     parameters:
       interval: __REQUIRED_FIELD__
-      limit_by_label_key: ""
+      limit_by_label_key: "limit_key"
     # Request Parameters.
     # Type: aperture.spec.v1.RateLimiterRequestParameters
     request_parameters: {}

--- a/docs/content/reference/blueprints/quota-scheduling/base.md
+++ b/docs/content/reference/blueprints/quota-scheduling/base.md
@@ -135,7 +135,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/quota-sched
     description='Rate Limiter Parameters.'
     type='Object (aperture.spec.v1.RateLimiterParameters)'
     reference='../../configuration/spec#rate-limiter-parameters'
-    value='{"interval": "__REQUIRED_FIELD__", "limit_by_label_key": ""}'
+    value='{"interval": "__REQUIRED_FIELD__", "limit_by_label_key": "limit_key"}'
 />
 
 <!-- vale on -->

--- a/docs/content/reference/blueprints/rate-limiting/base.md
+++ b/docs/content/reference/blueprints/rate-limiting/base.md
@@ -135,7 +135,7 @@ href={`https://github.com/fluxninja/aperture/tree/${aver}/blueprints/rate-limiti
     description='Parameters.'
     type='Object (aperture.spec.v1.RateLimiterParameters)'
     reference='../../configuration/spec#rate-limiter-parameters'
-    value='{"interval": "__REQUIRED_FIELD__", "limit_by_label_key": ""}'
+    value='{"interval": "__REQUIRED_FIELD__", "limit_by_label_key": "limit_key"}'
 />
 
 <!-- vale on -->


### PR DESCRIPTION
### Description of change

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the rate limiter configuration to use 'limit_key' as the default value for `limit_by_label_key`.

- **Documentation**
  - Revised documentation to reflect the new default `limit_by_label_key` value in rate limiting and quota scheduling blueprints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->