### PR TITLE
 Separate counter to track inf signals

### DIFF
--- a/docs/content/reference/observability/prometheus-metrics/controller.md
+++ b/docs/content/reference/observability/prometheus-metrics/controller.md
@@ -13,10 +13,11 @@ Controller.
 
 <!-- vale off -->
 
-| Name                   | Type    | Labels                                                                | Unit            | Description                      |
-| ---------------------- | ------- | --------------------------------------------------------------------- | --------------- | -------------------------------- |
-| signal_reading         | Summary | instance, job, process_uuid, signal_name, policy_name, sub_circuit_id | various         | The reading from a signal        |
-| invalid_signal_reading | Counter | instance, job, process_uuid, signal_name, policy_name, sub_circuit_id | count (no unit) | Count of invalid signal readings |
+| Name                    | Type    | Labels                                                                | Unit            | Description                       |
+| ----------------------- | ------- | --------------------------------------------------------------------- | --------------- | --------------------------------- |
+| signal_reading          | Summary | instance, job, process_uuid, signal_name, policy_name, sub_circuit_id | various         | The reading from a signal         |
+| invalid_signal_reading  | Counter | instance, job, process_uuid, signal_name, policy_name, sub_circuit_id | count (no unit) | Count of invalid signal readings  |
+| infinite_signal_reading | Counter | instance, job, process_uuid, signal_name, policy_name, sub_circuit_id | count (no unit) | Count of infinite signal readings |
 
 <!-- vale on -->
 

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -22,6 +22,8 @@ const (
 	FluxMeterMetricName = "flux_meter"
 	// InvalidSignalReadingsTotalMetricName - counts invalid signal readings.
 	InvalidSignalReadingsTotalMetricName = "invalid_signal_readings_total"
+	// InfiniteSignalReadingsTotalMetricName - counts infinite signal readings.
+	InfiniteSignalReadingsTotalMetricName = "infinite_signal_readings_total"
 	// InvalidFluxMeterTotalMetricName - counts invalid flux meters.
 	InvalidFluxMeterTotalMetricName = "invalid_flux_meter_total"
 	// RateLimiterCounterTotalMetricName - name of the counter describing times rate limiter was triggered.

--- a/pkg/prometheus/prom-query.go
+++ b/pkg/prometheus/prom-query.go
@@ -64,10 +64,6 @@ func (pq *promQuery) execute(jobCtxt context.Context) (proto.Message, error) {
 			return innerErr
 		}
 
-		log.Info().Str("query", query).Msg("Executing promQL query")
-		// sleep for 100 seconds
-		time.Sleep(100 * time.Second)
-
 		result, warnings, err = pq.promAPI.Query(ctx, query, pq.endTimestamp)
 		// if jobCtxt is closed, return PermanentError
 		if jobCtxt.Err() != nil {

--- a/pkg/prometheus/prom-query.go
+++ b/pkg/prometheus/prom-query.go
@@ -64,6 +64,10 @@ func (pq *promQuery) execute(jobCtxt context.Context) (proto.Message, error) {
 			return innerErr
 		}
 
+		log.Info().Str("query", query).Msg("Executing promQL query")
+		// sleep for 100 seconds
+		time.Sleep(100 * time.Second)
+
 		result, warnings, err = pq.promAPI.Query(ctx, query, pq.endTimestamp)
 		// if jobCtxt is closed, return PermanentError
 		if jobCtxt.Err() != nil {


### PR DESCRIPTION
### Description of change
* Inf signals were breaking the prometheus counter silently

##### Checklist

- [ ] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new metric to track infinite signal readings within the system.

- **Documentation**
  - Updated the reference documentation to include the new `infinite_signal_reading` counter.

- **Bug Fixes**
  - Renamed metric to accurately reflect the counting of infinite signal readings.

- **Refactor**
  - Enhanced the internal logic for metric collection to include infinite signal readings.

- **Chores**
  - Improved logging for Prometheus query executions and added a delay for better process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->