### PR TITLE
Add accept words for blog

### DIFF
--- a/.github/styles/config/vocabularies/FluxNinja/accept.txt
+++ b/.github/styles/config/vocabularies/FluxNinja/accept.txt
@@ -124,3 +124,8 @@ APIKey
 [Aa]uthz
 exat
 productizing
+[Gg]rammarly
+chatbots
+gameplay
+composable
+productionize

--- a/cmd/aperture-agent/config/types.go
+++ b/cmd/aperture-agent/config/types.go
@@ -26,8 +26,8 @@ type AgentOTelConfig struct {
 	otelconfig.CommonOTelConfig `json:",inline"`
 	// DisableKubernetesScraper disables the default metrics collection for Kubernetes resources.
 	DisableKubernetesScraper bool `json:"disable_kubernetes_scraper" default:"false"`
-	// DisableKubeletScraper disables the default metrics collection for kubelet.
-	// Deprecated: kubelet scraper is removed entirely, so this flag makes no difference.
+	// DisableKubeletScraper disables the default metrics collection for Kubelet.
+	// Deprecated: Kubelet scraper is removed entirely, so this flag makes no difference.
 	DisableKubeletScraper bool `json:"disable_kubelet_scraper" default:"false"`
 	// EnableHighCardinalityPlatformMetrics filters out high cardinality Aperture platform metrics from being
 	// published to Prometheus. Filtered out metrics are:

--- a/docs/content/reference/configuration/agent.md
+++ b/docs/content/reference/configuration/agent.md
@@ -811,8 +811,8 @@ AgentOTelConfig is the configuration for Agent's OTel collector.
 
 <!-- vale on -->
 
-DisableKubeletScraper disables the default metrics collection for kubelet.
-Deprecated: kubelet scraper is removed entirely, so this flag makes no
+DisableKubeletScraper disables the default metrics collection for Kubelet.
+Deprecated: Kubelet scraper is removed entirely, so this flag makes no
 difference.
 
 </dd>

--- a/docs/gen/config/agent/config-swagger.yaml
+++ b/docs/gen/config/agent/config-swagger.yaml
@@ -72,8 +72,8 @@ definitions:
             disable_kubelet_scraper:
                 default: false
                 description: |-
-                    DisableKubeletScraper disables the default metrics collection for kubelet.
-                    Deprecated: kubelet scraper is removed entirely, so this flag makes no difference.
+                    DisableKubeletScraper disables the default metrics collection for Kubelet.
+                    Deprecated: Kubelet scraper is removed entirely, so this flag makes no difference.
                 type: boolean
                 x-go-name: DisableKubeletScraper
                 x-go-tag-default: "false"

--- a/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
+++ b/manifests/charts/aperture-agent/crds/fluxninja.com_agents.yaml
@@ -1600,7 +1600,7 @@ spec:
                         type: object
                       disable_kubelet_scraper:
                         description: 'DisableKubeletScraper disables the default metrics
-                          collection for kubelet. Deprecated: kubelet scraper is removed
+                          collection for Kubelet. Deprecated: Kubelet scraper is removed
                           entirely, so this flag makes no difference.'
                         type: boolean
                       disable_kubernetes_scraper:

--- a/operator/config/crd/bases/fluxninja.com_agents.yaml
+++ b/operator/config/crd/bases/fluxninja.com_agents.yaml
@@ -1600,7 +1600,7 @@ spec:
                         type: object
                       disable_kubelet_scraper:
                         description: 'DisableKubeletScraper disables the default metrics
-                          collection for kubelet. Deprecated: kubelet scraper is removed
+                          collection for Kubelet. Deprecated: Kubelet scraper is removed
                           entirely, so this flag makes no difference.'
                         type: boolean
                       disable_kubernetes_scraper:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the FluxNinja vocabulary with new terms, including "Grammarly," "chatbots," "gameplay," "composable," and "productionize."
  - Updated the documentation to reflect the removal of the kubelet scraper, changed "kubelet" to "Kubelet" for consistency, and clarified the deprecation of the related flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->