### PR TITLE
Change grafana port to 3333

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -134,14 +134,14 @@ The load generator is configured to generate the following traffic pattern for
 - Hold at `5` concurrent users for `2m`.
 
 Once the traffic is running, you can visualize the decisions made by Aperture in
-Grafana. Navigate to [localhost:3000](http://localhost:3000) on your browser to
+Grafana. Navigate to [localhost:3333](http://localhost:3333) on your browser to
 reach Grafana. You can open the `FluxNinja` dashboard under `aperture-system`
 folder to a bunch of useful panels.
 
 ![Grafana Dashboard](./assets/dashboard.png)
 
 > 📍 Grafana's dashboard browser address is
-> [localhost:3000/dashboards](http://localhost:3000/dashboards)
+> [localhost:3333/dashboards](http://localhost:3333/dashboards)
 
 To stop the traffic at any point of time, press the `Stop Wavepool Generator`
 button in the `DemoApplications` resource.

--- a/playground/Tiltfile
+++ b/playground/Tiltfile
@@ -1207,7 +1207,7 @@ def declare_resources(resources, dep_tree, inv_dep_tree, race_arg, cloud_extensi
             labels=["ApertureController"],
             resource_deps=["grafana"],
             service="aperture-grafana",
-            local_port=3000,
+            local_port=3333,
             remote_port=3000,
             extra_env={
                 "PERIOD": "1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Grafana access URL in the documentation from `localhost:3000` to `localhost:3333`.

- **Chores**
  - Adjusted the `local_port` configuration for the Grafana service to match the new URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->