### PR TITLE
Add Agent Group processor to FN pipeline

### DIFF
--- a/extensions/fluxninja/otel/provide.go
+++ b/extensions/fluxninja/otel/provide.go
@@ -170,6 +170,7 @@ func addMetricsSlowPipeline(config *otelconfig.Config) {
 		Processors: []string{
 			processorBatchMetricsSlow,
 			processorAttributes,
+			otelconsts.ProcessorAgentGroup,
 		},
 		Exporters: []string{exporterFluxNinja},
 	})


### PR DESCRIPTION
### Description of change
This ensures `agent_group` label is added to metrics sent to Aperture Cloud.

Resolves: #3085

##### Checklist

- [x] Tested in playground or other setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced telemetry by including a new processor in the metrics pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->