### PR TITLE
SDK CI allow empty commit when version is updated via aperture

### DIFF
--- a/sdks/aperture-java/.github/workflows/create_release.yaml
+++ b/sdks/aperture-java/.github/workflows/create_release.yaml
@@ -86,7 +86,7 @@ jobs:
 
           # Create a new stable branch
           git checkout -b "stable/v${newVersion}"
-          git commit -am "Bump version to ${newVersion}"
+          git commit --allow-empty -am "Bump version to ${newVersion}"
 
           # Create a new tag and push it to origin
           git tag -a "releases/aperture-java/v${newVersion}" -m "Release v${newVersion}"

--- a/sdks/aperture-js/.github/workflows/create_release.yaml
+++ b/sdks/aperture-js/.github/workflows/create_release.yaml
@@ -70,7 +70,7 @@ jobs:
 
           # Create a stable release branch
           git checkout -b "stable/v${newVersion}"
-          git commit -am "Bump version to ${newVersion}"
+          git commit --allow-empty -am "Bump version to ${newVersion}"
 
           # Create a new tag and push it to origin
           git tag -a "releases/aperture-js/v${newVersion}" -m "Release v${newVersion}"

--- a/sdks/aperture-py/.github/workflows/create_release.yaml
+++ b/sdks/aperture-py/.github/workflows/create_release.yaml
@@ -80,7 +80,7 @@ jobs:
 
           # Create a new stable branch
           git checkout -b "stable/v${newVersion}"
-          git commit -am "Bump version to ${newVersion}"
+          git commit --allow-empty -am "Bump version to ${newVersion}"
 
           # Create a new tag and push it to origin
           git tag -a "releases/aperture-py/v${newVersion}" -m "Release v${newVersion}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflows across Java, JavaScript, and Python SDKs to allow empty commits, facilitating version bumping even when no code changes occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->