### PR TITLE
aperture-js add grpc call options

### DIFF
--- a/sdks/aperture-js/docs/classes/ApertureClient.md
+++ b/sdks/aperture-js/docs/classes/ApertureClient.md
@@ -92,9 +92,9 @@ ___
 ▸ **startFlow**(`controlPoint`, `params`): `Promise`\<[`Flow`](../interfaces/Flow.md)\>
 
 Starts a new flow with the specified control point and parameters.
-StartFlow takes a control point and labels that get passed to Aperture Agent via flowcontrolv1.Check call.
+startFlow() takes a control point and labels that get passed to Aperture Agent via flowcontrolv1.Check call.
 Return value is a Flow.
-The default semantics are fail-to-wire. If StartFlow fails, calling Flow.ShouldRun() on returned Flow returns as true.
+The default semantics are fail-to-wire. If startFlow() fails, calling Flow.ShouldRun() on returned Flow returns as true.
 
 #### Parameters
 
@@ -112,7 +112,7 @@ A promise that resolves to a Flow object.
 **`Example`**
 
 ```ts
-apertureClient.StartFlow("awesomeFeature", {
+apertureClient.startFlow("awesomeFeature", {
  labels: labels,
  grpcCallOptions: {
    deadline: Date.now() + 30000,

--- a/sdks/aperture-js/sdk/client.ts
+++ b/sdks/aperture-js/sdk/client.ts
@@ -142,15 +142,15 @@ export class ApertureClient {
 
   /**
    * Starts a new flow with the specified control point and parameters.
-   * StartFlow takes a control point and labels that get passed to Aperture Agent via flowcontrolv1.Check call.
+   * startFlow() takes a control point and labels that get passed to Aperture Agent via flowcontrolv1.Check call.
    * Return value is a Flow.
-   * The default semantics are fail-to-wire. If StartFlow fails, calling Flow.ShouldRun() on returned Flow returns as true.
+   * The default semantics are fail-to-wire. If startFlow() fails, calling Flow.ShouldRun() on returned Flow returns as true.
    * @param controlPoint The control point for the flow.
    * @param params The parameters for the flow.
    * @returns A promise that resolves to a Flow object.
    * @example
    * ```ts
-   *apertureClient.StartFlow("awesomeFeature", {
+   *apertureClient.startFlow("awesomeFeature", {
    *  labels: labels,
    *  grpcCallOptions: {
    *    deadline: Date.now() + 30000,
@@ -171,13 +171,11 @@ export class ApertureClient {
         resolve(
           new _Flow(
             this.fcsClient,
-            params.grpcCallOptions ?? {},
             controlPoint,
             span,
             startDate,
             params.rampMode,
             params.resultCacheKey,
-            params.globalCacheKeys,
             response,
             err,
           ),

--- a/sdks/aperture-js/sdk/flow.ts
+++ b/sdks/aperture-js/sdk/flow.ts
@@ -161,7 +161,11 @@ export class _Flow implements Flow {
    * @param cacheEntry The cache entry to set.
    * @returns A promise that resolves to the response of the key upsert operation.
    */
-  async setGlobalCache(key: string, cacheEntry: CacheEntry) {
+  async setGlobalCache(
+    key: string,
+    cacheEntry: CacheEntry,
+    grpcCallOptions: grpc.CallOptions,
+  ) {
     return new Promise<KeyUpsertResponse>((resolve) => {
       let cacheUpsertRequest: CacheUpsertRequest = {
         globalCacheEntries: {
@@ -173,7 +177,7 @@ export class _Flow implements Flow {
       };
       this.fcsClient.CacheUpsert(
         cacheUpsertRequest,
-        this.grpcCallOptions,
+        grpcCallOptions,
         (err, res) => {
           if (err) {
             const resp = new _KeyUpsertResponse(err);

--- a/sdks/aperture-js/sdk/flow.ts
+++ b/sdks/aperture-js/sdk/flow.ts
@@ -71,13 +71,11 @@ export class _Flow implements Flow {
 
   constructor(
     private fcsClient: FlowControlServiceClient,
-    private grpcCallOptions: grpc.CallOptions,
     private controlPoint: string,
     private _span: Span,
     private startDate: number,
     private rampMode: boolean = false,
     private resultCacheKey: string | null = null,
-    private globalCacheKeys: string[] | null = null,
     private _checkResponse: CheckResponse__Output | null = null,
     private _error: Error | null = null,
   ) {
@@ -115,7 +113,10 @@ export class _Flow implements Flow {
    * @param cacheEntry The cache entry to set.
    * @returns A promise that resolves to the response of the key upsert operation.
    */
-  async setResultCache(cacheEntry: CacheEntry) {
+  async setResultCache(
+    cacheEntry: CacheEntry,
+    grpcCallOptions?: grpc.CallOptions,
+  ) {
     return new Promise<KeyUpsertResponse>((resolve) => {
       if (!this.resultCacheKey) {
         const resp = new _KeyUpsertResponse(new Error("No cache key"));
@@ -132,7 +133,7 @@ export class _Flow implements Flow {
       };
       this.fcsClient.CacheUpsert(
         cacheUpsertRequest,
-        this.grpcCallOptions,
+        grpcCallOptions ?? {},
         (err, res) => {
           if (err) {
             const resp = new _KeyUpsertResponse(err);
@@ -164,7 +165,7 @@ export class _Flow implements Flow {
   async setGlobalCache(
     key: string,
     cacheEntry: CacheEntry,
-    grpcCallOptions: grpc.CallOptions,
+    grpcCallOptions?: grpc.CallOptions,
   ) {
     return new Promise<KeyUpsertResponse>((resolve) => {
       let cacheUpsertRequest: CacheUpsertRequest = {
@@ -177,7 +178,7 @@ export class _Flow implements Flow {
       };
       this.fcsClient.CacheUpsert(
         cacheUpsertRequest,
-        grpcCallOptions,
+        grpcCallOptions ?? {},
         (err, res) => {
           if (err) {
             const resp = new _KeyUpsertResponse(err);
@@ -204,7 +205,7 @@ export class _Flow implements Flow {
    * Deletes the result cache for the flow.
    * @returns A promise that resolves to the response of the key delete operation.
    */
-  async deleteResultCache() {
+  async deleteResultCache(grpcCallOptions?: grpc.CallOptions) {
     if (!this.resultCacheKey) {
       return Promise.reject(new Error("No cache key"));
     }
@@ -217,7 +218,7 @@ export class _Flow implements Flow {
       };
       this.fcsClient.CacheDelete(
         cacheDeleteRequest,
-        this.grpcCallOptions,
+        grpcCallOptions ?? {},
         (err, res) => {
           if (err) {
             const resp = new _KeyDeleteResponse(err);
@@ -238,14 +239,14 @@ export class _Flow implements Flow {
    * @param key The key of the cache entry to delete.
    * @returns A promise that resolves to the response of the key delete operation.
    */
-  async deleteGlobalCache(key: string) {
+  async deleteGlobalCache(key: string, grpcCallOptions?: grpc.CallOptions) {
     return new Promise<KeyDeleteResponse>((resolve) => {
       let cacheDeleteRequest: CacheDeleteRequest = {
         globalCacheKeys: [key],
       };
       this.fcsClient.CacheDelete(
         cacheDeleteRequest,
-        this.grpcCallOptions,
+        grpcCallOptions ?? {},
         (err, res) => {
           if (err) {
             const resp = new _KeyDeleteResponse(err);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the function naming convention in the documentation to camelCase.
  - Revised example usage to reflect the new function name.

- **Refactor**
  - Renamed a method to follow camelCase naming convention.
  - Adjusted cache-related methods to accept a new parameter for enhanced configuration.

- **Chores**
  - Removed an unused default parameter to streamline method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->