### PR TITLE
Add event based Olric metrics

### DIFF
--- a/pkg/dist-cache/dist-cache-metrics.go
+++ b/pkg/dist-cache/dist-cache-metrics.go
@@ -9,14 +9,16 @@ import (
 
 // DistCacheMetrics holds metrics from DistCache, Olric, DMap statistics.
 type DistCacheMetrics struct {
-	EntriesTotal          *prometheus.GaugeVec
-	DeleteHits            *prometheus.GaugeVec
-	DeleteMisses          *prometheus.GaugeVec
-	GetMisses             *prometheus.GaugeVec
-	GetHits               *prometheus.GaugeVec
-	EvictedTotal          *prometheus.GaugeVec
-	PartitionsCount       *prometheus.GaugeVec
-	BackupPartitionsCount *prometheus.GaugeVec
+	EntriesTotal                 *prometheus.GaugeVec
+	DeleteHits                   *prometheus.GaugeVec
+	DeleteMisses                 *prometheus.GaugeVec
+	GetMisses                    *prometheus.GaugeVec
+	GetHits                      *prometheus.GaugeVec
+	EvictedTotal                 *prometheus.GaugeVec
+	PartitionsCount              *prometheus.GaugeVec
+	BackupPartitionsCount        *prometheus.GaugeVec
+	FragmentMigrationEventsTotal *prometheus.CounterVec
+	FragmentReceivedEventsTotal  *prometheus.CounterVec
 }
 
 func newDistCacheMetrics() *DistCacheMetrics {
@@ -54,6 +56,14 @@ func newDistCacheMetrics() *DistCacheMetrics {
 			Name: metrics.DistCacheBackupPartitionsCountMetricsName,
 			Help: "Current number of non-empty backup partitions owned by given node.",
 		}, distCacheMetricsLabels),
+		FragmentMigrationEventsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: metrics.DistCacheFragmentMigrationEventsTotalMetricsName,
+			Help: "Cumulative number of fragment migration (outgoing) events.",
+		}, distCacheMetricsLabels),
+		FragmentReceivedEventsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: metrics.DistCacheFragmentReceivedEventsTotalMetricsName,
+			Help: "Cumulative number of fragment received (incoming) events.",
+		}, distCacheMetricsLabels),
 	}
 }
 
@@ -67,6 +77,8 @@ func (dm *DistCacheMetrics) allMetrics() []prometheus.Collector {
 		dm.EvictedTotal,
 		dm.PartitionsCount,
 		dm.BackupPartitionsCount,
+		dm.FragmentMigrationEventsTotal,
+		dm.FragmentReceivedEventsTotal,
 	}
 }
 

--- a/pkg/dist-cache/dist-cache.go
+++ b/pkg/dist-cache/dist-cache.go
@@ -156,7 +156,7 @@ func (dc *DistCache) getMetricsLabels() (prometheus.Labels, bool) {
 	metricLabels := make(prometheus.Labels)
 	metricLabels[metrics.DistCacheMemberIDLabel] = dc.memberID
 	metricLabels[metrics.DistCacheMemberNameLabel] = dc.memberName
-	return metricLabels, dc.memberID == "" || dc.memberName == ""
+	return metricLabels, dc.memberID != "" && dc.memberName != ""
 }
 
 // GetStats returns stats of the current Olric member.

--- a/pkg/dist-cache/dist-cache.go
+++ b/pkg/dist-cache/dist-cache.go
@@ -2,12 +2,14 @@ package distcache
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/buraksezer/olric"
 	olricconfig "github.com/buraksezer/olric/config"
+	"github.com/buraksezer/olric/events"
 	olricstats "github.com/buraksezer/olric/stats"
 	"github.com/clarketm/json"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,6 +33,10 @@ type DistCache struct {
 	metrics           *DistCacheMetrics
 	shutDowner        fx.Shutdowner
 	statsFailureCount uint8
+
+	// These are periodically update by the scapeMetrics function.
+	memberID   string
+	memberName string
 }
 
 // NewDistCache creates a new instance of DistCache.
@@ -81,11 +87,10 @@ func (dc *DistCache) scrapeMetrics(ctx context.Context) (proto.Message, error) {
 
 	dc.statsFailureCount = 0
 
-	memberID := stats.Member.ID
-	memberName := stats.Member.Name
-	metricLabels := make(prometheus.Labels)
-	metricLabels[metrics.DistCacheMemberIDLabel] = strconv.FormatUint(memberID, 10)
-	metricLabels[metrics.DistCacheMemberNameLabel] = memberName
+	dc.memberID = strconv.FormatUint(stats.Member.ID, 10)
+	dc.memberName = stats.Member.Name
+	// We don't care about the second argument as we just set all needed values above.
+	metricLabels, _ := dc.getMetricsLabels()
 
 	entriesTotalGauge, err := dc.metrics.EntriesTotal.GetMetricWith(metricLabels)
 	if err != nil {
@@ -145,6 +150,15 @@ func (dc *DistCache) scrapeMetrics(ctx context.Context) (proto.Message, error) {
 	return nil, nil
 }
 
+// getMetricsLabels returns metric labels based on dc.memberID and dc.memberName.
+// If any of those is empty, function will return false as second argument.
+func (dc *DistCache) getMetricsLabels() (prometheus.Labels, bool) {
+	metricLabels := make(prometheus.Labels)
+	metricLabels[metrics.DistCacheMemberIDLabel] = dc.memberID
+	metricLabels[metrics.DistCacheMemberNameLabel] = dc.memberName
+	return metricLabels, dc.memberID == "" || dc.memberName == ""
+}
+
 // GetStats returns stats of the current Olric member.
 func (dc *DistCache) GetStats(ctx context.Context, _ *emptypb.Empty) (*structpb.Struct, error) {
 	// create a new context with a timeout to avoid hanging
@@ -180,6 +194,55 @@ func (dc *DistCache) GetStats(ctx context.Context, _ *emptypb.Empty) (*structpb.
 	return structpbStats, nil
 }
 
+func (dc *DistCache) startReportingMetricsFromEvents(ctx context.Context) error {
+	ps, err := dc.client.NewPubSub()
+	if err != nil {
+		return fmt.Errorf("failed creating pub sub client: %w", err)
+	}
+	rps := ps.Subscribe(ctx, events.ClusterEventsChannel)
+	msgCh := rps.Channel()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case message, ok := <-msgCh:
+				if !ok {
+					log.Warn().Msg("Events channel closed")
+					return
+				}
+				event, err := olricEventFromPayload(message.Payload)
+				if err != nil {
+					log.Debug().Err(err).Msg("Failed getting olric event from payload")
+					continue
+				}
+				metricLabels, ready := dc.getMetricsLabels()
+				if !ready {
+					log.Warn().Msg("Member ID or Member Name not yet set. Skipping event")
+					continue
+				}
+				switch event.Kind {
+				case events.KindFragmentMigrationEvent:
+					fragmentMigrationEventsCounter, err := dc.metrics.FragmentMigrationEventsTotal.GetMetricWith(metricLabels)
+					if err != nil {
+						log.Debug().Msgf("Could not extract fragment migrate counter metric from olric instance: %v", err)
+						continue
+					}
+					fragmentMigrationEventsCounter.Inc()
+				case events.KindFragmentReceivedEvent:
+					fragmentReceivedEventsCounter, err := dc.metrics.FragmentReceivedEventsTotal.GetMetricWith(metricLabels)
+					if err != nil {
+						log.Debug().Msgf("Could not extract fragment received counter metric from olric instance: %v", err)
+						continue
+					}
+					fragmentReceivedEventsCounter.Inc()
+				}
+			}
+		}
+	}()
+	return nil
+}
+
 func countNotEmptyPartitions(partitions map[olricstats.PartitionID]olricstats.Partition) int {
 	result := 0
 	for _, partition := range partitions {
@@ -188,4 +251,17 @@ func countNotEmptyPartitions(partitions map[olricstats.PartitionID]olricstats.Pa
 		}
 	}
 	return result
+}
+
+type olricEvent struct {
+	Kind string `json:"Kind"`
+}
+
+func olricEventFromPayload(payload string) (*olricEvent, error) {
+	var event olricEvent
+	err := json.Unmarshal([]byte(payload), &event)
+	if err != nil {
+		return nil, fmt.Errorf("failed unmarhalling event from payload: %w", err)
+	}
+	return &event, nil
 }

--- a/pkg/dist-cache/provider.go
+++ b/pkg/dist-cache/provider.go
@@ -147,6 +147,7 @@ func (constructor DistCacheConstructor) ProvideDistCache(in DistCacheConstructor
 
 	dc := NewDistCache(oc, o, newDistCacheMetrics(), in.Shutdowner)
 
+	// Context used by goroutine listening for Olric events. Should be canceled in fx.Stop.
 	eventListenerCtx, eventListenerCancel := context.WithCancel(context.Background())
 	job := jobs.NewBasicJob(distCacheMetricsJobName, dc.scrapeMetrics)
 	in.Lifecycle.Append(fx.Hook{
@@ -190,6 +191,7 @@ func (constructor DistCacheConstructor) ProvideDistCache(in DistCacheConstructor
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
+			log.Info().Msg("Canceling events listener context")
 			eventListenerCancel()
 			err := in.LivenessMultiJob.DeregisterJob(distCacheMetricsJobName)
 			if err != nil {

--- a/pkg/dist-cache/provider.go
+++ b/pkg/dist-cache/provider.go
@@ -99,6 +99,7 @@ func (constructor DistCacheConstructor) ProvideDistCache(in DistCacheConstructor
 	}
 	oc.BindAddr = bindAddr
 	oc.BindPort = bindPort
+	oc.EnableClusterEventsChannel = true
 
 	memberlistBindAddr, p, err := net.SplitHostPort(defaultConfig.MemberlistBindAddr)
 	if err != nil {

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -51,6 +51,10 @@ const (
 	DistCachePartitionsCountMetricsName = "distcache_partitions_count"
 	// DistCacheBackupPartitionsCountMetricsName - metric for the current number of non-empty backups owned by given node.
 	DistCacheBackupPartitionsCountMetricsName = "distcache_backup_partitions_count"
+	// DistCacheFragmentMigrationEventsTotalMetricsName - metric for cumulative number of fragment migration (outgoing) events.
+	DistCacheFragmentMigrationEventsTotalMetricsName = "distcache_fragment_migration_events_total"
+	// DistCacheFragmentReceivedEventsTotalMetricsName - metric for cumulative number of fragment received (incoming) events.
+	DistCacheFragmentReceivedEventsTotalMetricsName = "distcache_fragment_received_events_total"
 
 	// Workload metrics.
 


### PR DESCRIPTION
### Description of change
This allows to track fragment migrate/received events count to monitor how Olric cluster is rebalanced.

##### Checklist

- [x] Tested in playground or other setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced distributed cache metrics with new event tracking for fragment migrations and receptions.
  - Improved cache event monitoring capabilities with the integration of Olric event packages.
  - Introduced new context management for event listeners to ensure graceful shutdown.

- **Bug Fixes**
  - Implemented error handling in metrics reporting to increase system reliability.

- **Documentation**
  - Updated metric names for clarity in monitoring distributed cache events.

- **Refactor**
  - Refined `DistCache` structure with additional member identification fields to improve metrics accuracy.
  - Optimized metric scraping by introducing label extraction methods.

- **Chores**
  - Added utility functions for partition counting to aid in cache management tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->