### PR TITLE
Fix validator in label matcher operator

### DIFF
--- a/api/aperture/policy/language/v1/label_matcher.proto
+++ b/api/aperture/policy/language/v1/label_matcher.proto
@@ -23,7 +23,7 @@ message LabelMatcher {
   // List of Kubernetes-style label matcher requirements.
   //
   // Note: The requirements are combined using the logical AND operator.
-  repeated K8sLabelMatcherRequirement match_expressions = 2;
+  repeated K8sLabelMatcherRequirement match_expressions = 2; // @gotags: validate:"dive"
 
   // An arbitrary expression to be evaluated on the labels.
   MatchExpression expression = 3;
@@ -36,7 +36,7 @@ message K8sLabelMatcherRequirement {
 
   // Logical operator which represents a key's relationship to a set of values.
   // Valid operators are In, NotIn, Exists and DoesNotExist.
-  string operator = 2; // @gotags: validate:"oneof=In NotIn Exists DoesNotExist"
+  string operator = 2; // @gotags: validate:"required,oneof=In NotIn Exists DoesNotExist"
 
   // An array of string values that relates to the key by an operator.
   // If the operator is In or NotIn, the values array must be non-empty.

--- a/api/aperture/policy/language/v1/label_matcher.proto
+++ b/api/aperture/policy/language/v1/label_matcher.proto
@@ -36,7 +36,7 @@ message K8sLabelMatcherRequirement {
 
   // Logical operator which represents a key's relationship to a set of values.
   // Valid operators are In, NotIn, Exists and DoesNotExist.
-  string operator = 2; // @gotags: validate:"oneof=In NotIn Exists DoesNotExists"
+  string operator = 2; // @gotags: validate:"oneof=In NotIn Exists DoesNotExist"
 
   // An array of string values that relates to the key by an operator.
   // If the operator is In or NotIn, the values array must be non-empty.

--- a/api/buf.lock
+++ b/api/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: envoy
-    commit: b5857e315ad24102aa6ca2bd153d042d
-    digest: shake256:3e3c6123dbc1ff6e7f635a5f6d9d245358801e9f89935818f095ddc716c27b99dbe1e37169d590a3e9accb568f1bc2c3babe1522012cd8d03f09dc44710fcfca
+    commit: dbbad6a3b91241d4866cb7977bded76f
+    digest: shake256:690b1eb1d34c88db50ed16219c45bd4b38210cafa86641b1355b98c066c7ae6d95ab333e787151dd4d9fe3157e473b56dc91ba0f1aaae3bd2cb46ee0674b9f30
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate

--- a/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
@@ -44,7 +44,7 @@ type LabelMatcher struct {
 	// List of Kubernetes-style label matcher requirements.
 	//
 	// Note: The requirements are combined using the logical AND operator.
-	MatchExpressions []*K8SLabelMatcherRequirement `protobuf:"bytes,2,rep,name=match_expressions,json=matchExpressions,proto3" json:"match_expressions,omitempty"`
+	MatchExpressions []*K8SLabelMatcherRequirement `protobuf:"bytes,2,rep,name=match_expressions,json=matchExpressions,proto3" json:"match_expressions,omitempty" validate:"dive"` // @gotags: validate:"dive"
 	// An arbitrary expression to be evaluated on the labels.
 	Expression *MatchExpression `protobuf:"bytes,3,opt,name=expression,proto3" json:"expression,omitempty"`
 }
@@ -112,7 +112,7 @@ type K8SLabelMatcherRequirement struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty" validate:"required"` // @gotags: validate:"required"
 	// Logical operator which represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists and DoesNotExist.
-	Operator string `protobuf:"bytes,2,opt,name=operator,proto3" json:"operator,omitempty" validate:"oneof=In NotIn Exists DoesNotExist"` // @gotags: validate:"oneof=In NotIn Exists DoesNotExist"
+	Operator string `protobuf:"bytes,2,opt,name=operator,proto3" json:"operator,omitempty" validate:"required,oneof=In NotIn Exists DoesNotExist"` // @gotags: validate:"required,oneof=In NotIn Exists DoesNotExist"
 	// An array of string values that relates to the key by an operator.
 	// If the operator is In or NotIn, the values array must be non-empty.
 	// If the operator is Exists or DoesNotExist, the values array must be empty.

--- a/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
@@ -112,7 +112,7 @@ type K8SLabelMatcherRequirement struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty" validate:"required"` // @gotags: validate:"required"
 	// Logical operator which represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists and DoesNotExist.
-	Operator string `protobuf:"bytes,2,opt,name=operator,proto3" json:"operator,omitempty" validate:"oneof=In NotIn Exists DoesNotExists"` // @gotags: validate:"oneof=In NotIn Exists DoesNotExists"
+	Operator string `protobuf:"bytes,2,opt,name=operator,proto3" json:"operator,omitempty" validate:"oneof=In NotIn Exists DoesNotExist"` // @gotags: validate:"oneof=In NotIn Exists DoesNotExist"
 	// An array of string values that relates to the key by an operator.
 	// If the operator is In or NotIn, the values array must be non-empty.
 	// If the operator is Exists or DoesNotExist, the values array must be empty.

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -1918,10 +1918,10 @@
         },
         "operator": {
           "description": "Logical operator which represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.\n\n",
-          "enum": ["In", "NotIn", "Exists", "DoesNotExists"],
+          "enum": ["In", "NotIn", "Exists", "DoesNotExist"],
           "type": "string",
-          "x-go-tag-validate": "oneof=In NotIn Exists DoesNotExists",
-          "x-oneof": "In | NotIn | Exists | DoesNotExists"
+          "x-go-tag-validate": "oneof=In NotIn Exists DoesNotExist",
+          "x-oneof": "In | NotIn | Exists | DoesNotExist"
         },
         "values": {
           "description": "An array of string values that relates to the key by an operator.\nIf the operator is In or NotIn, the values array must be non-empty.\nIf the operator is Exists or DoesNotExist, the values array must be empty.",

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -1920,7 +1920,7 @@
           "description": "Logical operator which represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.\n\n",
           "enum": ["In", "NotIn", "Exists", "DoesNotExist"],
           "type": "string",
-          "x-go-tag-validate": "oneof=In NotIn Exists DoesNotExist",
+          "x-go-tag-validate": "required,oneof=In NotIn Exists DoesNotExist",
           "x-oneof": "In | NotIn | Exists | DoesNotExist"
         },
         "values": {
@@ -1931,7 +1931,7 @@
           "type": "array"
         }
       },
-      "required": ["key"],
+      "required": ["key", "operator"],
       "type": "object",
       "additionalProperties": false
     },
@@ -1977,12 +1977,13 @@
           "description": "An arbitrary expression to be evaluated on the labels."
         },
         "match_expressions": {
-          "description": "List of Kubernetes-style label matcher requirements.\n\nNote: The requirements are combined using the logical AND operator.",
+          "description": "List of Kubernetes-style label matcher requirements.\n\nNote: The requirements are combined using the logical AND operator.\n\n",
           "items": {
             "$ref": "#/definitions/K8sLabelMatcherRequirement",
             "type": "object"
           },
-          "type": "array"
+          "type": "array",
+          "x-go-tag-validate": "dive"
         },
         "match_labels": {
           "additionalProperties": {

--- a/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
@@ -246,10 +246,10 @@ definitions:
                     - In
                     - NotIn
                     - Exists
-                    - DoesNotExists
+                    - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExists
-                x-oneof: In | NotIn | Exists | DoesNotExists
+                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
                     An array of string values that relates to the key by an operator.

--- a/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
@@ -248,7 +248,7 @@ definitions:
                     - Exists
                     - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-go-tag-validate: required,oneof=In NotIn Exists DoesNotExist
                 x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
@@ -260,6 +260,7 @@ definitions:
                 type: array
         required:
             - key
+            - operator
         type: object
     LabelMatcher:
         description: |-
@@ -275,14 +276,16 @@ definitions:
                 $ref: '#/definitions/MatchExpression'
                 description: An arbitrary expression to be evaluated on the labels.
             match_expressions:
-                description: |-
+                description: |+
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
+
                 items:
                     $ref: '#/definitions/K8sLabelMatcherRequirement'
                     type: object
                 type: array
+                x-go-tag-validate: dive
             match_labels:
                 additionalProperties:
                     type: string

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2117,7 +2117,7 @@ definitions:
                     - Exists
                     - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-go-tag-validate: required,oneof=In NotIn Exists DoesNotExist
                 x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
@@ -2129,6 +2129,7 @@ definitions:
                 type: array
         required:
             - key
+            - operator
         type: object
     KubernetesObjectSelector:
         description: |-
@@ -2185,14 +2186,16 @@ definitions:
                 $ref: '#/definitions/MatchExpression'
                 description: An arbitrary expression to be evaluated on the labels.
             match_expressions:
-                description: |-
+                description: |+
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
+
                 items:
                     $ref: '#/definitions/K8sLabelMatcherRequirement'
                     type: object
                 type: array
+                x-go-tag-validate: dive
             match_labels:
                 additionalProperties:
                     type: string

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2115,10 +2115,10 @@ definitions:
                     - In
                     - NotIn
                     - Exists
-                    - DoesNotExists
+                    - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExists
-                x-oneof: In | NotIn | Exists | DoesNotExists
+                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
                     An array of string values that relates to the key by an operator.

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -2522,10 +2522,10 @@ definitions:
                     - In
                     - NotIn
                     - Exists
-                    - DoesNotExists
+                    - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExists
-                x-oneof: In | NotIn | Exists | DoesNotExists
+                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
                     An array of string values that relates to the key by an operator.

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -2524,7 +2524,7 @@ definitions:
                     - Exists
                     - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-go-tag-validate: required,oneof=In NotIn Exists DoesNotExist
                 x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
@@ -2536,6 +2536,7 @@ definitions:
                 type: array
         required:
             - key
+            - operator
         type: object
     KubernetesObjectSelector:
         description: |-
@@ -2592,14 +2593,16 @@ definitions:
                 $ref: '#/definitions/MatchExpression'
                 description: An arbitrary expression to be evaluated on the labels.
             match_expressions:
-                description: |-
+                description: |+
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
+
                 items:
                     $ref: '#/definitions/K8sLabelMatcherRequirement'
                     type: object
                 type: array
+                x-go-tag-validate: dive
             match_labels:
                 additionalProperties:
                     type: string

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -4799,7 +4799,7 @@ Label key that the selector applies to.
 
 <!-- vale off -->
 
-(string, one of: `In | NotIn | Exists | DoesNotExists`)
+(string, one of: `In | NotIn | Exists | DoesNotExist`)
 
 <!-- vale on -->
 

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -4799,7 +4799,7 @@ Label key that the selector applies to.
 
 <!-- vale off -->
 
-(string, one of: `In | NotIn | Exists | DoesNotExist`)
+(string, one of: `In | NotIn | Exists | DoesNotExist`, **required**)
 
 <!-- vale on -->
 

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -2049,10 +2049,10 @@ definitions:
                     - In
                     - NotIn
                     - Exists
-                    - DoesNotExists
+                    - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExists
-                x-oneof: In | NotIn | Exists | DoesNotExists
+                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
                     An array of string values that relates to the key by an operator.

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -2051,7 +2051,7 @@ definitions:
                     - Exists
                     - DoesNotExist
                 type: string
-                x-go-tag-validate: oneof=In NotIn Exists DoesNotExist
+                x-go-tag-validate: required,oneof=In NotIn Exists DoesNotExist
                 x-oneof: In | NotIn | Exists | DoesNotExist
             values:
                 description: |-
@@ -2063,6 +2063,7 @@ definitions:
                 type: array
         required:
             - key
+            - operator
         type: object
     KubernetesObjectSelector:
         description: |-
@@ -2119,14 +2120,16 @@ definitions:
                 $ref: '#/definitions/MatchExpression'
                 description: An arbitrary expression to be evaluated on the labels.
             match_expressions:
-                description: |-
+                description: |+
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
+
                 items:
                     $ref: '#/definitions/K8sLabelMatcherRequirement'
                     type: object
                 type: array
+                x-go-tag-validate: dive
             match_labels:
                 additionalProperties:
                     type: string

--- a/pkg/policies/flowcontrol/selectors/selector.go
+++ b/pkg/policies/flowcontrol/selectors/selector.go
@@ -3,6 +3,7 @@
 package selectors
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -101,7 +102,9 @@ func MMExprFromLabelMatcher(lm *policylangv1.LabelMatcher) (mm.Expr, error) {
 		case metav1.LabelSelectorOpDoesNotExist:
 			reqExprs = append(reqExprs, mm.Not(mm.LabelExists(req.Key)))
 		default:
-			log.Panic().Msg("unknown match expression operator")
+			message := fmt.Sprintf("unknown match expression operator: %v", req.Operator)
+			log.Error().Msg(message)
+			return nil, errors.New(message)
 		}
 	}
 


### PR DESCRIPTION
### Description of change
* Do not panic on wrong operator in matcher
* Fix typo in operator validator enum
* Fix validation of match expressions to do dive validation

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [x] Documentation is changed or added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced label matching capabilities in policy configurations.

- **Bug Fixes**
  - Corrected the list of valid label match expression operators to include `DoesNotExist`.

- **Documentation**
  - Updated the configuration specification to reflect mandatory fields and valid options.

- **Refactor**
  - Improved error handling in label match expressions to prevent application crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->