### PR TITLE
Run scheduling while global cache lookup is in progress

### DIFF
--- a/pkg/policies/flowcontrol/iface/cache.go
+++ b/pkg/policies/flowcontrol/iface/cache.go
@@ -2,6 +2,7 @@ package iface
 
 import (
 	"context"
+	"sync"
 
 	flowcontrolv1 "github.com/fluxninja/aperture/api/v2/gen/proto/go/aperture/flowcontrol/check/v1"
 )
@@ -21,6 +22,8 @@ const (
 type Cache interface {
 	// Lookup looks up specified keys in cache. It takes flowcontrolv1.LookupRequest and returns flowcontrolv1.LookupResponse.
 	Lookup(ctx context.Context, request *flowcontrolv1.CacheLookupRequest) *flowcontrolv1.CacheLookupResponse
+	// LookupWait starts lookup for specified keys in cache. It does not wait for response. It takes flowcontrolv1.LookupRequest and returns flowcontrolv1.LookupResponse and result and global wait groups.
+	LookupWait(ctx context.Context, request *flowcontrolv1.CacheLookupRequest) (*flowcontrolv1.CacheLookupResponse, *sync.WaitGroup, *sync.WaitGroup)
 	// Upsert inserts or updates specified cache entries. It takes flowcontrolv1.UpsertRequest and returns flowcontrolv1.UpsertResponse.
 	Upsert(ctx context.Context, req *flowcontrolv1.CacheUpsertRequest) *flowcontrolv1.CacheUpsertResponse
 	// Delete deletes specified keys from cache. It takes flowcontrolv1.DeleteRequest and returns flowcontrolv1.DeleteResponse.


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved cache lookup operations to be asynchronous, enhancing performance and responsiveness.

- **Documentation**
	- Updated method signatures in documentation to reflect new asynchronous behavior.

- **Chores**
	- Updated interface implementations to include new asynchronous cache lookup methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->