### PR TITLE
Update `match_expressions` deprecation version to `v3.0.0`

### DIFF
--- a/api/aperture/policy/language/v1/label_matcher.proto
+++ b/api/aperture/policy/language/v1/label_matcher.proto
@@ -23,7 +23,7 @@ message LabelMatcher {
   // List of Kubernetes-style label matcher requirements.
   //
   // Note: The requirements are combined using the logical AND operator.
-  // Deprecated: v2.27.0. Use `match_list` instead.
+  // Deprecated: v3.0.0. Use `match_list` instead.
   repeated MatchRequirement match_expressions = 2; // @gotags: validate:"dive"
 
   // An arbitrary expression to be evaluated on the labels.

--- a/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
+++ b/api/gen/proto/go/aperture/policy/language/v1/label_matcher.pb.go
@@ -44,7 +44,7 @@ type LabelMatcher struct {
 	// List of Kubernetes-style label matcher requirements.
 	//
 	// Note: The requirements are combined using the logical AND operator.
-	// Deprecated: v2.27.0. Use `match_list` instead.
+	// Deprecated: v3.0.0. Use `match_list` instead.
 	MatchExpressions []*MatchRequirement `protobuf:"bytes,2,rep,name=match_expressions,json=matchExpressions,proto3" json:"match_expressions,omitempty" validate:"dive"` // @gotags: validate:"dive"
 	// An arbitrary expression to be evaluated on the labels.
 	Expression *Expression `protobuf:"bytes,3,opt,name=expression,proto3" json:"expression,omitempty"`

--- a/blueprints/gen/jsonschema/_definitions.json
+++ b/blueprints/gen/jsonschema/_definitions.json
@@ -1997,7 +1997,7 @@
           "description": "An arbitrary expression to be evaluated on the labels."
         },
         "match_expressions": {
-          "description": "List of Kubernetes-style label matcher requirements.\n\nNote: The requirements are combined using the logical AND operator.\nDeprecated: v2.27.0. Use `match_list` instead.\n\n",
+          "description": "List of Kubernetes-style label matcher requirements.\n\nNote: The requirements are combined using the logical AND operator.\nDeprecated: v3.0.0. Use `match_list` instead.\n\n",
           "items": {
             "$ref": "#/definitions/MatchRequirement",
             "type": "object"

--- a/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-agent.swagger.yaml
@@ -290,7 +290,7 @@ definitions:
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
-                    Deprecated: v2.27.0. Use `match_list` instead.
+                    Deprecated: v3.0.0. Use `match_list` instead.
 
                 items:
                     $ref: '#/definitions/MatchRequirement'

--- a/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture-controller.swagger.yaml
@@ -2200,7 +2200,7 @@ definitions:
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
-                    Deprecated: v2.27.0. Use `match_list` instead.
+                    Deprecated: v3.0.0. Use `match_list` instead.
 
                 items:
                     $ref: '#/definitions/MatchRequirement'

--- a/docs/content/assets/openapiv2/aperture.swagger.yaml
+++ b/docs/content/assets/openapiv2/aperture.swagger.yaml
@@ -2679,7 +2679,7 @@ definitions:
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
-                    Deprecated: v2.27.0. Use `match_list` instead.
+                    Deprecated: v3.0.0. Use `match_list` instead.
 
                 items:
                     $ref: '#/definitions/MatchRequirement'

--- a/docs/content/reference/configuration/spec.md
+++ b/docs/content/reference/configuration/spec.md
@@ -5011,7 +5011,7 @@ An arbitrary expression to be evaluated on the labels.
 List of Kubernetes-style label matcher requirements.
 
 Note: The requirements are combined using the logical AND operator. Deprecated:
-v2.27.0. Use `match_list` instead.
+v3.0.0. Use `match_list` instead.
 
 </dd>
 <dt>match_labels</dt>

--- a/docs/gen/policy/policy.yaml
+++ b/docs/gen/policy/policy.yaml
@@ -2134,7 +2134,7 @@ definitions:
                     List of Kubernetes-style label matcher requirements.
 
                     Note: The requirements are combined using the logical AND operator.
-                    Deprecated: v2.27.0. Use `match_list` instead.
+                    Deprecated: v3.0.0. Use `match_list` instead.
 
                 items:
                     $ref: '#/definitions/MatchRequirement'


### PR DESCRIPTION
##### Checklist

- [x] Tested in playground or other setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deprecation notices in API documentation and configuration specifications to reflect the transition from version 2.27.0 to 3.0.0.
  - Advised on the use of `match_list` as a replacement for a deprecated method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->