### PR TITLE
Change TTL in aperturectl to be seconds instead of millis

### DIFF
--- a/cmd/aperturectl/cmd/cloud/globalcache/set.go
+++ b/cmd/aperturectl/cmd/cloud/globalcache/set.go
@@ -16,7 +16,7 @@ func init() {
 	SetCommand.Flags().StringVarP(&agentGroup, "agent-group", "a", "", "Agent group")
 	SetCommand.Flags().StringVarP(&key, "key", "k", "", "Key")
 	SetCommand.Flags().StringVarP(&value, "value", "", "", "Value")
-	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600000, "TTL in milliseconds")
+	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600, "TTL in seconds")
 	err := SetCommand.MarkFlagRequired("agent-group")
 	if err != nil {
 		panic(err)
@@ -45,7 +45,7 @@ var SetCommand = &cobra.Command{
 			AgentGroup: agentGroup,
 			Key:        key,
 			Value:      value,
-			TTL:        time.Duration(ttl) * time.Millisecond,
+			TTL:        time.Duration(ttl) * time.Second,
 		}
 
 		return utils.ParseGlobalCacheUpsert(client, input)

--- a/cmd/aperturectl/cmd/cloud/resultcache/set.go
+++ b/cmd/aperturectl/cmd/cloud/resultcache/set.go
@@ -17,7 +17,7 @@ func init() {
 	SetCommand.Flags().StringVarP(&controlPoint, "control-point", "c", "", "Control point")
 	SetCommand.Flags().StringVarP(&key, "key", "k", "", "Key")
 	SetCommand.Flags().StringVarP(&value, "value", "", "", "Value")
-	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600000, "TTL in milliseconds")
+	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600, "TTL in seconds")
 	err := SetCommand.MarkFlagRequired("agent-group")
 	if err != nil {
 		panic(err)
@@ -51,7 +51,7 @@ var SetCommand = &cobra.Command{
 			ControlPoint: controlPoint,
 			Key:          key,
 			Value:        value,
-			TTL:          time.Duration(ttl) * time.Millisecond,
+			TTL:          time.Duration(ttl) * time.Second,
 		}
 
 		return utils.ParseResultCacheUpsert(client, input)

--- a/cmd/aperturectl/cmd/globalcache/set.go
+++ b/cmd/aperturectl/cmd/globalcache/set.go
@@ -16,7 +16,7 @@ func init() {
 	SetCommand.Flags().StringVarP(&agentGroup, "agent-group", "a", "", "Agent group")
 	SetCommand.Flags().StringVarP(&key, "key", "k", "", "Key")
 	SetCommand.Flags().StringVarP(&value, "value", "", "", "Value")
-	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600000, "TTL in milliseconds")
+	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600, "TTL in seconds")
 	err := SetCommand.MarkFlagRequired("agent-group")
 	if err != nil {
 		panic(err)
@@ -45,7 +45,7 @@ var SetCommand = &cobra.Command{
 			AgentGroup: agentGroup,
 			Key:        key,
 			Value:      value,
-			TTL:        time.Duration(ttl) * time.Millisecond,
+			TTL:        time.Duration(ttl) * time.Second,
 		}
 
 		return utils.ParseGlobalCacheUpsert(client, input)

--- a/cmd/aperturectl/cmd/resultcache/set.go
+++ b/cmd/aperturectl/cmd/resultcache/set.go
@@ -17,7 +17,7 @@ func init() {
 	SetCommand.Flags().StringVarP(&controlPoint, "control-point", "c", "", "Control point")
 	SetCommand.Flags().StringVarP(&key, "key", "k", "", "Key")
 	SetCommand.Flags().StringVarP(&value, "value", "", "", "Value")
-	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600000, "TTL in milliseconds")
+	SetCommand.Flags().Int64VarP(&ttl, "ttl", "t", 600, "TTL in seconds")
 	err := SetCommand.MarkFlagRequired("agent-group")
 	if err != nil {
 		panic(err)
@@ -51,7 +51,7 @@ var SetCommand = &cobra.Command{
 			ControlPoint: controlPoint,
 			Key:          key,
 			Value:        value,
-			TTL:          time.Duration(ttl) * time.Millisecond,
+			TTL:          time.Duration(ttl) * time.Second,
 		}
 
 		return utils.ParseResultCacheUpsert(client, input)

--- a/docs/content/reference/aperture-cli/aperturectl/cloud/global-cache/set/set.md
+++ b/docs/content/reference/aperture-cli/aperturectl/cloud/global-cache/set/set.md
@@ -26,7 +26,7 @@ aperturectl cloud global-cache set [flags]
   -a, --agent-group string   Agent group
   -h, --help                 help for set
   -k, --key string           Key
-  -t, --ttl int              TTL in milliseconds (default 600000)
+  -t, --ttl int              TTL in seconds (default 600)
       --value string         Value
 ```
 

--- a/docs/content/reference/aperture-cli/aperturectl/cloud/result-cache/set/set.md
+++ b/docs/content/reference/aperture-cli/aperturectl/cloud/result-cache/set/set.md
@@ -27,7 +27,7 @@ aperturectl cloud result-cache set [flags]
   -c, --control-point string   Control point
   -h, --help                   help for set
   -k, --key string             Key
-  -t, --ttl int                TTL in milliseconds (default 600000)
+  -t, --ttl int                TTL in seconds (default 600)
       --value string           Value
 ```
 

--- a/docs/content/reference/aperture-cli/aperturectl/global-cache/set/set.md
+++ b/docs/content/reference/aperture-cli/aperturectl/global-cache/set/set.md
@@ -26,7 +26,7 @@ aperturectl global-cache set [flags]
   -a, --agent-group string   Agent group
   -h, --help                 help for set
   -k, --key string           Key
-  -t, --ttl int              TTL in milliseconds (default 600000)
+  -t, --ttl int              TTL in seconds (default 600)
       --value string         Value
 ```
 

--- a/docs/content/reference/aperture-cli/aperturectl/result-cache/set/set.md
+++ b/docs/content/reference/aperture-cli/aperturectl/result-cache/set/set.md
@@ -27,7 +27,7 @@ aperturectl result-cache set [flags]
   -c, --control-point string   Control point
   -h, --help                   help for set
   -k, --key string             Key
-  -t, --ttl int                TTL in milliseconds (default 600000)
+  -t, --ttl int                TTL in seconds (default 600)
       --value string           Value
 ```
 


### PR DESCRIPTION
### Description of change

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the TTL (Time to Live) parameter for cache settings from milliseconds to seconds for improved user experience and clarity.

- **Documentation**
  - Revised documentation to reflect the change in TTL units across various `aperturectl` commands.

- **Bug Fixes**
  - Ensured consistent TTL unit usage across all caching commands to prevent confusion and potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->