### PR TITLE
Add partition length metrics to Olric

### DIFF
--- a/pkg/dist-cache/dist-cache-metrics.go
+++ b/pkg/dist-cache/dist-cache-metrics.go
@@ -19,6 +19,8 @@ type DistCacheMetrics struct {
 	BackupPartitionsCount        *prometheus.GaugeVec
 	FragmentMigrationEventsTotal *prometheus.CounterVec
 	FragmentReceivedEventsTotal  *prometheus.CounterVec
+	PartitionsLength             *prometheus.GaugeVec
+	BackupPartitionsLength       *prometheus.GaugeVec
 }
 
 func newDistCacheMetrics() *DistCacheMetrics {
@@ -64,6 +66,14 @@ func newDistCacheMetrics() *DistCacheMetrics {
 			Name: metrics.DistCacheFragmentReceivedEventsTotalMetricsName,
 			Help: "Cumulative number of fragment received (incoming) events.",
 		}, distCacheMetricsLabels),
+		PartitionsLength: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: metrics.DistCachePartitionsLength,
+			Help: "Current length of partitions of given node.",
+		}, distCacheMetricsLabels),
+		BackupPartitionsLength: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: metrics.DistCacheBackupPartitionsLength,
+			Help: "Current length of backup partitions of given node.",
+		}, distCacheMetricsLabels),
 	}
 }
 
@@ -79,6 +89,8 @@ func (dm *DistCacheMetrics) allMetrics() []prometheus.Collector {
 		dm.BackupPartitionsCount,
 		dm.FragmentMigrationEventsTotal,
 		dm.FragmentReceivedEventsTotal,
+		dm.PartitionsLength,
+		dm.BackupPartitionsLength,
 	}
 }
 

--- a/pkg/dist-cache/dist-cache.go
+++ b/pkg/dist-cache/dist-cache.go
@@ -147,6 +147,28 @@ func (dc *DistCache) scrapeMetrics(ctx context.Context) (proto.Message, error) {
 	} else {
 		backupPartitionsCountGauge.Set(float64(countNotEmptyPartitions(stats.Backups)))
 	}
+
+	partitionsLength := 0
+	for _, v := range stats.Partitions {
+		partitionsLength += v.Length
+	}
+	partitionsLengthGauge, err := dc.metrics.PartitionsLength.GetMetricWith(metricLabels)
+	if err != nil {
+		log.Debug().Msgf("Could not extract partitions length gauge metric from olric instance: %v", err)
+	} else {
+		partitionsLengthGauge.Set(float64(partitionsLength))
+	}
+
+	backupPartitionsLength := 0
+	for _, v := range stats.Backups {
+		backupPartitionsLength += v.Length
+	}
+	backupPartitionsLengthGauge, err := dc.metrics.BackupPartitionsLength.GetMetricWith(metricLabels)
+	if err != nil {
+		log.Debug().Msgf("Could not extract backup partitions length gauge metric from olric instance: %v", err)
+	} else {
+		backupPartitionsLengthGauge.Set(float64(backupPartitionsLength))
+	}
 	return nil, nil
 }
 

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -55,6 +55,10 @@ const (
 	DistCacheFragmentMigrationEventsTotalMetricsName = "distcache_fragment_migration_events_total"
 	// DistCacheFragmentReceivedEventsTotalMetricsName - metric for cumulative number of fragment received (incoming) events.
 	DistCacheFragmentReceivedEventsTotalMetricsName = "distcache_fragment_received_events_total"
+	//DistCachePartitionsLength - metric for current length of partitions on given node.
+	DistCachePartitionsLength = "distcache_partitions_length"
+	//DistCacheBackupPartitionsLength - metric for current length of backup partitions on given node.
+	DistCacheBackupPartitionsLength = "distcache_backup_partitions_length"
 
 	// Cache metrics.
 

--- a/pkg/metrics/schema.go
+++ b/pkg/metrics/schema.go
@@ -55,9 +55,9 @@ const (
 	DistCacheFragmentMigrationEventsTotalMetricsName = "distcache_fragment_migration_events_total"
 	// DistCacheFragmentReceivedEventsTotalMetricsName - metric for cumulative number of fragment received (incoming) events.
 	DistCacheFragmentReceivedEventsTotalMetricsName = "distcache_fragment_received_events_total"
-	//DistCachePartitionsLength - metric for current length of partitions on given node.
+	// DistCachePartitionsLength - metric for current length of partitions on given node.
 	DistCachePartitionsLength = "distcache_partitions_length"
-	//DistCacheBackupPartitionsLength - metric for current length of backup partitions on given node.
+	// DistCacheBackupPartitionsLength - metric for current length of backup partitions on given node.
 	DistCacheBackupPartitionsLength = "distcache_backup_partitions_length"
 
 	// Cache metrics.


### PR DESCRIPTION
### Description of change
This can be used to track number of keys and their backups in Olric.

##### Checklist

- [x] Tested in playground or other setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new metrics to monitor the length of cache partitions and backup partitions, enhancing visibility into cache performance and health.

- **Refactor**
  - Updated cache metrics collection to include new partition length measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->