### PR TITLE
Fix pod labels and annotations reconciliation in operator

### DIFF
--- a/operator/controllers/agent/daemonset.go
+++ b/operator/controllers/agent/daemonset.go
@@ -170,8 +170,8 @@ func daemonsetForAgent(instance *agentv1alpha1.Agent, log logr.Logger, scheme *r
 func daemonsetMutate(dms *appsv1.DaemonSet, spec appsv1.DaemonSetSpec) controllerutil.MutateFn {
 	return func() error {
 		dms.Spec.Selector = spec.Selector
-		dms.Spec.Template.Annotations = spec.Template.Annotations
-		dms.Spec.Template.Labels = spec.Template.Labels
+		dms.Spec.Template.Annotations = controllers.SyncMaps(spec.Template.Annotations, dms.Spec.Template.Annotations)
+		dms.Spec.Template.Labels = controllers.SyncMaps(spec.Template.Labels, dms.Spec.Template.Labels)
 		dms.Spec.Template.Spec.ServiceAccountName = spec.Template.Spec.ServiceAccountName
 		dms.Spec.Template.Spec.ImagePullSecrets = spec.Template.Spec.ImagePullSecrets
 		dms.Spec.Template.Spec.NodeSelector = spec.Template.Spec.NodeSelector

--- a/operator/controllers/agent/daemonset_test.go
+++ b/operator/controllers/agent/daemonset_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package agent
 
 import (
+	"fmt"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -664,6 +666,10 @@ var _ = Describe("Test DaemonSet Mutate", func() {
 		err := daemonsetMutate(dms, expected.Spec)()
 
 		Expect(err).NotTo(HaveOccurred())
+		fmt.Println(dms.Spec.Template.Annotations)
+		fmt.Println(expected.Spec.Template.Annotations)
+		fmt.Println(dms.Spec.Template.Labels)
+		fmt.Println(expected.Spec.Template.Labels)
 		Expect(dms).To(Equal(expected))
 	})
 })

--- a/operator/controllers/agent/daemonset_test.go
+++ b/operator/controllers/agent/daemonset_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package agent
 
 import (
-	"fmt"
-
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -666,10 +664,6 @@ var _ = Describe("Test DaemonSet Mutate", func() {
 		err := daemonsetMutate(dms, expected.Spec)()
 
 		Expect(err).NotTo(HaveOccurred())
-		fmt.Println(dms.Spec.Template.Annotations)
-		fmt.Println(expected.Spec.Template.Annotations)
-		fmt.Println(dms.Spec.Template.Labels)
-		fmt.Println(expected.Spec.Template.Labels)
 		Expect(dms).To(Equal(expected))
 	})
 })

--- a/operator/controllers/agent/deployment.go
+++ b/operator/controllers/agent/deployment.go
@@ -174,8 +174,8 @@ func deploymentMutate(dep *appsv1.Deployment, spec appsv1.DeploymentSpec) contro
 	return func() error {
 		dep.Spec.Selector = spec.Selector
 		dep.Spec.Strategy = spec.Strategy
-		dep.Spec.Template.Annotations = spec.Template.Annotations
-		dep.Spec.Template.Labels = spec.Template.Labels
+		dep.Spec.Template.Annotations = controllers.SyncMaps(spec.Template.Annotations, dep.Spec.Template.Annotations)
+		dep.Spec.Template.Labels = controllers.SyncMaps(spec.Template.Labels, dep.Spec.Template.Labels)
 		dep.Spec.Template.Spec.ServiceAccountName = spec.Template.Spec.ServiceAccountName
 		dep.Spec.Template.Spec.HostAliases = spec.Template.Spec.HostAliases
 		dep.Spec.Template.Spec.ImagePullSecrets = spec.Template.Spec.ImagePullSecrets

--- a/operator/controllers/controller/deployment.go
+++ b/operator/controllers/controller/deployment.go
@@ -162,8 +162,8 @@ func deploymentMutate(dep *appsv1.Deployment, spec appsv1.DeploymentSpec) contro
 	return func() error {
 		dep.Spec.Selector = spec.Selector
 		dep.Spec.Strategy = spec.Strategy
-		dep.Spec.Template.Annotations = spec.Template.Annotations
-		dep.Spec.Template.Labels = spec.Template.Labels
+		dep.Spec.Template.Annotations = controllers.SyncMaps(spec.Template.Annotations, dep.Spec.Template.Annotations)
+		dep.Spec.Template.Labels = controllers.SyncMaps(spec.Template.Labels, dep.Spec.Template.Labels)
 		dep.Spec.Template.Spec.ServiceAccountName = spec.Template.Spec.ServiceAccountName
 		dep.Spec.Template.Spec.HostAliases = spec.Template.Spec.HostAliases
 		dep.Spec.Template.Spec.ImagePullSecrets = spec.Template.Spec.ImagePullSecrets

--- a/operator/controllers/utils.go
+++ b/operator/controllers/utils.go
@@ -1046,3 +1046,16 @@ func localControllerNamespaceFromEndpoint(endpoint string) string {
 
 	return subdomains[1]
 }
+
+// SyncMaps syncs the dst map with the src map.
+func SyncMaps(src, dst map[string]string) map[string]string {
+	if dst == nil && src != nil {
+		dst = map[string]string{}
+	}
+
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Kubernetes controller to retain existing annotations and labels during updates, ensuring custom configurations are preserved.

- **Bug Fixes**
  - Fixed an issue where annotations and labels could be unintentionally removed during synchronization.

- **Refactor**
  - Implemented a new `SyncMaps` utility function to improve the handling of Kubernetes object metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->