### PR TITLE
Making Controller and Agent charts GitOps-friendlier

### DIFF
--- a/manifests/charts/aperture-agent/templates/operator-mutatingwebhook.yaml
+++ b/manifests/charts/aperture-agent/templates/operator-mutatingwebhook.yaml
@@ -33,5 +33,6 @@ webhooks:
     - UPDATE
     resources:
     - agents
+    scope: Namespaced
   sideEffects: None
 {{- end }}

--- a/manifests/charts/aperture-agent/values.yaml
+++ b/manifests/charts/aperture-agent/values.yaml
@@ -63,7 +63,7 @@ operator:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
-    pullSecrets: []
+    # pullSecrets: []
 
   ## @param operator.replicaCount Number of replicas for Operator deployment
   ##
@@ -386,7 +386,7 @@ agent:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
-    pullSecrets: []
+    # pullSecrets: []
   ## Agent service parameters
   ##
   service:

--- a/manifests/charts/aperture-controller/templates/operator-mutatingwebhook.yaml
+++ b/manifests/charts/aperture-controller/templates/operator-mutatingwebhook.yaml
@@ -33,5 +33,6 @@ webhooks:
     - UPDATE
     resources:
     - controllers
+    scope: Namespaced
   sideEffects: None
 {{- end }}

--- a/manifests/charts/aperture-controller/templates/post-install-hook.yaml
+++ b/manifests/charts/aperture-controller/templates/post-install-hook.yaml
@@ -17,6 +17,8 @@ metadata:
   {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   ttlSecondsAfterFinished: 10
   backoffLimit: 0

--- a/manifests/charts/aperture-controller/values.yaml
+++ b/manifests/charts/aperture-controller/values.yaml
@@ -63,7 +63,7 @@ operator:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
-    pullSecrets: []
+    # pullSecrets: []
 
   ## @param operator.replicaCount Number of replicas for Operator deployment
   ##
@@ -383,7 +383,7 @@ controller:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
-    pullSecrets: []
+    # pullSecrets: []
   ## Controller service parameters
   ##
   service:


### PR DESCRIPTION
### Description of change

There are three small fixes in this PR

1) The default value of `MutatingWebhookConfiguration.webhooks.rules.scope` is `'*'`. However, it watches the namespaced resources only. Therefore, the result of `kubectl diff` detects a skew with the result of `helm template`, with the attempt to restore the default value.

![image](https://github.com/fluxninja/aperture/assets/4749332/c8b9c060-df08-42f3-ad01-13cdb27aee73)

2) Empty `pullSecrets` lists are ignored by `kubectl diff`. On the other hand, Helm does not provide a mechanism to remove default values from a dependency chart - they can only be replaced by other values.

![image](https://github.com/fluxninja/aperture/assets/4749332/4443e5a4-9459-495d-a5e4-a7e1737494d1)

3) The `ttlSecondsAfterFinished` deletes the post-install hook Job after 10 seconds. However, the Job is not annotated with `hook-delete-policy`. Therefore Argo CD is willing to restore the job.


##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

The changes were tested by deploying a chart with locally modified dependencies

```
dependencies:
- name: aperture-agent
  version: v2.34.0-rc.1
  repository: "file://aperture-agent"
#  repository: https://fluxninja.github.io/aperture/
  alias: agent
- name: aperture-controller
  version: v2.34.0-rc.1
  repository: "file://aperture-controller"
#  repository: https://fluxninja.github.io/aperture/
  alias: controller
```
