### PR TITLE
Add Global Cache OLAP telemetry

### DIFF
--- a/docs/content/reference/observability/flow-metrics/flow-metrics.md
+++ b/docs/content/reference/observability/flow-metrics/flow-metrics.md
@@ -25,13 +25,13 @@ and behavior. The stream can be stored and visualized in
 | --------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------- |
 | aperture.source                   | single      | sdk, envoy                                                                                                                                                                | Aperture Flow source                               | SDKs, Envoy               |
 | aperture.decision_type            | single      | DECISION_TYPE_ACCEPTED, DECISION_TYPE_REJECTED                                                                                                                            | Decision type taken by policy                      | SDKs, Envoy               |
-| aperture.reject_reason            | single      | REJECT_REASON_NONE, REJECT_REASON_RATE_LIMITED, REJECT_REASON_NO_TOKENS, REJECT_REASON_NOT_SAMPLED                                                                          | Reject reason of the decision taken by policy      | SDKs, Envoy               |
+| aperture.reject_reason            | single      | REJECT_REASON_NONE, REJECT_REASON_RATE_LIMITED, REJECT_REASON_NO_TOKENS, REJECT_REASON_NOT_SAMPLED                                                                        | Reject reason of the decision taken by policy      | SDKs, Envoy               |
 | aperture.rate_limiters            | multi-value | "policy_name:s1, component_id:18, policy_hash:5kZjj"                                                                                                                      | Rate limiters matched to the traffic               | SDKs, Envoy               |
 | aperture.dropping_rate_limiters   | multi-value | "policy_name:s1, component_id:18, policy_hash:5kZjj"                                                                                                                      | Rate limiters dropping the traffic                 | SDKs, Envoy               |
 | aperture.load_schedulers          | multi-value | "policy_name:s1, component_id:13, policy_hash:5kZjj"                                                                                                                      | Concurrency limiters matched to the traffic        | SDKs, Envoy               |
 | aperture.dropping_load_schedulers | multi-value | "policy_name:s1, component_id:13, policy_hash:5kZjj"                                                                                                                      | Concurrency limiters dropping the traffic          | SDKs, Envoy               |
-| aperture.samplers          | multi-value | "policy_name:s1, component_id:18, policy_hash:5kZjj"                                                                                                                      | Samplers matched to the traffic             | SDKs, Envoy               |
-| aperture.dropping_samplers | multi-value | "policy_name:s1, component_id:18, policy_hash:5kZjj"                                                                                                                      | Samplers dropping the traffic               | SDKs, Envoy               |
+| aperture.samplers                 | multi-value | "policy_name:s1, component_id:18, policy_hash:5kZjj"                                                                                                                      | Samplers matched to the traffic                    | SDKs, Envoy               |
+| aperture.dropping_samplers        | multi-value | "policy_name:s1, component_id:18, policy_hash:5kZjj"                                                                                                                      | Samplers dropping the traffic                      | SDKs, Envoy               |
 | aperture.workloads                | multi-value | "policy_name:s1, component_id:13, workload_index:0, policy_hash:5kZjj"                                                                                                    | Workloads matched to the traffic                   | SDKs, Envoy               |
 | aperture.dropping_workloads       | multi-value | "policy_name:s1, component_id:13, workload_index:0, policy_hash:5kZjj"                                                                                                    | Workloads dropping the traffic                     | SDKs, Envoy               |
 | aperture.flux_meters              | multi-value | s1                                                                                                                                                                        | Flux Meters matched to the traffic                 | SDKs, Envoy               |
@@ -41,7 +41,7 @@ and behavior. The stream can be stored and visualized in
 | aperture.services                 | multi-value | s1.demoapp.svc.cluster.local, s2.demoapp.svc.cluster.local                                                                                                                | Services to which metrics refer                    | SDKs, Envoy               |
 | aperture.control_point            | single      | type:TYPE_INGRESS, type:TYPE_EGRESS                                                                                                                                       | Control point to which metrics refer               | SDKs, Envoy               |
 | aperture.flow.status              | single      | OK, Error                                                                                                                                                                 | Denotes OK or Error across all protocols           | SDKs, Envoy               |
-| response_received                 | single      | true, false                                                                                                                                                               | Designates whether a response was received         | SDKs, envoy               |
+| response_received                 | single      | true, false                                                                                                                                                               | Designates whether a response was received         | SDKs, Envoy               |
 
 <!-- vale on -->
 
@@ -67,9 +67,13 @@ and behavior. The stream can be stored and visualized in
 
 <!-- vale off -->
 
-| Name                  | Type | Example Values | Description                                      | Flow Control Integrations |
-| --------------------- | ---- | -------------- | ------------------------------------------------ | ------------------------- |
-| {user-defined-labels} |      |                | Explicitly passed through FlowStart call in SDKs | SDKs                      |
+| Name                                   | Type   | Example Values | Description                                      | Flow Control Integrations |
+| -------------------------------------- | ------ | -------------- | ------------------------------------------------ | ------------------------- |
+| aperture.cache_lookup_status           | single | HIT, MISS      | Result of result cache lookup                    | SDKs                      |
+| aperture.cache_operation_status        | single | SUCCESS, ERROR | Result of result cache operation                 | SDKs                      |
+| aperture.global_cache_lookup_status    | single | HIT, MISS      | Result of global cache lookup                    | SDKs                      |
+| aperture.global_cache_operation_status | single | SUCCESS, ERROR | Result of global cache operation                 | SDKs                      |
+| {user-defined-labels}                  |        |                | Explicitly passed through FlowStart call in SDKs | SDKs                      |
 
 <!-- vale on -->
 

--- a/docs/content/reference/observability/flow-metrics/flow-metrics.md
+++ b/docs/content/reference/observability/flow-metrics/flow-metrics.md
@@ -67,13 +67,13 @@ and behavior. The stream can be stored and visualized in
 
 <!-- vale off -->
 
-| Name                                   | Type   | Example Values | Description                                      | Flow Control Integrations |
-| -------------------------------------- | ------ | -------------- | ------------------------------------------------ | ------------------------- |
-| aperture.cache_lookup_status           | single | HIT, MISS      | Result of result cache lookup                    | SDKs                      |
-| aperture.cache_operation_status        | single | SUCCESS, ERROR | Result of result cache operation                 | SDKs                      |
-| aperture.global_cache_lookup_status    | single | HIT, MISS      | Result of global cache lookup                    | SDKs                      |
-| aperture.global_cache_operation_status | single | SUCCESS, ERROR | Result of global cache operation                 | SDKs                      |
-| {user-defined-labels}                  |        |                | Explicitly passed through FlowStart call in SDKs | SDKs                      |
+| Name                                     | Type        | Example Values | Description                                      | Flow Control Integrations |
+| ---------------------------------------- | ----------- | -------------- | ------------------------------------------------ | ------------------------- |
+| aperture.cache_lookup_status             | single      | HIT, MISS      | Result of result cache lookup                    | SDKs                      |
+| aperture.cache_operation_status          | single      | SUCCESS, ERROR | Result of result cache operation                 | SDKs                      |
+| aperture.global_cache_lookup_statuses    | multi-value | HIT, MISS      | Results of global cache lookups                  | SDKs                      |
+| aperture.global_cache_operation_statuses | multi-value | SUCCESS, ERROR | Results of global cache operations               | SDKs                      |
+| {user-defined-labels}                    |             |                | Explicitly passed through FlowStart call in SDKs | SDKs                      |
 
 <!-- vale on -->
 

--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -91,10 +91,10 @@ const (
 	ApertureResultCacheLookupStatusLabel = "aperture.cache_lookup_status"
 	// ApertureResultCacheOperationStatusLabel describes status of the cache operation.
 	ApertureResultCacheOperationStatusLabel = "aperture.cache_operation_status"
-	// ApertureGlobalCacheLookupStatusLabel describes status of the cache lookup.
-	ApertureGlobalCacheLookupStatusLabel = "aperture.global_cache_lookup_status"
-	// ApertureGlobalCacheOperationStatusLabel describes status of the cache operation.
-	ApertureGlobalCacheOperationStatusLabel = "aperture.global_cache_operation_status"
+	// ApertureGlobalCacheLookupStatusesLabel describes statuses of the global cache lookups.
+	ApertureGlobalCacheLookupStatusesLabel = "aperture.global_cache_lookup_statuses"
+	// ApertureGlobalCacheOperationStatusesLabel describes statuses of the global cache operations.
+	ApertureGlobalCacheOperationStatusesLabel = "aperture.global_cache_operation_statuses"
 
 	/* HTTP Specific labels. */
 

--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -87,10 +87,14 @@ const (
 	ApertureFlowStatusOK = "OK"
 	// ApertureFlowStatusError const for error status.
 	ApertureFlowStatusError = "Error"
-	// ApertureCacheLookupStatusLabel describes status of the cache lookup.
-	ApertureCacheLookupStatusLabel = "aperture.cache_lookup_status"
-	// ApertureCacheOperationStatusLabel describes status of the cache operation.
-	ApertureCacheOperationStatusLabel = "aperture.cache_operation_status"
+	// ApertureResultCacheLookupStatusLabel describes status of the cache lookup.
+	ApertureResultCacheLookupStatusLabel = "aperture.cache_lookup_status"
+	// ApertureResultCacheOperationStatusLabel describes status of the cache operation.
+	ApertureResultCacheOperationStatusLabel = "aperture.cache_operation_status"
+	// ApertureGlobalCacheLookupStatusLabel describes status of the cache lookup.
+	ApertureGlobalCacheLookupStatusLabel = "aperture.global_cache_lookup_status"
+	// ApertureGlobalCacheOperationStatusLabel describes status of the cache operation.
+	ApertureGlobalCacheOperationStatusLabel = "aperture.global_cache_operation_status"
 
 	/* HTTP Specific labels. */
 

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
@@ -29,6 +29,10 @@ import (
 // * otelconsts.ApertureClassifierErrorsLabel
 // * otelconsts.ApertureDecisionTypeLabel
 // * otelconsts.ApertureRejectReasonLabel
+// * otelconsts.ApertureResultCacheLookupStatusLabel
+// * otelconsts.ApertureResultCacheOperationStatusLabel
+// * otelconsts.ApertureGlobalCacheLookupStatusLabel
+// * otelconsts.ApertureGlobalCacheOperationStatusLabel
 // * dynamic flow labels.
 func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse, sourceStr string) {
 	// Aperture Processing Duration

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
@@ -31,8 +31,8 @@ import (
 // * otelconsts.ApertureRejectReasonLabel
 // * otelconsts.ApertureResultCacheLookupStatusLabel
 // * otelconsts.ApertureResultCacheOperationStatusLabel
-// * otelconsts.ApertureGlobalCacheLookupStatusLabel
-// * otelconsts.ApertureGlobalCacheOperationStatusLabel
+// * otelconsts.ApertureGlobalCacheLookupStatusesLabel
+// * otelconsts.ApertureGlobalCacheOperationStatusesLabel
 // * dynamic flow labels.
 func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcontrolv1.CheckResponse, sourceStr string) {
 	// Aperture Processing Duration
@@ -69,12 +69,14 @@ func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcont
 			attributes.PutStr(otelconsts.ApertureResultCacheLookupStatusLabel, resultCacheResponse.LookupStatus.String())
 			attributes.PutStr(otelconsts.ApertureResultCacheOperationStatusLabel, resultCacheResponse.OperationStatus.String())
 		}
+		globalCacheLookupStatuses := attributes.PutEmptySlice(otelconsts.ApertureGlobalCacheLookupStatusesLabel)
+		globalCacheOperationStatuses := attributes.PutEmptySlice(otelconsts.ApertureGlobalCacheOperationStatusesLabel)
 		for _, globalCacheResponse := range checkResponse.CacheLookupResponse.GlobalCacheResponses {
 			if globalCacheResponse == nil {
 				continue
 			}
-			attributes.PutStr(otelconsts.ApertureGlobalCacheLookupStatusLabel, globalCacheResponse.LookupStatus.String())
-			attributes.PutStr(otelconsts.ApertureGlobalCacheOperationStatusLabel, globalCacheResponse.OperationStatus.String())
+			globalCacheLookupStatuses.AppendEmpty().SetStr(globalCacheResponse.LookupStatus.String())
+			globalCacheOperationStatuses.AppendEmpty().SetStr(globalCacheResponse.OperationStatus.String())
 		}
 	}
 

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels.go
@@ -59,10 +59,19 @@ func AddCheckResponseBasedLabels(attributes pcommon.Map, checkResponse *flowcont
 	)
 
 	// Cache
-	if checkResponse.CacheLookupResponse != nil && checkResponse.CacheLookupResponse.ResultCacheResponse != nil {
-		resultCacheResponse := checkResponse.CacheLookupResponse.ResultCacheResponse
-		attributes.PutStr(otelconsts.ApertureCacheLookupStatusLabel, resultCacheResponse.LookupStatus.String())
-		attributes.PutStr(otelconsts.ApertureCacheOperationStatusLabel, resultCacheResponse.OperationStatus.String())
+	if checkResponse.CacheLookupResponse != nil {
+		if checkResponse.CacheLookupResponse.ResultCacheResponse != nil {
+			resultCacheResponse := checkResponse.CacheLookupResponse.ResultCacheResponse
+			attributes.PutStr(otelconsts.ApertureResultCacheLookupStatusLabel, resultCacheResponse.LookupStatus.String())
+			attributes.PutStr(otelconsts.ApertureResultCacheOperationStatusLabel, resultCacheResponse.OperationStatus.String())
+		}
+		for _, globalCacheResponse := range checkResponse.CacheLookupResponse.GlobalCacheResponses {
+			if globalCacheResponse == nil {
+				continue
+			}
+			attributes.PutStr(otelconsts.ApertureGlobalCacheLookupStatusLabel, globalCacheResponse.LookupStatus.String())
+			attributes.PutStr(otelconsts.ApertureGlobalCacheOperationStatusLabel, globalCacheResponse.OperationStatus.String())
+		}
 	}
 
 	// Note: Sorted alphabetically to help sorting attributes in rollupprocessor.key at least a bit.

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels_test.go
@@ -138,6 +138,42 @@ var _ = DescribeTable("Check Response labels", func(checkResponse *flowcontrolv1
 			otelconsts.ApertureClassifierErrorsLabel: []interface{}{"ERROR_MULTI_EXPRESSION,policy_name:foo,classifier_index:42,policy_hash:bar"},
 		},
 	),
+
+	Entry("Sets result cache dimensions",
+		&flowcontrolv1.CheckResponse{
+			CacheLookupResponse: &flowcontrolv1.CacheLookupResponse{
+				ResultCacheResponse: &flowcontrolv1.KeyLookupResponse{
+					LookupStatus:    flowcontrolv1.CacheLookupStatus_MISS,
+					OperationStatus: flowcontrolv1.CacheOperationStatus_ERROR,
+				},
+			},
+		},
+		map[string]interface{}{
+			otelconsts.ApertureResultCacheLookupStatusLabel:    "MISS",
+			otelconsts.ApertureResultCacheOperationStatusLabel: "ERROR",
+		},
+	),
+
+	Entry("Sets global cache dimensions",
+		&flowcontrolv1.CheckResponse{
+			CacheLookupResponse: &flowcontrolv1.CacheLookupResponse{
+				GlobalCacheResponses: map[string]*flowcontrolv1.KeyLookupResponse{
+					"foo": {
+						LookupStatus:    flowcontrolv1.CacheLookupStatus_HIT,
+						OperationStatus: flowcontrolv1.CacheOperationStatus_SUCCESS,
+					},
+					"bar": {
+						LookupStatus:    flowcontrolv1.CacheLookupStatus_MISS,
+						OperationStatus: flowcontrolv1.CacheOperationStatus_ERROR,
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			otelconsts.ApertureGlobalCacheLookupStatusesLabel:    []interface{}{"HIT", "MISS"},
+			otelconsts.ApertureGlobalCacheOperationStatusesLabel: []interface{}{"SUCCESS", "ERROR"},
+		},
+	),
 )
 
 var _ = Describe("AddFlowLabels", func() {

--- a/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
+++ b/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
@@ -40,10 +40,6 @@ var (
 		otelconsts.ResponseReceivedLabel,
 		otelconsts.ApertureSourceServiceLabel,
 		otelconsts.ApertureDestinationServiceLabel,
-		otelconsts.ApertureResultCacheLookupStatusLabel,
-		otelconsts.ApertureResultCacheOperationStatusLabel,
-		otelconsts.ApertureGlobalCacheLookupStatusLabel,
-		otelconsts.ApertureGlobalCacheOperationStatusLabel,
 	}
 
 	_includeAttributesHTTP = []string{
@@ -54,6 +50,10 @@ var (
 
 	_includeAttributesSDK = []string{
 		otelconsts.ApertureFlowStatusLabel,
+		otelconsts.ApertureResultCacheLookupStatusLabel,
+		otelconsts.ApertureResultCacheOperationStatusLabel,
+		otelconsts.ApertureGlobalCacheLookupStatusLabel,
+		otelconsts.ApertureGlobalCacheOperationStatusLabel,
 	}
 
 	includeListHTTP = utils.SliceToSet(append(_includeAttributesCommon, _includeAttributesHTTP...))

--- a/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
+++ b/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
@@ -40,8 +40,10 @@ var (
 		otelconsts.ResponseReceivedLabel,
 		otelconsts.ApertureSourceServiceLabel,
 		otelconsts.ApertureDestinationServiceLabel,
-		otelconsts.ApertureCacheLookupStatusLabel,
-		otelconsts.ApertureCacheOperationStatusLabel,
+		otelconsts.ApertureResultCacheLookupStatusLabel,
+		otelconsts.ApertureResultCacheOperationStatusLabel,
+		otelconsts.ApertureGlobalCacheLookupStatusLabel,
+		otelconsts.ApertureGlobalCacheOperationStatusLabel,
 	}
 
 	_includeAttributesHTTP = []string{

--- a/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
+++ b/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
@@ -52,8 +52,8 @@ var (
 		otelconsts.ApertureFlowStatusLabel,
 		otelconsts.ApertureResultCacheLookupStatusLabel,
 		otelconsts.ApertureResultCacheOperationStatusLabel,
-		otelconsts.ApertureGlobalCacheLookupStatusLabel,
-		otelconsts.ApertureGlobalCacheOperationStatusLabel,
+		otelconsts.ApertureGlobalCacheLookupStatusesLabel,
+		otelconsts.ApertureGlobalCacheOperationStatusesLabel,
 	}
 
 	includeListHTTP = utils.SliceToSet(append(_includeAttributesCommon, _includeAttributesHTTP...))

--- a/pkg/otelcollector/metricsprocessor/processor.go
+++ b/pkg/otelcollector/metricsprocessor/processor.go
@@ -66,10 +66,7 @@ func (p *metricsProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) (plog.
 				1 + // FlowStatus
 				21 + // CheckResponse
 				len(checkResponse.GetTelemetryFlowLabels())
-			_ = capacity
-			// Not calling EnsureCapacity as it's broken:
-			// https://github.com/open-telemetry/opentelemetry-collector/issues/7955
-			// attributes.EnsureCapacity(capacity)
+			attributes.EnsureCapacity(capacity)
 		}
 
 		// Source specific processing

--- a/pkg/otelcollector/metricsprocessor/processor.go
+++ b/pkg/otelcollector/metricsprocessor/processor.go
@@ -64,7 +64,7 @@ func (p *metricsProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) (plog.
 			capacity := attributes.Len() +
 				5 + // EnvoySpecificLabels
 				1 + // FlowStatus
-				17 + // CheckResponse
+				21 + // CheckResponse
 				len(checkResponse.GetTelemetryFlowLabels())
 			_ = capacity
 			// Not calling EnsureCapacity as it's broken:


### PR DESCRIPTION
### Description of change
This adds Global Cache metrics to OLAP telemetry.

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed cache status labels for clarity and consistency.
  - Improved handling of cache lookup and operation statuses in telemetry data.

- **New Features**
  - Introduced new telemetry labels for global cache lookup and operation statuses.

- **Documentation**
  - Updated the observability documentation to reflect new and modified telemetry fields.

- **Bug Fixes**
  - Corrected capitalization in the `response_received` field.
  - Removed an outdated reject reason from the `aperture.reject_reason` field.

- **Style**
  - Standardized formatting in the `Flow` interface and related methods for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->