### PR TITLE
Add Concurrency Schedulers to OLAP telemetry

### DIFF
--- a/pkg/otelcollector/consts/consts.go
+++ b/pkg/otelcollector/consts/consts.go
@@ -57,6 +57,10 @@ const (
 	ApertureRateLimitersLabel = "aperture.rate_limiters"
 	// ApertureDroppingRateLimitersLabel describes rate limiters dropping the traffic.
 	ApertureDroppingRateLimitersLabel = "aperture.dropping_rate_limiters"
+	// ApertureConcurrencySchedulersLabel describes rate limiters matched to the traffic.
+	ApertureConcurrencySchedulersLabel = "aperture.concurrency_schedulers"
+	// ApertureDroppingConcurrencySchedulersLabel describes rate limiters dropping the traffic.
+	ApertureDroppingConcurrencySchedulersLabel = "aperture.dropping_concurrency_schedulers"
 	// ApertureLoadSchedulersLabel describes load schedulers matched to the traffic.
 	ApertureLoadSchedulersLabel = "aperture.load_schedulers"
 	// ApertureQuotaSchedulersLabel describes quota schedulers matched to the traffic.

--- a/pkg/otelcollector/metricsprocessor/internal/check_response_labels_test.go
+++ b/pkg/otelcollector/metricsprocessor/internal/check_response_labels_test.go
@@ -105,6 +105,28 @@ var _ = DescribeTable("Check Response labels", func(checkResponse *flowcontrolv1
 		},
 	),
 
+	Entry("Sets concurrency schedulers",
+		&flowcontrolv1.CheckResponse{
+			LimiterDecisions: []*flowcontrolv1.LimiterDecision{
+				{
+					PolicyName:  "foo",
+					PolicyHash:  "foo-hash",
+					ComponentId: "1",
+					Dropped:     true,
+					Details: &flowcontrolv1.LimiterDecision_ConcurrencySchedulerInfo_{
+						ConcurrencySchedulerInfo: &flowcontrolv1.LimiterDecision_ConcurrencySchedulerInfo{
+							WorkloadIndex: "0",
+						},
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			otelconsts.ApertureConcurrencySchedulersLabel:         []interface{}{"policy_name:foo,component_id:1,policy_hash:foo-hash"},
+			otelconsts.ApertureDroppingConcurrencySchedulersLabel: []interface{}{"policy_name:foo,component_id:1,policy_hash:foo-hash"},
+		},
+	),
+
 	Entry("Sets flux meters",
 		&flowcontrolv1.CheckResponse{
 			FluxMeterInfos: []*flowcontrolv1.FluxMeterInfo{

--- a/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
+++ b/pkg/otelcollector/metricsprocessor/internal/labels_filter.go
@@ -27,6 +27,8 @@ var (
 		otelconsts.ApertureDroppingQuotaSchedulersLabel,
 		otelconsts.ApertureSamplersLabel,
 		otelconsts.ApertureDroppingSamplersLabel,
+		otelconsts.ApertureConcurrencySchedulersLabel,
+		otelconsts.ApertureDroppingConcurrencySchedulersLabel,
 		otelconsts.ApertureWorkloadsLabel,
 		otelconsts.ApertureDroppingWorkloadsLabel,
 		otelconsts.ApertureFluxMetersLabel,


### PR DESCRIPTION
### Description of change
This adds missing scheduler do OLAP telemetry.

##### Checklist

- [x] Tested in playground or other setup
- [ ] Screenshot (Grafana) from playground added to PR for 15+ minute run
- [ ] Documentation is changed or added
- [x] Tests and/or benchmarks are included
- [ ] Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded the set of labels for rate limiters and schedulers, including new labels for Aperture, concurrency schedulers, and dropping concurrency schedulers.
- **Enhancements**
	- Improved label handling in the metrics processor to support new scheduler and rate limiter labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->